### PR TITLE
Fix scene loading memory errors

### DIFF
--- a/sp/src/game/server/sceneentity.cpp
+++ b/sp/src/game/server/sceneentity.cpp
@@ -4298,7 +4298,7 @@ const char *GetFirstSoundInScene(const char *pszScene)
 	else
 	{
 		void *pBuffer = NULL;
-		if (filesystem->ReadFileEx( pszScene, "MOD", &pBuffer, false, true ))
+		if (filesystem->ReadFileEx( pszScene, "MOD", &pBuffer, true ))
 		{
 			g_TokenProcessor.SetBuffer((char*)pBuffer);
 			CChoreoScene *pScene = ChoreoLoadScene( pszScene, NULL, &g_TokenProcessor, LocalScene_Printf );
@@ -5284,7 +5284,7 @@ int GetSceneSpeechCount( char const *pszScene )
 	else
 	{
 		void *pBuffer = NULL;
-		if (filesystem->ReadFileEx( pszScene, "MOD", &pBuffer, false, true ))
+		if (filesystem->ReadFileEx( pszScene, "MOD", &pBuffer, true ))
 		{
 			int iNumSounds = 0;
 
@@ -5359,7 +5359,7 @@ void PrecacheInstancedScene( char const *pszScene )
 
 		// Attempt to precache manually
 		void *pBuffer = NULL;
-		if (filesystem->ReadFileEx( loadfile, "MOD", &pBuffer, false, true ))
+		if (filesystem->ReadFileEx( loadfile, "MOD", &pBuffer, true ))
 		{
 			g_TokenProcessor.SetBuffer((char*)pBuffer);
 			CChoreoScene *pScene = ChoreoLoadScene( loadfile, NULL, &g_TokenProcessor, LocalScene_Printf );


### PR DESCRIPTION
I've seen crashes when loading maps, which I've tracked down to a runaway read-pointer when loading scene files.
It looks like the parser expects the buffers to be NUL terminated, as also evidenced by the fact that the length of the buffer does not get passed to the parser.
It looks like maybe `bOptimalAlloc` was set to `true` instead of `bNullTerminate`. I don't know what `bOptimalAlloc` does, if it may be important here. Since it looks like a mixup to be `bOptimalAlloc` will default to `false` with this PR.
Assuming `bOptimalAlloc` is desired, the buffer should then also be freed using `filesystem->FreeOptimalReadBuffer()`, so this also (potentially) fixes an incorrect deallocation.

I've also noticed that some buffers get leaked, which I fixed in the second commit.

---

<!-- Replace [ ] with [x] for each item your PR satisfies -->
#### PR Checklist
- [x] **My PR follows all guidelines in the CONTRIBUTING.md file**
- [x] My PR targets a `develop` branch OR targets another branch with a specific goal in mind
