### PR TITLE
Fix console error on BreakableBrushes without spawnobject

### DIFF
--- a/sp/src/game/server/func_break.cpp
+++ b/sp/src/game/server/func_break.cpp
@@ -221,6 +221,10 @@ bool CBreakable::KeyValue( const char *szKeyName, const char *szValue )
 		if ( object > 0 && object < ARRAYSIZE(pSpawnObjects) )
 			m_iszSpawnObject = MAKE_STRING( pSpawnObjects[object] );
 #ifdef MAPBASE
+		// "0" is the default value of a "choices" field in Hammer, representing nothing selected
+		// atoi() returning 0 may also indicate a failed conversion, so check szValue directly
+		else if ( FStrEq( szValue, "0" ) )
+			m_iszSpawnObject = NULL_STRING;
 		else
 			m_iszSpawnObject = AllocPooledString(szValue);
 #endif


### PR DESCRIPTION
BreakableBrushes (e.g. func_physbox) without a "spawnobject" produced an error "NULL Ent in UTIL_PrecacheOther".
The field in the fgd is a choices-field, which is "0" if nothing is selected.

---

<!-- Replace [ ] with [x] for each item your PR satisfies -->
#### PR Checklist
- [x] **My PR follows all guidelines in the CONTRIBUTING.md file**
- [x] My PR targets a `develop` branch OR targets another branch with a specific goal in mind
