### PR TITLE
func_fake_worldportal overhaul

### DIFF
--- a/sp/src/game/client/mapbase/c_func_fake_worldportal.cpp
+++ b/sp/src/game/client/mapbase/c_func_fake_worldportal.cpp
@@ -1,6 +1,6 @@
 //========= Mapbase - https://github.com/mapbase-source/source-sdk-2013 ============//
 //
-// Purpose: Recreates Portal 2 linked_portal_door functionality using SDK code only.
+// Purpose: Recreates Portal 2 linked_portal_door visual functionality using SDK code only.
 //			(basically a combination of point_camera and func_reflective_glass)
 //
 // $NoKeywords: $
@@ -120,8 +120,8 @@ C_FuncFakeWorldPortal *IsFakeWorldPortalInView( const CViewSetup& view, cplane_t
 //-----------------------------------------------------------------------------
 // Iterates through fake world portals instead of just picking one
 //-----------------------------------------------------------------------------
-C_FuncFakeWorldPortal *NextFakeWorldPortal( C_FuncFakeWorldPortal *pStart, const CViewSetup& view, cplane_t &plane,
-	const Frustum_t &frustum )
+C_FuncFakeWorldPortal *NextFakeWorldPortal( C_FuncFakeWorldPortal *pStart, const CViewSetup& view,
+	cplane_t &plane, Vector &vecPlaneOrigin, const Frustum_t &frustum )
 {
 	// Early out if no cameras
 	C_FuncFakeWorldPortal *pReflectiveGlass = NULL;
@@ -167,6 +167,7 @@ C_FuncFakeWorldPortal *NextFakeWorldPortal( C_FuncFakeWorldPortal *pStart, const
 			if ( !pReflectiveGlass->m_hTargetPlane )
 				continue;
 
+			vecPlaneOrigin = vecOrigin;
 			return pReflectiveGlass;
 		}
 	}

--- a/sp/src/game/client/mapbase/c_func_fake_worldportal.h
+++ b/sp/src/game/client/mapbase/c_func_fake_worldportal.h
@@ -55,8 +55,8 @@ public:
 //-----------------------------------------------------------------------------
 C_FuncFakeWorldPortal *IsFakeWorldPortalInView( const CViewSetup& view, cplane_t &plane );
 
-C_FuncFakeWorldPortal *NextFakeWorldPortal( C_FuncFakeWorldPortal *pStart, const CViewSetup& view, cplane_t &plane,
-	const Frustum_t &frustum );
+C_FuncFakeWorldPortal *NextFakeWorldPortal( C_FuncFakeWorldPortal *pStart, const CViewSetup& view,
+	cplane_t &plane, Vector &vecPlaneOrigin, const Frustum_t &frustum );
 
 
 #endif // C_FUNC_FAKE_WORLDPORTAL

--- a/sp/src/game/client/viewrender.h
+++ b/sp/src/game/client/viewrender.h
@@ -454,7 +454,7 @@ private:
 #ifdef MAPBASE
 	bool			DrawFakeWorldPortal( ITexture *pRenderTarget, C_FuncFakeWorldPortal *pCameraEnt, const CViewSetup &cameraView, C_BasePlayer *localPlayer, 
 						int x, int y, int width, int height,
-						const CViewSetup &mainView, cplane_t &ourPlane );
+						const CViewSetup &mainView, cplane_t &ourPlane, const Vector &vecPlaneOrigin );
 #endif
 
 	// Drawing primitives

--- a/sp/src/game/server/mapbase/func_fake_worldportal.cpp
+++ b/sp/src/game/server/mapbase/func_fake_worldportal.cpp
@@ -1,6 +1,6 @@
 //========= Mapbase - https://github.com/mapbase-source/source-sdk-2013 ============//
 //
-// Purpose: Recreates Portal 2 linked_portal_door functionality using SDK code only.
+// Purpose: Recreates Portal 2 linked_portal_door visual functionality using SDK code only.
 //			(basically a combination of point_camera and func_reflective_glass)
 //
 //===========================================================================//


### PR DESCRIPTION
This overhauls the WIP `func_fake_worldportal` code to clean up the code, fix some oversights, and use a matrix-based method based on the `logic_measure_movement` code rather than the rotating 3D skybox code. This fixes several prior issues with the entity and makes `func_fake_worldportal`'s angled appearance behave more like portals from the Portal series.

With this pull request, `func_fake_worldportal` would no longer be a work-in-progress and would actually be usable in a map.