### PR TITLE
Potential fix for GitHub workflows not being able to compile .sln files

### DIFF
--- a/.github/workflows/fix_sln.sh
+++ b/.github/workflows/fix_sln.sh
@@ -14,6 +14,20 @@ Global
 		Debug|Win32 = Debug|Win32
 		Release|Win32 = Release|Win32
 	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+EOF
+while read -r line; do
+	[ "${line:0:8}" != "Project(" ] && continue
+	id="$(echo "${line}"|cut -d',' -f 3)"
+	id="${id:2:-2}"
+	for cfg in "Debug" "Release"; do
+		for param in "ActiveCfg" "Build.0"; do
+			echo "		${id}.${cfg}|Win32.${param} = ${cfg}|Win32"
+		done
+	done
+done | crlf
+crlf <<EOF
+	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection

--- a/.github/workflows/fix_sln.sh
+++ b/.github/workflows/fix_sln.sh
@@ -1,0 +1,35 @@
+#!/bin/bash -eu
+
+IFS=''
+
+crlf() {
+	while read -r line; do
+		printf '%s\r\n' "${line}"
+	done
+}
+
+crlf <<EOF
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Win32 = Debug|Win32
+		Release|Win32 = Release|Win32
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+EOF
+while read -r line; do
+	[ "${line:0:8}" != "Project(" ] && continue
+	id="$(echo "${line}"|cut -d',' -f 3)"
+	id="${id:2:-2}"
+	for cfg in "Debug" "Release"; do
+		for param in "ActiveCfg" "Build.0"; do
+			echo "		${id}.${cfg}|Win32.${param} = ${cfg}|Win32"
+		done
+	done
+done | crlf
+crlf <<EOF
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal
+EOF

--- a/.github/workflows/fix_sln.sh
+++ b/.github/workflows/fix_sln.sh
@@ -14,20 +14,6 @@ Global
 		Debug|Win32 = Debug|Win32
 		Release|Win32 = Release|Win32
 	EndGlobalSection
-	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-EOF
-while read -r line; do
-	[ "${line:0:8}" != "Project(" ] && continue
-	id="$(echo "${line}"|cut -d',' -f 3)"
-	id="${id:2:-2}"
-	for cfg in "Debug" "Release"; do
-		for param in "ActiveCfg" "Build.0"; do
-			echo "		${id}.${cfg}|Win32.${param} = ${cfg}|Win32"
-		done
-	done
-done | crlf
-crlf <<EOF
-	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection

--- a/.github/workflows/mapbase_build-base.yml
+++ b/.github/workflows/mapbase_build-base.yml
@@ -80,7 +80,9 @@ jobs:
     - name: Fix sln
       working-directory: '${{inputs.branch}}/src'
       shell: bash
-      run: cat ${{inputs.solution-name}}.sln
+      run: |
+        ../../.github/workflows/fix_sln.sh ${{inputs.solution-name}}.sln >>${{inputs.solution-name}}.sln
+        cat ${{inputs.solution-name}}.sln
 
     - name: Build
       working-directory: '${{inputs.branch}}/src'

--- a/.github/workflows/mapbase_build-base.yml
+++ b/.github/workflows/mapbase_build-base.yml
@@ -80,7 +80,7 @@ jobs:
     - name: Fix sln
       working-directory: '${{inputs.branch}}/src'
       shell: bash
-      run: ../../.github/workflows/fix_sln.sh ${{inputs.solution-name}}.sln >>${{inputs.solution-name}}.sln
+      run: cat ${{inputs.solution-name}}.sln
 
     - name: Build
       working-directory: '${{inputs.branch}}/src'

--- a/.github/workflows/mapbase_build-base.yml
+++ b/.github/workflows/mapbase_build-base.yml
@@ -76,7 +76,7 @@ jobs:
         create${{inputs.project-group}}projects.bat
 
       # --------------------------------------------------------------------
-	  
+
     - name: Fix sln
       working-directory: '${{inputs.branch}}/src'
       shell: bash

--- a/.github/workflows/mapbase_build-base.yml
+++ b/.github/workflows/mapbase_build-base.yml
@@ -72,72 +72,23 @@ jobs:
       shell: cmd
       # https://github.com/ValveSoftware/source-sdk-2013/issues/72
       run: |
-        reg add "HKLM\SOFTWARE\WOW6432Node\Microsoft\VisualStudio\10.0\Projects\{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}" /v DefaultProjectExtension /t REG_SZ /d vcproj /f
+        reg add "HKLM\SOFTWARE\WOW6432Node\Microsoft\VisualStudio\10.0\Projects\{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}" /v DefaultProjectExtension /t REG_SZ /d vcxproj /f
         create${{inputs.project-group}}projects.bat
 
       # --------------------------------------------------------------------
-
-      # "I'm invoking msbuild for each project individually, which looks a bit odd considering there is a solution file which should be able to invoke the builds in their proper order automatically, but passing the solution to msbuild doesn't seem to work."
-      # https://github.com/mapbase-source/source-sdk-2013/pull/162
-
-    - name: Build mathlib
-      #if: steps.filter.outputs.game == 'true'
+	  
+    - name: Fix sln
       working-directory: '${{inputs.branch}}/src'
+      shell: bash
+      run: ../../.github/workflows/fix_sln.sh ${{inputs.solution-name}}.sln >>${{inputs.solution-name}}.sln
+
+    - name: Build
+      working-directory: '${{inputs.branch}}/src'
+      # Add additional options to the MSBuild command line here (like platform or verbosity level).
+      # See https://docs.microsoft.com/visualstudio/msbuild/msbuild-command-line-reference
       shell: cmd
       run: |
