### PR TITLE
Initialize all basis vectors for env_projectedtexture with target

### DIFF
--- a/sp/src/game/client/c_env_projectedtexture.cpp
+++ b/sp/src/game/client/c_env_projectedtexture.cpp
@@ -283,6 +283,8 @@ void C_EnvProjectedTexture::UpdateLight( void )
 
 				//			VectorNormalize( vRight );
 				//			VectorNormalize( vUp );
+
+				VectorVectors( vForward, vRight, vUp );
 			}
 		}
 		else


### PR DESCRIPTION
I've noticed that the env_prjectedtexture with target didn't always render shadows, and I got some asserts in the console leading me here.
There's an `Assert( 0 )` here, which I think can be removed, but I'm not sure, since I'm just supplying "arbitrary" right- and up-vectors and I don't know if that's what's really expected. The shadows look okay, but this may just be happenstance or be missing edge-cases.

---

<!-- Replace [ ] with [x] for each item your PR satisfies -->
#### PR Checklist
- [x] **My PR follows all guidelines in the CONTRIBUTING.md file**
- [x] My PR targets a `develop` branch OR targets another branch with a specific goal in mind
