### PR TITLE
Add real function parameter registration on ScriptHook_t

### DIFF
--- a/sp/src/vscript/vscript_squirrel.cpp
+++ b/sp/src/vscript/vscript_squirrel.cpp
@@ -1566,9 +1566,12 @@ void RegisterHookDocumentation(HSQUIRRELVM vm, const ScriptHook_t* pHook, const 
 			V_strcat_safe(signature, ", ");
 
 		V_strcat_safe(signature, ScriptDataTypeToName(pFuncDesc.m_Parameters[i]));
-		V_strcat_safe(signature, " [");
-		V_strcat_safe(signature, pHook->m_pszParameterNames[i]);
-		V_strcat_safe(signature, "]");
+		if ( !pHook->m_bUsingRealParams )
+		{
+			V_strcat_safe(signature, " [");
+			V_strcat_safe(signature, pHook->m_pszParameterNames[i]);
+			V_strcat_safe(signature, "]");
+		}
 	}
 
 	V_strcat_safe(signature, ")");


### PR DESCRIPTION
A small change to allow proper function parameters on ScriptHook_t. Apart from its lookup cost, using global variables practically reserves those arbitrary parameter variable names. An example of how it can go wrong:

```cs
// user variable
::variable <- "some important data"

// call a hook with 'variable' "parameter"
CallSomeHookFunc()

// index does not exist, throws error
print( ::variable )
```

---

#### PR Checklist
- [x] **My PR follows all guidelines in the CONTRIBUTING.md file**
- [x] My PR targets a `develop` branch OR targets another branch with a specific goal in mind
