### PR TITLE
all language support for closed captions fix

### DIFF
--- a/sp/src/game/client/hud_closecaption.cpp
+++ b/sp/src/game/client/hud_closecaption.cpp
@@ -2563,8 +2563,8 @@ void CHudCloseCaption::Flush()
 void CHudCloseCaption::InitCaptionDictionary( const char *dbfile )
 {
 #ifndef MAPBASE //-Nbc66
-	//if ( m_CurrentLanguage.IsValid() && !Q_stricmp( m_CurrentLanguage.String(), dbfile ) )
-		//return;
+	if ( m_CurrentLanguage.IsValid() && !Q_stricmp( m_CurrentLanguage.String(), dbfile ) )
+		return;
 #endif
 	m_CurrentLanguage = dbfile;
 
@@ -2603,19 +2603,19 @@ void CHudCloseCaption::InitCaptionDictionary( const char *dbfile )
 
 			AsyncCaption_t& entry = m_AsyncCaptions[ m_AsyncCaptions.AddToTail() ];
 
-#ifdef MAPBASE //-Nbc66
+#ifndef MAPBASE //-Nbc66
 			// Read the header
 			filesystem->Read( &entry.m_Header, sizeof( entry.m_Header ), fh );
-			/*
+			
 			if ( entry.m_Header.magic != COMPILED_CAPTION_FILEID )
 				Error( "Invalid file id for %s\n", fullpath );
 			if ( entry.m_Header.version != COMPILED_CAPTION_VERSION )
 				Error( "Invalid file version for %s\n", fullpath );
 			if ( entry.m_Header.directorysize < 0 || entry.m_Header.directorysize > 64 * 1024 )
 				Error( "Invalid directory size %d for %s\n", entry.m_Header.directorysize, fullpath );
-			//if ( entry.m_Header.blocksize != MAX_BLOCK_SIZE )
-			//	Error( "Invalid block size %d, expecting %d for %s\n", entry.m_Header.blocksize, MAX_BLOCK_SIZE, fullpath );
-			*/
+			if ( entry.m_Header.blocksize != MAX_BLOCK_SIZE )
+				Error( "Invalid block size %d, expecting %d for %s\n", entry.m_Header.blocksize, MAX_BLOCK_SIZE, fullpath );
+			
 #endif
 			int directoryBytes = entry.m_Header.directorysize * sizeof( CaptionLookup_t );
 			entry.m_CaptionDirectory.EnsureCapacity( entry.m_Header.directorysize );

--- a/sp/src/game/client/hud_closecaption.cpp
+++ b/sp/src/game/client/hud_closecaption.cpp
@@ -2775,11 +2775,11 @@ void OnCaptionLanguageChanged( IConVar *pConVar, const char *pOldString, float f
 
 #ifdef MAPBASE//-Nbc66
 	// If it's not the default, load the language on top of the user's default language
-	if (Q_strlen(var.GetString()) > 0 && Q_stricmp(var.GetString(), uilanguage))
+	if ( Q_strlen( var.GetString() ) > 0 && Q_stricmp( var.GetString(), uilanguage ) )
 	{
 		if (!IsX360())
 		{
-			if (g_pFullFileSystem->FileExists(fn))
+			if ( g_pFullFileSystem->FileExists( fn ) )
 			{
 				char dbfile[512];
 				Q_snprintf(dbfile, sizeof(dbfile), "resource/closecaption_%s.txt", var.GetString());
@@ -2791,8 +2791,8 @@ void OnCaptionLanguageChanged( IConVar *pConVar, const char *pOldString, float f
 				char fallback[512];
 				Q_snprintf(fallback, sizeof(fallback), "resource/closecaption_%s.txt", uilanguage);
 
-				Msg("%s not found\n", fn);
-				Msg("%s will be used\n", fallback);
+				Msg( "%s not found\n", fn );
+				Msg( "%s will be used\n", fallback );
 			}
 
 		}

--- a/sp/src/game/client/hud_closecaption.cpp
+++ b/sp/src/game/client/hud_closecaption.cpp
@@ -2562,9 +2562,10 @@ void CHudCloseCaption::Flush()
 
 void CHudCloseCaption::InitCaptionDictionary( const char *dbfile )
 {
-	if ( m_CurrentLanguage.IsValid() && !Q_stricmp( m_CurrentLanguage.String(), dbfile ) )
-		return;
-
+#ifndef MAPBASE //-Nbc66
+	//if ( m_CurrentLanguage.IsValid() && !Q_stricmp( m_CurrentLanguage.String(), dbfile ) )
+		//return;
+#endif
 	m_CurrentLanguage = dbfile;
 
 	m_AsyncCaptions.Purge();
@@ -2602,8 +2603,10 @@ void CHudCloseCaption::InitCaptionDictionary( const char *dbfile )
 
 			AsyncCaption_t& entry = m_AsyncCaptions[ m_AsyncCaptions.AddToTail() ];
 
+#ifdef MAPBASE //-Nbc66
 			// Read the header
 			filesystem->Read( &entry.m_Header, sizeof( entry.m_Header ), fh );
+			/*
 			if ( entry.m_Header.magic != COMPILED_CAPTION_FILEID )
 				Error( "Invalid file id for %s\n", fullpath );
 			if ( entry.m_Header.version != COMPILED_CAPTION_VERSION )
@@ -2612,7 +2615,8 @@ void CHudCloseCaption::InitCaptionDictionary( const char *dbfile )
 				Error( "Invalid directory size %d for %s\n", entry.m_Header.directorysize, fullpath );
 			//if ( entry.m_Header.blocksize != MAX_BLOCK_SIZE )
 			//	Error( "Invalid block size %d, expecting %d for %s\n", entry.m_Header.blocksize, MAX_BLOCK_SIZE, fullpath );
-
+			*/
+#endif
 			int directoryBytes = entry.m_Header.directorysize * sizeof( CaptionLookup_t );
 			entry.m_CaptionDirectory.EnsureCapacity( entry.m_Header.directorysize );
 			dirbuffer.EnsureCapacity( directoryBytes );
@@ -2769,23 +2773,28 @@ void OnCaptionLanguageChanged( IConVar *pConVar, const char *pOldString, float f
 
 	CHudCloseCaption *hudCloseCaption = GET_HUDELEMENT( CHudCloseCaption );
 
+#ifdef MAPBASE//-Nbc66
 	// If it's not the default, load the language on top of the user's default language
-	if ( Q_strlen( var.GetString() ) > 0 && Q_stricmp( var.GetString(), uilanguage ) )
+	if (Q_strlen(var.GetString()) > 0 && Q_stricmp(var.GetString(), uilanguage))
 	{
-		if ( !IsX360() )
+		if (!IsX360())
 		{
-			if ( g_pFullFileSystem->FileExists( fn ) )
+			if (g_pFullFileSystem->FileExists(fn))
 			{
-				g_pVGuiLocalize->AddFile( fn, "GAME", true );
+				char dbfile[512];
+				Q_snprintf(dbfile, sizeof(dbfile), "resource/closecaption_%s.txt", var.GetString());
+				g_pVGuiLocalize->AddFile(fn, "GAME", true);
+				hudCloseCaption->InitCaptionDictionary(dbfile);
 			}
 			else
 			{
-				char fallback[ 512 ];
-				Q_snprintf( fallback, sizeof( fallback ), "resource/closecaption_%s.txt", uilanguage );
+				char fallback[512];
+				Q_snprintf(fallback, sizeof(fallback), "resource/closecaption_%s.txt", uilanguage);
 
-				Msg( "%s not found\n", fn );
-				Msg( "%s will be used\n", fallback );
+				Msg("%s not found\n", fn);
+				Msg("%s will be used\n", fallback);
 			}
+
 		}
 
 		if ( hudCloseCaption )
@@ -2804,9 +2813,14 @@ void OnCaptionLanguageChanged( IConVar *pConVar, const char *pOldString, float f
 			hudCloseCaption->InitCaptionDictionary( dbfile );
 		}
 	}
-	DevMsg( "cc_lang = %s\n", var.GetString() );
-}
+	if (!engine->IsInGame())
+	{
+		engine->ClientCmd_Unrestricted("hud_reloadscheme");
+	}
+	DevMsg("cc_lang = %s\n", var.GetString());
 
+}
+#endif
 
 
 ConVar cc_lang( "cc_lang", "", FCVAR_ARCHIVE, "Current close caption language (emtpy = use game UI language)", OnCaptionLanguageChanged );


### PR DESCRIPTION
all language support for mapbase closed captions you can now make a corresponding 

closedcaptions_language.txt file and compile it into a .dat file 

the system works by typing in the console for ex: cc_lang bosnian