### PR TITLE
Fix CScriptNetMsgHelper::WriteEntity()

### DIFF
--- a/sp/src/game/shared/mapbase/vscript_singletons.cpp
+++ b/sp/src/game/shared/mapbase/vscript_singletons.cpp
@@ -1749,8 +1749,8 @@ void CNetMsgScriptHelper::WriteEntity( HSCRIPT hEnt )
 {
 	SCRIPT_NETMSG_WRITE_FUNC
 	CBaseEntity *p = ToEnt(hEnt);
-	int i = p ? p->entindex() : -1;
-	m_MsgOut.WriteSBitLong( i, MAX_EDICT_BITS );
+	int i = p ? p->entindex() : 0;
+	m_MsgOut.WriteUBitLong( i, MAX_EDICT_BITS );
 }
 
 void CNetMsgScriptHelper::WriteEHandle( HSCRIPT hEnt )
@@ -1861,7 +1861,11 @@ bool CNetMsgScriptHelper::ReadBool()
 
 HSCRIPT CNetMsgScriptHelper::ReadEntity()
 {
-	int index = m_MsgIn_()ReadSBitLong( MAX_EDICT_BITS );
+	int index = m_MsgIn_()ReadUBitLong( MAX_EDICT_BITS );
+
+	if ( !index )
+		return NULL;
+
 #ifdef GAME_DLL
 	edict_t *e = INDEXENT(index);
 	if ( e && !e->IsFree() )

--- a/sp/src/game/shared/mapbase/vscript_singletons.cpp
+++ b/sp/src/game/shared/mapbase/vscript_singletons.cpp
@@ -740,7 +740,11 @@ void CScriptGameEventListener::StopListeningForEvent()
 #ifdef _DEBUG
 	// Event listeners are iterated forwards in the game event manager,
 	// removing while iterating will cause it to skip one listener.
-	// This could be prevented by writing a custom game event manager.
+	//
+	// Fix this in engine without altering any behaviour by
+	// changing event exeuction order to tail->head,
+	// changing listener removal to tail->head,
+	// changing listener addition to head
 	if ( m_nEventTick == gpGlobals->tickcount )
 	{
 		Warning("CScriptGameEventListener stopped in the same frame it was fired. This will break other event listeners!\n");

--- a/sp/src/vscript/vscript_squirrel.cpp
+++ b/sp/src/vscript/vscript_squirrel.cpp
@@ -2779,7 +2779,6 @@ bool SquirrelVM::GenerateUniqueKey(const char* pszRoot, char* pBuf, int nBufSize
 	static int keyIdx = 0;
 	// This gets used for script scope, still confused why it needs to be inside IScriptVM
 	// is it just to be a compatible name for CreateScope?
-	SquirrelSafeCheck safeCheck(vm_);
 	V_snprintf(pBuf, nBufSize, "%08X_%s", ++keyIdx, pszRoot);
 	return true;
 }


### PR DESCRIPTION
Previously would only write 10 bits, missing indices [1024,2048)

---

#### PR Checklist
- [x] **My PR follows all guidelines in the CONTRIBUTING.md file**
- [x] My PR targets a `develop` branch OR targets another branch with a specific goal in mind
