### PR TITLE
Fix VS2019 _msize_base() exception specification

### DIFF
--- a/sp/src/public/tier0/memoverride.cpp
+++ b/sp/src/public/tier0/memoverride.cpp
@@ -282,6 +282,9 @@ ALLOC_CALL void * __cdecl _recalloc ( void * memblock, size_t count, size_t size
 }
 
 size_t _msize_base( void *pMem )
+#if _MSC_VER >= 1925 //VS2019+
+	throw()
+#endif
 {
 	return g_pMemAlloc->GetSize(pMem);
 }


### PR DESCRIPTION
Looks like vs VS2019 builds fails currently:
>      1>D:\a\source-sdk-2013\source-sdk-2013\sp\src\public\tier0\memoverride.cpp(284,8): error C2382: '_msize_base': redefinition; different exception specifications [D:\a\source-sdk-2013\source-sdk-2013\sp\src\game\server\server_ntks.vcxproj]
>       C:\Program Files (x86)\Windows Kits\10\Include\10.0.22000.0\ucrt\corecrt_malloc.h(107): message : see declaration of '_msize_base' [D:\a\source-sdk-2013\source-sdk-2013\sp\src\game\server\server_ntks.vcxproj]

With this applied, the build runs through: https://github.com/NTKS-Team/source-sdk-2013/actions/runs/1459268410
This is the script used for the CI: https://github.com/NTKS-Team/source-sdk-2013/blob/91eef577deed1bb28d2f88d68ce0ef22b62879bd/.github/workflows/msbuild.yml
VS2012 isn't available on Github's CI without hosting your own instance. I've tried installing it through Chocolatey, but the install scripts I've found seem to be defunct due to some change on Microsoft's part of the install process, I think something about online registration or some such.
I've been told the binaries even work! Feel free to adopt the script for mapbase or pose any related questions if you have em. I can also hop on Discord, though note that I'm rarely online there.
I'm invoking msbuild for each project individually, which looks a bit odd considering there is a solution file which should be able to invoke the builds in their proper order automatically, but [passing the solution to msbuild](https://github.com/NTKS-Team/source-sdk-2013/commit/67728fa84707b5da2d5cf5daf901685cfd940aa1) doesn't seem to [work](https://github.com/NTKS-Team/source-sdk-2013/runs/4204448047?check_suite_focus=true).
> Microsoft (R) Build Engine version 16.11.2+f32259642 for .NET Framework
> Copyright (C) Microsoft Corporation. All rights reserved.
> 
> Build started 11/14/2021 4:35:57 PM.
>      1>Project "D:\a\source-sdk-2013\source-sdk-2013\sp\src\games_ntks.sln" on node 1 (Client _NTKS_ target(s)).
>      1>ValidateSolutionConfiguration:
>          Building solution configuration "Release|Win32".
>      1>Done Building Project "D:\a\source-sdk-2013\source-sdk-2013\sp\src\games_ntks.sln" (Client _NTKS_ target(s)).
> 
> Build succeeded.
>     0 Warning(s)
>     0 Error(s)

(It doesn't build anything.)
I'm not really up to the task of trying to remotely debug how to fix it and the workaround of building each project separately is good enough for me.

I could also look into doing Linux builds on Github's CI if you want.

---
<!-- Replace [ ] with [x] for each item your PR satisfies -->
#### PR Checklist
- [x] **My PR follows all guidelines in the CONTRIBUTING.md file**
- [x] My PR targets a `develop` branch OR targets another branch with a specific goal in mind
