### PR TITLE
Fix hardware shadow filtering

### DIFF
--- a/sp/src/game/client/clientshadowmgr.cpp
+++ b/sp/src/game/client/clientshadowmgr.cpp
@@ -1494,7 +1494,8 @@ void CClientShadowMgr::InitDepthTextureShadows()
 #else
 #if defined(MAPBASE) //&& !defined(ASW_PROJECTED_TEXTURES)
 			// SAUL: we want to create a *DEPTH TEXTURE* of specific size, so use RT_SIZE_NO_CHANGE and MATERIAL_RT_DEPTH_ONLY
-			depthTex.InitRenderTarget( m_nDepthTextureResolution, m_nDepthTextureResolution, RT_SIZE_NO_CHANGE, dstFormat, MATERIAL_RT_DEPTH_ONLY, false, strRTName );
+			// However, MATERIAL_RT_DEPTH_ONLY forces point filtering to be enabled which negatively affect PCF, so the standard MATERIAL_RT_DEPTH_NONE works better.
+			depthTex.InitRenderTarget( m_nDepthTextureResolution, m_nDepthTextureResolution, RT_SIZE_NO_CHANGE, dstFormat, MATERIAL_RT_DEPTH_NONE, false, strRTName );
 #else
 			depthTex.InitRenderTarget( m_nDepthTextureResolution, m_nDepthTextureResolution, RT_SIZE_OFFSCREEN, dstFormat, MATERIAL_RT_DEPTH_NONE, false, strRTName );
 #endif


### PR DESCRIPTION
Using MATERIAL_RT_DEPTH_ONLY disables hardware filtering, which causes shadows to be pixelated. 
![image](https://user-images.githubusercontent.com/55934692/99319514-884c2e00-28ce-11eb-8b7e-895b14f34535.png)

Changing it back to MATERIAL_RT_DEPTH_NONE re-enables hardware filtering, while still working as a depth texture.
![image](https://user-images.githubusercontent.com/55934692/99319563-9732e080-28ce-11eb-8d68-1928f58b790b.png)
