### PR TITLE
Fix a video playback issue related to 'playvideo'

### DIFF
--- a/sp/src/game/client/vgui_video.cpp
+++ b/sp/src/game/client/vgui_video.cpp
@@ -24,7 +24,7 @@ VideoPanel::VideoPanel( unsigned int nXPos, unsigned int nYPos, unsigned int nHe
 	m_nPlaybackHeight( 0 ),
 	m_bAllowAlternateMedia( allowAlternateMedia )
 {
-	vgui::VPANEL pParent = enginevgui->GetPanel( PANEL_GAMEUIDLL );
+	vgui::VPANEL pParent = enginevgui->GetPanel( PANEL_ROOT );
 	SetParent( pParent );
 	SetVisible( false );
 	

--- a/sp/src/game/client/vgui_video.cpp
+++ b/sp/src/game/client/vgui_video.cpp
@@ -24,7 +24,12 @@ VideoPanel::VideoPanel( unsigned int nXPos, unsigned int nYPos, unsigned int nHe
 	m_nPlaybackHeight( 0 ),
 	m_bAllowAlternateMedia( allowAlternateMedia )
 {
+		
+#ifdef MAPBASE
 	vgui::VPANEL pParent = enginevgui->GetPanel( PANEL_ROOT );
+#else
+	vgui::VPANEL pParent = enginevgui->GetPanel( PANEL_GAMEUIDLL );
+#endif
 	SetParent( pParent );
 	SetVisible( false );
 	


### PR DESCRIPTION
There is currently a bug that prohibits 'playvideo' command from successfully playing media in-game, as the player must firstly go to the main menu for it to play, this issue makes sure that the command can work without having the player go to the menu.