### PR TITLE
Enable Counter-Strike Source view model chirality in Mapbase

### DIFF
--- a/sp/src/game/client/c_baseviewmodel.cpp
+++ b/sp/src/game/client/c_baseviewmodel.cpp
@@ -32,7 +32,7 @@
 // memdbgon must be the last include file in a .cpp file!!!
 #include "tier0/memdbgon.h"
 
-#ifdef CSTRIKE_DLL
+#if defined(CSTRIKE_DLL) || defined (MAPBASE)
 	ConVar cl_righthand( "cl_righthand", "1", FCVAR_ARCHIVE, "Use right-handed view models." );
 #endif
 
@@ -194,7 +194,7 @@ bool C_BaseViewModel::Interpolate( float currentTime )
 
 inline bool C_BaseViewModel::ShouldFlipViewModel()
 {
-#ifdef CSTRIKE_DLL
+#if defined(CSTRIKE_DLL) || defined (MAPBASE)
 	// If cl_righthand is set, then we want them all right-handed.
 	CBaseCombatWeapon *pWeapon = m_hWeapon.Get();
 	if ( pWeapon )


### PR DESCRIPTION
This pull request simply activates two preprocessors that previously had deactivated the code Counter-Strike uses to switch left handed viewmodels to right handed mode. This will allow weapons to be switched to left handed mode if desired.

Please note that in order to use left handed viewmodels, the following values will need to be added to each weapon script:

```
	"BuiltRightHanded"  "1"
	"AllowFlipping"  "1"
```

If these values are set, then a player or mapper may change the chirality of the player's hands with this ConVar:
```
cl_righthand 0 // left handed
cl_righthand 1 // right handed
```

---

#### Does this PR close any issues?
* #83

<!-- Replace [ ] with [x] for each item your PR satisfies -->
#### PR Checklist
- [x] **My PR follows all guidelines in the CONTRIBUTING.md file**
- [x] My PR targets a `develop` branch OR targets another branch with a specific goal in mind