-        msbuild -m -p:Configuration=${{inputs.configuration}} mathlib\mathlib.vcxproj
-
-    - name: Build Base Libraries
-      if: inputs.project-group == 'all' || inputs.project-group == 'game' || inputs.project-group == 'maptools'
-      working-directory: '${{inputs.branch}}/src'
-      shell: cmd
-      run: |
-        msbuild -m -p:Configuration=${{inputs.configuration}} raytrace\raytrace.vcxproj
-        msbuild -m -p:Configuration=${{inputs.configuration}} tier1\tier1.vcxproj
-        msbuild -m -p:Configuration=${{inputs.configuration}} vgui2\vgui_controls\vgui_controls.vcxproj
-        msbuild -m -p:Configuration=${{inputs.configuration}} vscript\vscript.vcxproj
-
-    - name: Build Map Tools
-      if: inputs.project-group == 'all' || inputs.project-group == 'maptools'
-      working-directory: '${{inputs.branch}}/src'
-      shell: cmd
-      run: |
-        msbuild -m -p:Configuration=${{inputs.configuration}} fgdlib\fgdlib.vcxproj
-        msbuild -m -p:Configuration=${{inputs.configuration}} utils\vbsp\vbsp.vcxproj
-        msbuild -m -p:Configuration=${{inputs.configuration}} utils\vvis\vvis_dll.vcxproj
-        msbuild -m -p:Configuration=${{inputs.configuration}} utils\vvis_launcher\vvis_launcher.vcxproj
-        msbuild -m -p:Configuration=${{inputs.configuration}} utils\vrad\vrad_dll.vcxproj
-        msbuild -m -p:Configuration=${{inputs.configuration}} utils\vrad_launcher\vrad_launcher.vcxproj
-
-    - name: Build Shaders
-      if: inputs.project-group == 'shaders'
-      working-directory: '${{inputs.branch}}/src'
-      shell: cmd
-      run: |
-        msbuild -m -p:Configuration=${{inputs.configuration}} materialsystem\stdshaders\game_shader_dx9_${{inputs.game}}.vcxproj
-
-    - name: Build Game
-      if: inputs.project-group == 'game'
-      working-directory: '${{inputs.branch}}/src'
-      shell: cmd
-      run: |
-        msbuild -m -p:Configuration=${{inputs.configuration}} responserules\runtime\responserules.vcxproj
-        msbuild -m -p:Configuration=${{inputs.configuration}} game\client\client_${{inputs.game}}.vcxproj
-        msbuild -m -p:Configuration=${{inputs.configuration}} game\server\server_${{inputs.game}}.vcxproj
-
-    # TODO: Hook to game naming?
-    - name: Build everything
-      if: inputs.project-group == 'all'
-      working-directory: '${{inputs.branch}}/src'
-      shell: cmd
-      run: |
-        msbuild -m -p:Configuration=${{inputs.configuration}} responserules\runtime\responserules.vcxproj
-        msbuild -m -p:Configuration=${{inputs.configuration}} materialsystem\stdshaders\game_shader_dx9_episodic.vcxproj
-        msbuild -m -p:Configuration=${{inputs.configuration}} materialsystem\stdshaders\game_shader_dx9_hl2.vcxproj
-        msbuild -m -p:Configuration=${{inputs.configuration}} game\client\client_episodic.vcxproj
-        msbuild -m -p:Configuration=${{inputs.configuration}} game\client\client_hl2.vcxproj
-        msbuild -m -p:Configuration=${{inputs.configuration}} game\server\server_episodic.vcxproj
-        msbuild -m -p:Configuration=${{inputs.configuration}} game\server\server_hl2.vcxproj
+        msbuild -m -p:Configuration=${{inputs.configuration}} -t:rebuild ${{inputs.solution-name}}.sln
 
       # --------------------------------------------------------------------
 

--- a/.github/workflows/mapbase_build-sp-games.yml
+++ b/.github/workflows/mapbase_build-sp-games.yml
@@ -13,6 +13,7 @@ on:
     branches:
       - develop
     paths:
+      - '.github/workflows/mapbase_build-base.yml'
       - '.github/workflows/mapbase_build-sp-rel-games.yml'
       - 'sp/src/vpc_scripts/**'
       - 'sp/src/game/**'

--- a/.github/workflows/mapbase_build-sp-maptools.yml
+++ b/.github/workflows/mapbase_build-sp-maptools.yml
@@ -13,6 +13,7 @@ on:
     branches:
       - develop
     paths:
+      - '.github/workflows/mapbase_build-base.yml'
       - '.github/workflows/mapbase_build-sp-rel-maptools.yml'
       - 'sp/src/vpc_scripts/**'
       - 'sp/src/utils/vbsp/**'

--- a/.github/workflows/mapbase_build-sp-shaders.yml
+++ b/.github/workflows/mapbase_build-sp-shaders.yml
@@ -13,6 +13,7 @@ on:
     branches:
       - develop
     paths:
+      - '.github/workflows/mapbase_build-base.yml'
       - '.github/workflows/mapbase_build-sp-rel-shaders.yml'
       - 'sp/src/vpc_scripts/**'
       - 'sp/src/materialsystem/**'


### PR DESCRIPTION
Utilizes [z33ky's original attempt at compiling the .sln](https://github.com/NTKS-Team/source-sdk-2013/commit/67728fa84707b5da2d5cf5daf901685cfd940aa1), but changes the regkey to use `.vcxproj` instead of `.vcproj`