### PR TITLE
Misc vscript fixes

### DIFF
--- a/sp/src/game/client/vscript_client.cpp
+++ b/sp/src/game/client/vscript_client.cpp
@@ -13,9 +13,7 @@
 #include "characterset.h"
 #include "isaverestore.h"
 #include "gamerules.h"
-#ifdef _WIN32
-//#include "vscript_client_nut.h"
-#endif
+#include "vscript_client.nut"
 #ifdef MAPBASE_VSCRIPT
 #include "c_world.h"
 #include "proxyentity.h"
@@ -405,12 +403,12 @@ bool VScriptClientInit()
 				IGameSystem::RegisterVScriptAllSystems();
 
 				RegisterSharedScriptFunctions();
-#else
-				if ( scriptLanguage == SL_SQUIRREL )
-				{
-					//g_pScriptVM->Run( g_Script_vscript_client );
-				}
 #endif
+
+				if (scriptLanguage == SL_SQUIRREL)
+				{
+					g_pScriptVM->Run( g_Script_vscript_client );
+				}
 
 				VScriptRunScript( "mapspawn", false );
 

--- a/sp/src/game/client/vscript_client.nut
+++ b/sp/src/game/client/vscript_client.nut
@@ -1,3 +1,4 @@
+static char g_Script_vscript_client[] = R"vscript(
 //========== Copyright © 2008, Valve Corporation, All rights reserved. ========
 //
 // Purpose:
@@ -17,3 +18,5 @@ function IncludeScript( name, scope = null )
 	}
 	return ::DoIncludeScript( name, scope );
 }
+
+)vscript";

--- a/sp/src/game/server/vscript_server.cpp
+++ b/sp/src/game/server/vscript_server.cpp
@@ -15,9 +15,7 @@
 #include "sceneentity.h"		// for exposing scene precache function
 #include "isaverestore.h"
 #include "gamerules.h"
-#ifdef _WIN32
-//#include "vscript_server_nut.h"
-#endif
+#include "vscript_server.nut"
 #ifdef MAPBASE_VSCRIPT
 #include "world.h"
 #endif
@@ -555,12 +553,12 @@ bool VScriptServerInit()
 				IGameSystem::RegisterVScriptAllSystems();
 
 				RegisterSharedScriptFunctions();
-#else
-				if ( scriptLanguage == SL_SQUIRREL )
-				{
-					//g_pScriptVM->Run( g_Script_vscript_server );
-				}
 #endif
+
+				if (scriptLanguage == SL_SQUIRREL)
+				{
+					g_pScriptVM->Run( g_Script_vscript_server );
+				}
 
 				VScriptRunScript( "mapspawn", false );
 

--- a/sp/src/game/server/vscript_server.nut
+++ b/sp/src/game/server/vscript_server.nut
@@ -1,3 +1,4 @@
+static char g_Script_vscript_server[] = R"vscript(
 //========== Copyright © 2008, Valve Corporation, All rights reserved. ========
 //
 // Purpose:
@@ -38,7 +39,7 @@ function __ReplaceClosures( script, scope )
 	
 	local tempParent = { getroottable = function() { return null; } };
 	local temp = { runscript = script };
-	delegate tempParent : temp;
+	temp.set_delegate(tempParent);
 	
 	temp.runscript()
 	foreach( key,val in temp )
@@ -125,3 +126,4 @@ function __DumpScope( depth, table )
 	}
 }
 
+)vscript";

--- a/sp/src/game/shared/mapbase/vscript_funcs_shared.cpp
+++ b/sp/src/game/shared/mapbase/vscript_funcs_shared.cpp
@@ -344,7 +344,7 @@ public:
 private:
 } g_ScriptConvarLookup;
 
-BEGIN_SCRIPTDESC_ROOT_NAMED( CScriptConvarLookup, "Convars", SCRIPT_SINGLETON "Provides an interface for getting and setting convars." )
+BEGIN_SCRIPTDESC_ROOT_NAMED( CScriptConvarLookup, "CConvars", SCRIPT_SINGLETON "Provides an interface for getting and setting convars." )
 #ifndef CLIENT_DLL
 	DEFINE_SCRIPTFUNC( GetClientConvarValue, "Returns the convar value for the entindex as a string. Only works with client convars with the FCVAR_USERINFO flag." )
 #endif


### PR DESCRIPTION
This fixes up support for `script_help`, it also re-enables `vscript_client.nut` and `vscript_server.nut` which are by default disabled in Alien Swarm SDK (but appear to be actually enabled in Alien Swarm itself), this was likely disabled because it doesn't have something to convert the `.nut` into the header to include, did a quicker work around anyway.

This also means that some other functionality that didn't exist before from these should now work such as `EntFire`, `UniqueString`, `ConnectOutputs`, `IncludeScript`, `script_reload_*` (I have not tested any of these)

This also resolves more of the save/restore bugs that exist, due to duplicated Convar being used for both variable and class name and regexp not correctly serializing.