### PR TITLE
Various vscript improvements

### DIFF
--- a/sp/src/vscript/vscript_squirrel.cpp
+++ b/sp/src/vscript/vscript_squirrel.cpp
@@ -817,7 +817,6 @@ bool getVariant(HSQUIRRELVM vm, SQInteger idx, ScriptVariant_t& variant)
 			tag == TYPETAG_VECTOR &&
 			SQ_SUCCEEDED(sq_getinstanceup(vm, idx, (SQUserPointer*)&v, TYPETAG_VECTOR)))
 		{
-			// TODO: This actually ends up pointing to the same data it seems error prone
 			variant = new Vector(*v);
 			variant.m_flags |= SV_FREE;
 			return true;
@@ -1206,11 +1205,13 @@ void SquirrelVM::Shutdown()
 
 bool SquirrelVM::ConnectDebugger()
 {
+	// TODO: Debugger support
 	return false;
 }
 
 void SquirrelVM::DisconnectDebugger()
 {
+	// TODO: Debugger support
 }
 
 ScriptLanguage_t SquirrelVM::GetLanguage()
@@ -1225,10 +1226,12 @@ const char* SquirrelVM::GetLanguageName()
 
 void SquirrelVM::AddSearchPath(const char* pszSearchPath)
 {
+	// TODO: Search path support
 }
 
 bool SquirrelVM::Frame(float simTime)
 {
+	// TODO: Frame support
 	return false;
 }
 
@@ -1254,7 +1257,7 @@ ScriptStatus_t SquirrelVM::Run(const char* pszScript, bool bWait)
 HSCRIPT SquirrelVM::CompileScript(const char* pszScript, const char* pszId)
 {
 	SquirrelSafeCheck safeCheck(vm_);
-	// TODO: sq_setcompilererrorhandler
+
 	Assert(vm_);
 	if (pszId == nullptr) pszId = "<unnamed>";
 	if (SQ_FAILED(sq_compilebuffer(vm_, pszScript, strlen(pszScript), pszId, SQTrue)))
@@ -1300,7 +1303,6 @@ ScriptStatus_t SquirrelVM::Run(HSCRIPT hScript, HSCRIPT hScope, bool bWait)
 	sq_pop(vm_, 1);
 	if (SQ_FAILED(result))
 	{
-		// TODO: sq_getlasterror
 		return SCRIPT_ERROR;
 	}
 	return SCRIPT_DONE;
@@ -1316,7 +1318,6 @@ ScriptStatus_t SquirrelVM::Run(HSCRIPT hScript, bool bWait)
 	sq_pop(vm_, 1);
 	if (SQ_FAILED(result))
 	{
-		// TODO: sq_getlasterror
 		return SCRIPT_ERROR;
 	}
 	return SCRIPT_DONE;
@@ -2771,16 +2772,19 @@ void SquirrelVM::RemoveOrphanInstances()
 void SquirrelVM::DumpState()
 {
 	SquirrelSafeCheck safeCheck(vm_);
+	// TODO: Dump state
 }
 
 void SquirrelVM::SetOutputCallback(ScriptOutputFunc_t pFunc)
 {
 	SquirrelSafeCheck safeCheck(vm_);
+	// TODO: Support output callbacks
 }
 
 void SquirrelVM::SetErrorCallback(ScriptErrorFunc_t pFunc)
 {
 	SquirrelSafeCheck safeCheck(vm_);
+	// TODO: Support error callbacks
 }
 
 bool SquirrelVM::RaiseException(const char* pszExceptionText)

--- a/sp/src/vscript/vscript_squirrel.cpp
+++ b/sp/src/vscript/vscript_squirrel.cpp
@@ -1837,13 +1837,40 @@ int	SquirrelVM::GetNumTableEntries(HSCRIPT hScope)
 int SquirrelVM::GetKeyValue(HSCRIPT hScope, int nIterator, ScriptVariant_t* pKey, ScriptVariant_t* pValue)
 {
 	SquirrelSafeCheck safeCheck(vm_);
-	// TODO: How does this work does it expect to output to pKey and pValue as an array from nIterator
-	// elements or does it expect nIterator to be an index in hScrope, if so how does that work without
-	// without depending on squirrel internals not public API for getting the iterator (which is opaque)
-	// or do you iterate until that point and output the value? If it should be iterator then this should
-	// be a HSCRIPT for ease of use.
-	Assert(!"GetKeyValue is not implemented");
-	return 0;
+
+	if (hScope)
+	{
+		Assert(hScope != INVALID_HSCRIPT);
+		HSQOBJECT* scope = (HSQOBJECT*)hScope;
+		sq_pushobject(vm_, *scope);
+	}
+	else
+	{
+		sq_pushroottable(vm_);
+	}
+
+	if (nIterator == -1)
+	{
+		sq_pushnull(vm_);
+	}
+	else
+	{
+		sq_pushinteger(vm_, nIterator);
+	}
+
+	SQInteger nextiter = -1;
+
+	if (SQ_SUCCEEDED(sq_next(vm_, -2)))
+	{
+		if (pKey) getVariant(vm_, -2, *pKey);
+		if (pValue) getVariant(vm_, -1, *pValue);
+
+		sq_getinteger(vm_, -3, &nextiter);
+		sq_pop(vm_, 2);
+	}
+	sq_pop(vm_, 2);
+
+	return nextiter;
 }
 
 bool SquirrelVM::GetValue(HSCRIPT hScope, const char* pszKey, ScriptVariant_t* pValue)


### PR DESCRIPTION
Fixes a few issues/improvements reported by @teamspen210 and @Blixibon

* print() is now aligned with standard vscript, added printl()
* Vector and Entity tostring are now supported
* Added some missing functions on Vector
* Cleanup some TODO comments
* Adding support for GetKeyValue