### PR TITLE
Making vscript register all classes

### DIFF
--- a/sp/src/game/client/vscript_client.cpp
+++ b/sp/src/game/client/vscript_client.cpp
@@ -487,6 +487,8 @@ bool VScriptClientInit()
 				}
 
 #ifdef MAPBASE_VSCRIPT
+				g_pScriptVM->RegisterAllClasses();
+
 				g_pScriptVM->RegisterInstance( &g_ScriptEntityIterator, "Entities" );
 
 				IGameSystem::RegisterVScriptAllSystems();

--- a/sp/src/game/server/vscript_server.cpp
+++ b/sp/src/game/server/vscript_server.cpp
@@ -569,6 +569,8 @@ bool VScriptServerInit()
 				g_pScriptVM->RegisterInstance( &g_ScriptEntityIterator, "Entities" );
 
 #ifdef MAPBASE_VSCRIPT
+				g_pScriptVM->RegisterAllClasses();
+
 				IGameSystem::RegisterVScriptAllSystems();
 
 				RegisterSharedScriptFunctions();

--- a/sp/src/public/vscript/ivscript.h
+++ b/sp/src/public/vscript/ivscript.h
@@ -297,7 +297,12 @@ public:
 
 struct ScriptClassDesc_t
 {
-	ScriptClassDesc_t() : m_pszScriptName( 0 ), m_pszClassname( 0 ), m_pszDescription( 0 ), m_pBaseDesc( 0 ), m_pfnConstruct( 0 ), m_pfnDestruct( 0 ), pHelper(NULL) {}
+	ScriptClassDesc_t() : m_pszScriptName( 0 ), m_pszClassname( 0 ), m_pszDescription( 0 ), m_pBaseDesc( 0 ), m_pfnConstruct( 0 ), m_pfnDestruct( 0 ), pHelper(NULL) 
+	{
+#ifdef MAPBASE_VSCRIPT
+		AllClassesDesc().AddToTail(this);
+#endif
+	}
 
 	const char *						m_pszScriptName;
 	const char *						m_pszClassname;
@@ -308,6 +313,14 @@ struct ScriptClassDesc_t
 	void *(*m_pfnConstruct)();
 	void (*m_pfnDestruct)( void *);
 	IScriptInstanceHelper *				pHelper; // optional helper
+
+#ifdef MAPBASE_VSCRIPT
+	static CUtlVector<ScriptClassDesc_t*>& AllClassesDesc()
+	{
+		static CUtlVector<ScriptClassDesc_t*> classes;
+		return classes;
+	}
+#endif
 };
 
 //---------------------------------------------------------
@@ -875,6 +888,16 @@ public:
 		return ExecuteFunction( hFunction, args, ARRAYSIZE(args), pReturn, hScope, bWait );
 	}
 
+#ifdef MAPBASE_VSCRIPT
+	void RegisterAllClasses()
+	{
+		CUtlVector<ScriptClassDesc_t*>& classDescs = ScriptClassDesc_t::AllClassesDesc();
+		FOR_EACH_VEC(classDescs, i)
+		{
+			RegisterClass(classDescs[i]);
+		}
+	}
+#endif
 };
 
 


### PR DESCRIPTION
This makes all vscript classes be registered during vscript initialization, removing the issues caused by classes not properly being registered.

Fixes #32 