### PR TITLE
VBSP Features for those who use Propper

### DIFF
--- a/sp/src/utils/vbsp/vbsp.cpp
+++ b/sp/src/utils/vbsp/vbsp.cpp
@@ -69,6 +69,8 @@ bool		g_bNoHiddenManifestMaps = false;
 #ifdef MAPBASE
 bool		g_bNoDefaultCubemaps = true;
 bool		g_bSkyboxCubemaps = false;
+bool		g_bPropperInsertAllAsStatic = false;
+bool		g_bPropperStripEntities = false;
 int			g_iDefaultCubemapSize = 32;
 #endif
 #ifdef MAPBASE_VSCRIPT
@@ -1192,6 +1194,14 @@ int RunVBSP( int argc, char **argv )
 			g_iDefaultCubemapSize = atoi( argv[i + 1] );
 			Msg( "Default cubemap size = %i\n", g_iDefaultCubemapSize );
 			i++;
+		}
+		else if ( !Q_stricmp( argv[i], "-defaultproppermodelsstatic" ) )
+		{
+			g_bPropperInsertAllAsStatic = true;
+		}
+		else if ( !Q_stricmp( argv[i], "-strippropperentities" ) )
+		{
+			g_bPropperStripEntities = true;
 		}
 #endif
 #ifdef MAPBASE_VSCRIPT

--- a/sp/src/utils/vbsp/vbsp.h
+++ b/sp/src/utils/vbsp/vbsp.h
@@ -401,6 +401,10 @@ extern	bool		g_DisableWaterLighting;
 extern	bool		g_bAllowDetailCracks;
 extern	bool		g_bNoVirtualMesh;
 extern	bool		g_bNoHiddenManifestMaps;
+#ifdef MAPBASE
+extern bool			g_bPropperInsertAllAsStatic;
+extern bool			g_bPropperStripEntities;
+#endif
 extern	char		outbase[32];
 
 extern	char	source[1024];


### PR DESCRIPTION
These are some small features for those using Propper.  [Recently Slartibarty released a new version of his Slammin' Tools](https://knockout.chat/thread/992/3#post-929516) with the ability to turn propper_models directly into static props.  Basically, this allows you to make a propper_model, compile the map, and see the propper_model as a static prop in-game without the manual hassle of placing the compiled model as a prop_static in Hammer yourself.  Slarti made a video showcasing how this works [here](https://www.youtube.com/watch?v=bCM9ysWPz78).

I figured those who use Mapbase and Propper would benefit from something like this.  So I made some changes to Mapbase's VBSP to basically do the same thing but with more control over what props get compiled as static into the BSP.  By default these features are off unless people run VBSP with `-DefaultPropperModelsStatic` or add the keyvalue `InsertAsStaticProp` (without SmartEdit)  to the propper_model entity (caps don't matter for either).

Furthermore, this code was tested with the version of Propper from Slammin' Tools (although I feel like the original Source 2013 Propper should work fine aswell).  With it being set up to run before VBSP just like how Slarti has his set up in his video.

For those who like convenience, you can add the `InsertAsStaticProp` keyvalue to the propper_model entity by editing Slarti's `propper.fgd` and adding this to the bottom of the propper_model entry:
```
InsertAsStaticProp(choices) : "Insert as Static Prop" : -1 : "If 'Yes', the propper_model entity will be turned into a prop_static, and will be compiled into the map with the settings above." +
"  If 'No', it'll never be compiled into the map." +
"  'Default' doesn't compile it into the map unless -DefaultPropperModelsStatic is specified for VBSP." =
[
	-1 : "Default"
	1 : "No (Never Insert)"
	2 : "Yes (Always Insert)"
]
```

### Run Down
#### VBSP
* Added `-DefaultPropperModelsStatic`: All propper_models will be inserted into the BSP as static props by default, unless `InsertAsStaticProp` equals `1`.
* Added `-StripPropperEntities`: Removes all entities with `propper_` in their classname.  This is to avoid a bunch of Propper entities attempting to spawn in-game despite them being internal entities.

#### propper_model
* Added keyvalue `InsertAsStaticProp`: This determines whether a propper_model gets inserted as a static prop into the BSP.  1 = Never Insert, and 2 = Always Insert.  Any other number will never insert it unless `-DefaultPropperModelsStatic` is specified for VBSP.

---

#### Does this PR close any issues?
No.

<!-- Replace [ ] with [x] for each item your PR satisfies -->
#### PR Checklist
- [x] **My PR follows all guidelines in the CONTRIBUTING.md file**
- [ ] My PR targets a `develop` branch OR targets another branch with a specific goal in mind
