### PR TITLE
Sprinting fixes

### DIFF
--- a/sp/src/game/server/hl2/hl2_player.cpp
+++ b/sp/src/game/server/hl2/hl2_player.cpp
@@ -725,12 +725,20 @@ void CHL2_Player::HandleSpeedChanges( void )
 
 	bool bCanSprint = CanSprint();
 	bool bIsSprinting = IsSprinting();
-	bool bWantSprint = ( bCanSprint && IsSuitEquipped() && (m_nButtons & IN_SPEED) );
+	bool bWantSprint = ( IsSuitEquipped() && (m_nButtons & IN_SPEED) );
+#ifndef MAPBASE
+	// for Mapbase this is added later so the IN_SPEED button is depressed while !bCanSprint
+	// this allows resuming sprint as soon as it is possible again
+	bWantSprint &= bCanSprint;
+#endif
 	if ( bIsSprinting != bWantSprint && (buttonsChanged & IN_SPEED) )
 	{
 		// If someone wants to sprint, make sure they've pressed the button to do so. We want to prevent the
 		// case where a player can hold down the sprint key and burn tiny bursts of sprint as the suit recharges
 		// We want a full debounce of the key to resume sprinting after the suit is completely drained
+#ifdef MAPBASE
+		bWantSprint &= bCanSprint;
+#endif
 		if ( bWantSprint )
 		{
 			if ( sv_stickysprint.GetBool() )


### PR DESCRIPTION
I don't know if these "fixes" align with the spirit of Mapbase.

I think that "[not] swallow[ing] sprinting while jumping" is an objective improvement. Basically without this change if you're in the air, press sprint and hit the ground, you need to let go of sprint and press it again to actually start sprinting.
With this change it will "virtually depress" sprint while you cannot actually sprint, so that as soon as you are able to (i.e. when landing on ground after jumping) you will resume sprinting.

The suit-energy thing may just be a gameplay quirk and not an outright bug. It seems nonsensical to me to let the energy be drained if you're in the air - now I've just said sprinting didn't work with jumping, but oh it does if you're sprinting *before* jumping. Just not during.
So anyways, if you sprint while jumping it will drain your suit, but not actually speed you up. Again, could just be considered a gameplay quirk, though I judged it to be buggy behavior and "fixed it.

If you only want one of these changes let me know and I'll remove the other commit from this branch.

---

#### Does this PR close any issues?

<!-- Replace [ ] with [x] for each item your PR satisfies -->
#### PR Checklist
- [x] **My PR follows all guidelines in the CONTRIBUTING.md file**
- [x] My PR targets a `develop` branch OR targets another branch with a specific goal in mind
