### PR TITLE
vscript vgui HUD visibility control

### DIFF
--- a/sp/src/game/client/hud.cpp
+++ b/sp/src/game/client/hud.cpp
@@ -947,11 +947,6 @@ float CHud::GetFOVSensitivityAdjust()
 {
 	return m_flFOVSensitivityAdjust;
 }
-
-#ifdef MAPBASE_VSCRIPT
-extern int g_iVScriptHideHUD;
-#endif
-
 //-----------------------------------------------------------------------------
 // Purpose: Return true if the passed in sections of the HUD shouldn't be drawn
 //-----------------------------------------------------------------------------
@@ -972,14 +967,6 @@ bool CHud::IsHidden( int iHudFlags )
 	{
 		iHideHud = hidehud.GetInt();
 	}
-
-#ifdef MAPBASE_VSCRIPT
-	// Hide elements hidden by scripts
-	if ( g_iVScriptHideHUD )
-	{
-		iHideHud |= g_iVScriptHideHUD;
-	}
-#endif
 
 	// Everything hidden?
 	if ( iHideHud & HIDEHUD_ALL )

--- a/sp/src/game/client/hudelement.h
+++ b/sp/src/game/client/hudelement.h
@@ -58,6 +58,9 @@ public:
 	// Hidden bits. 
 	// HIDEHUD_ flags that note when this element should be hidden in the HUD
 	virtual void				SetHiddenBits( int iBits );
+#ifdef MAPBASE_VSCRIPT
+	int							GetHiddenBits() const { return m_iHiddenBits; }
+#endif
 
 	bool						IsParentedToClientDLLRootPanel() const;
 	void						SetParentedToClientDLLRootPanel( bool parented );

--- a/sp/src/game/client/mapbase/c_func_fake_worldportal.cpp
+++ b/sp/src/game/client/mapbase/c_func_fake_worldportal.cpp
@@ -59,69 +59,10 @@ bool C_FuncFakeWorldPortal::ShouldDraw()
 
 
 //-----------------------------------------------------------------------------
-// Do we have a fake world portal in view?
-//-----------------------------------------------------------------------------
-C_FuncFakeWorldPortal *IsFakeWorldPortalInView( const CViewSetup& view, cplane_t &plane )
-{
-	// Early out if no cameras
-	C_FuncFakeWorldPortal *pReflectiveGlass = GetFakeWorldPortalList();
-	if ( !pReflectiveGlass )
-		return NULL;
-
-	Frustum_t frustum;
-	GeneratePerspectiveFrustum( view.origin, view.angles, view.zNear, view.zFar, view.fov, view.m_flAspectRatio, frustum );
-
-	cplane_t localPlane;
-	Vector vecOrigin, vecWorld, vecDelta, vecForward;
-	AngleVectors( view.angles, &vecForward, NULL, NULL );
-
-	for ( ; pReflectiveGlass != NULL; pReflectiveGlass = pReflectiveGlass->m_pNext )
-	{
-		if ( pReflectiveGlass->IsDormant() )
-			continue;
-
-		if ( pReflectiveGlass->m_iViewHideFlags & (1 << CurrentViewID()) )
-			continue;
-
-		Vector vecMins, vecMaxs;
-		pReflectiveGlass->GetRenderBoundsWorldspace( vecMins, vecMaxs );
-		if ( R_CullBox( vecMins, vecMaxs, frustum ) )
-			continue;
-
-		const model_t *pModel = pReflectiveGlass->GetModel();
-		const matrix3x4_t& mat = pReflectiveGlass->EntityToWorldTransform();
-
-		int nCount = modelinfo->GetBrushModelPlaneCount( pModel );
-		for ( int i = 0; i < nCount; ++i )
-		{
-			modelinfo->GetBrushModelPlane( pModel, i, localPlane, &vecOrigin );
-
-			MatrixTransformPlane( mat, localPlane, plane );			// Transform to world space
-			VectorTransform( vecOrigin, mat, vecWorld );
-					 
-			if ( view.origin.Dot( plane.normal ) <= plane.dist )	// Check for view behind plane
-				continue;
-			
-			VectorSubtract( vecWorld, view.origin, vecDelta );		// Backface cull
-			if ( vecDelta.Dot( plane.normal ) >= 0 )
-				continue;
-
-			// Must have valid plane
-			if ( !pReflectiveGlass->m_hTargetPlane )
-				continue;
-
-			return pReflectiveGlass;
-		}
-	}
-
-	return NULL;
-}
-
-//-----------------------------------------------------------------------------
 // Iterates through fake world portals instead of just picking one
 //-----------------------------------------------------------------------------
 C_FuncFakeWorldPortal *NextFakeWorldPortal( C_FuncFakeWorldPortal *pStart, const CViewSetup& view,
-	cplane_t &plane, Vector &vecPlaneOrigin, const Frustum_t &frustum )
+	Vector &vecAbsPlaneNormal, Vector &vecPlaneLocalOrigin, const Frustum_t &frustum )
 {
 	// Early out if no cameras
 	C_FuncFakeWorldPortal *pReflectiveGlass = NULL;
@@ -130,8 +71,9 @@ C_FuncFakeWorldPortal *NextFakeWorldPortal( C_FuncFakeWorldPortal *pStart, const
 	else
 		pReflectiveGlass = pStart->m_pNext;
 
-	cplane_t localPlane;
-	Vector vecOrigin, vecWorld, vecDelta;
+	cplane_t localPlane, worldPlane;
+	Vector vecMins, vecMaxs, vecLocalOrigin, vecAbsOrigin, vecDelta;
+
 	for ( ; pReflectiveGlass != NULL; pReflectiveGlass = pReflectiveGlass->m_pNext )
 	{
 		if ( pReflectiveGlass->IsDormant() )
@@ -140,7 +82,10 @@ C_FuncFakeWorldPortal *NextFakeWorldPortal( C_FuncFakeWorldPortal *pStart, const
 		if ( pReflectiveGlass->m_iViewHideFlags & (1 << CurrentViewID()) )
 			continue;
 
-		Vector vecMins, vecMaxs;
+		// Must have valid plane
+		if ( !pReflectiveGlass->m_hTargetPlane )
+			continue;
+
 		pReflectiveGlass->GetRenderBoundsWorldspace( vecMins, vecMaxs );
 		if ( R_CullBox( vecMins, vecMaxs, frustum ) )
 			continue;
@@ -151,23 +96,22 @@ C_FuncFakeWorldPortal *NextFakeWorldPortal( C_FuncFakeWorldPortal *pStart, const
 		int nCount = modelinfo->GetBrushModelPlaneCount( pModel );
 		for ( int i = 0; i < nCount; ++i )
 		{
-			modelinfo->GetBrushModelPlane( pModel, i, localPlane, &vecOrigin );
+			modelinfo->GetBrushModelPlane( pModel, i, localPlane, &vecLocalOrigin );
 
-			MatrixTransformPlane( mat, localPlane, plane );			// Transform to world space
-			VectorTransform( vecOrigin, mat, vecWorld );
+			MatrixTransformPlane( mat, localPlane, worldPlane );			// Transform to world space
 					 
-			if ( view.origin.Dot( plane.normal ) <= plane.dist )	// Check for view behind plane
+			if ( view.origin.Dot( worldPlane.normal ) <= worldPlane.dist )	// Check for view behind plane
 				continue;
 			
-			VectorSubtract( vecWorld, view.origin, vecDelta );		// Backface cull
-			if ( vecDelta.Dot( plane.normal ) >= 0 )
+			VectorTransform( vecLocalOrigin, mat, vecAbsOrigin );
+			VectorSubtract( vecAbsOrigin, view.origin, vecDelta );
+
+			if ( vecDelta.Dot( worldPlane.normal ) >= 0 )					// Backface cull
 				continue;
 
-			// Must have valid plane
-			if ( !pReflectiveGlass->m_hTargetPlane )
-				continue;
+			vecPlaneLocalOrigin = vecLocalOrigin;
+			vecAbsPlaneNormal = worldPlane.normal;
 
-			vecPlaneOrigin = vecOrigin;
 			return pReflectiveGlass;
 		}
 	}

--- a/sp/src/game/client/mapbase/c_func_fake_worldportal.cpp
+++ b/sp/src/game/client/mapbase/c_func_fake_worldportal.cpp
@@ -62,7 +62,7 @@ bool C_FuncFakeWorldPortal::ShouldDraw()
 // Iterates through fake world portals instead of just picking one
 //-----------------------------------------------------------------------------
 C_FuncFakeWorldPortal *NextFakeWorldPortal( C_FuncFakeWorldPortal *pStart, const CViewSetup& view,
-	Vector &vecAbsPlaneNormal, Vector &vecPlaneLocalOrigin, const Frustum_t &frustum )
+	Vector &vecAbsPlaneNormal, float &flLocalPlaneDist, const Frustum_t &frustum )
 {
 	// Early out if no cameras
 	C_FuncFakeWorldPortal *pReflectiveGlass = NULL;
@@ -109,7 +109,7 @@ C_FuncFakeWorldPortal *NextFakeWorldPortal( C_FuncFakeWorldPortal *pStart, const
 			if ( vecDelta.Dot( worldPlane.normal ) >= 0 )					// Backface cull
 				continue;
 
-			vecPlaneLocalOrigin = vecLocalOrigin;
+			flLocalPlaneDist = localPlane.dist;
 			vecAbsPlaneNormal = worldPlane.normal;
 
 			return pReflectiveGlass;

--- a/sp/src/game/client/mapbase/c_func_fake_worldportal.h
+++ b/sp/src/game/client/mapbase/c_func_fake_worldportal.h
@@ -53,10 +53,8 @@ public:
 //-----------------------------------------------------------------------------
 // Do we have reflective glass in view? If so, what's the reflection plane?
 //-----------------------------------------------------------------------------
-C_FuncFakeWorldPortal *IsFakeWorldPortalInView( const CViewSetup& view, cplane_t &plane );
-
 C_FuncFakeWorldPortal *NextFakeWorldPortal( C_FuncFakeWorldPortal *pStart, const CViewSetup& view,
-	cplane_t &plane, Vector &vecPlaneOrigin, const Frustum_t &frustum );
+	Vector &vecAbsPlaneNormal, Vector &vecPlaneOrigin, const Frustum_t &frustum );
 
 
 #endif // C_FUNC_FAKE_WORLDPORTAL

--- a/sp/src/game/client/mapbase/c_func_fake_worldportal.h
+++ b/sp/src/game/client/mapbase/c_func_fake_worldportal.h
@@ -54,7 +54,7 @@ public:
 // Do we have reflective glass in view? If so, what's the reflection plane?
 //-----------------------------------------------------------------------------
 C_FuncFakeWorldPortal *NextFakeWorldPortal( C_FuncFakeWorldPortal *pStart, const CViewSetup& view,
-	Vector &vecAbsPlaneNormal, Vector &vecPlaneOrigin, const Frustum_t &frustum );
+	Vector &vecAbsPlaneNormal, float &flLocalPlaneDist, const Frustum_t &frustum );
 
 
 #endif // C_FUNC_FAKE_WORLDPORTAL

--- a/sp/src/game/client/mapbase/vscript_vgui.cpp
+++ b/sp/src/game/client/mapbase/vscript_vgui.cpp
@@ -40,7 +40,9 @@
 #include <vgui_controls/TextImage.h>
 //#include <vgui_controls/Tooltip.h>
 
-//#include "bitmap/tgaloader.h"
+#if VGUI_TGA_IMAGE_PANEL
+#include "bitmap/tgaloader.h"
+#endif
 
 #if !defined(NO_STEAM)
 #include "steam/steam_api.h"
@@ -48,8 +50,8 @@
 #endif
 
 #include "view.h"
-
 #include "hudelement.h"
+//#include "iclientmode.h" // g_pClientMode->GetViewport()
 
 #include "vscript_vgui.h"
 #include "vscript_vgui.nut"
@@ -85,10 +87,15 @@
 //=============================================================================
 
 
-// When enabled, script panels will be parented to custom script root panels.
+// When enabled, script panels will be parented to custom root panels.
 // When disabled, script panels will be parented to engine root panels, and allow Z values for script panels to be interplaced amongst non-script panels.
 // Changing this is not backwards compatible, as existing top level script panel depth would then change relative to non-script panels.
 #define SCRIPT_ENGINE_ROOT_PANELS 1
+
+// NOTE: causes rendering issues
+#define ALLOW_SCRIPT_HUD_VIEWPORT_ROOT_PANEL 0
+
+#define ALLOW_SCRIPT_GAMEUI_ROOT_PANEL 0
 
 // On level transitions Restore is called up to 4 times in a row (due to .hl? client state files), each time
 // trying to restore script panels from pre and post transitions, failing every time because script panels are
@@ -101,6 +108,9 @@
 //
 // This code is left here for testing.
 #define SCRIPT_VGUI_SAVERESTORE 0
+
+#define SCRIPT_VGUI_SIGNAL_INTERFACE 0
+
 
 
 #ifdef _DEBUG
@@ -119,15 +129,6 @@
 
 
 
-using namespace vgui;
-class IScriptVGUIObject;
-struct FontData_t;
-template< typename T > class CCopyableUtlVectorConservative;
-
-// Aliases contain only one font definition unless 'yres' was defined
-typedef CCopyableUtlVectorConservative< FontData_t > fontalias_t;
-typedef CUtlDict< fontalias_t > CFontDict;
-
 template< typename T >
 class CCopyableUtlVectorConservative : public CUtlVectorConservative< T >
 {
@@ -138,6 +139,14 @@ public:
 	CCopyableUtlVectorConservative( CCopyableUtlVectorConservative const& vec ) { this->CopyArray( vec.Base(), vec.Count() ); }
 };
 
+
+using namespace vgui;
+class IScriptVGUIObject;
+struct FontData_t;
+
+// Aliases contain only one font definition unless 'yres' was defined
+typedef CCopyableUtlVectorConservative< FontData_t > fontalias_t;
+typedef CUtlDict< fontalias_t > CFontDict;
 
 
 CFontDict g_ScriptFonts( k_eDictCompareTypeCaseSensitive );
@@ -315,7 +324,7 @@ public:
 	// Ideally script fonts would be loaded along with others in engine.
 	// In that case CScriptRootPanel would be removed, and
 	// g_pScriptRootPanel would be CScriptRootDLLPanel inside #if SCRIPT_ENGINE_ROOT_PANELS
-	void OnScreenSizeChanged( int, int )
+	void OnScreenSizeChanged( int w, int t )
 	{
 		// Reload fonts in the next vgui frame
 		ivgui()->AddTickSignal( GetVPanel() );
@@ -324,6 +333,8 @@ public:
 		// Invalidate cached values
 		if ( g_pScriptVM )
 			g_pScriptVM->Run( "ISurface.__OnScreenSizeChanged()" );
+
+		Panel::OnScreenSizeChanged( w, t );
 	}
 
 private:
@@ -435,7 +446,6 @@ public:
 	void DrawOutlinedRect( int x0, int y0, int width, int height, int thickness );
 	void DrawLine( int x0, int y0, int x1, int y1 );
 	void DrawOutlinedCircle( int x, int y, int radius, int segments );
-	//void DrawColoredCircle( int x, int y, int radius, int r, int g, int b, int a );
 
 	void SetTextColor( int r, int g, int b, int a );
 	void SetTextPos( int x, int y );
@@ -450,10 +460,10 @@ public:
 
 	void CreateFont( const char *customName, const char *windowsFontName, int tall, int weight, int blur, int scanlines, int flags, int yresMin, int yresMax, bool proportional );
 	bool AddCustomFontFile( const char *fontFileName );
+
 	int GetTextureID( char const *filename );
 	int ValidateTexture( const char *filename, bool hardwareFilter, bool forceReload, bool procedural );
 	void SetTextureFile( int id, const char *filename, bool hardwareFilter );
-	//int ValidateMaterial( const char *materialName, const char *textureGroupName );
 	int GetTextureWide( int id );
 	int GetTextureTall( int id );
 	void SetTexture( int id );
@@ -843,7 +853,34 @@ void CScriptSurface::SetTextureFile( int id, const char *filename, bool hardware
 	}
 #endif
 }
+#if 0
+void CScriptSurface::SetTextureMaterial( int id, HSCRIPT hMaterial )
+{
+	IMaterial *pMaterial = (IMaterial*)HScriptToClass< IScriptMaterial >( hMaterial );
+	if ( !IsValid( pMaterial ) )
+		return;
 
+	if ( g_ScriptTextureIDs.HasElement(id) )
+	{
+		Assert( surface()->IsTextureIDValid(id) );
+		MatSystemSurface()->DrawSetTextureMaterial( id, pMaterial );
+
+		DebugMsg( "Set texture [%i]%s\n", id, pMaterial->GetName() );
+	}
+
+#ifdef _DEBUG
+	if ( !g_ScriptTextureIDs.HasElement(id) && surface()->IsTextureIDValid(id) )
+	{
+		DebugWarning( "Tried to set non-script created texture! [%i]\n", id );
+	}
+
+	if ( !surface()->IsTextureIDValid(id) )
+	{
+		DebugWarning( "Tried to set invalid texture id! [%i]\n", id );
+	}
+#endif
+}
+#endif
 int CScriptSurface::GetTextureWide( int id )
 {
 	int w, t;
@@ -1306,7 +1343,7 @@ public:
 
 		g_ScriptPanels.AddToTail( this );
 
-		// Script specified engine root panel.
+		// Script specified root panel - a cheap alternative to registering uneditable panel instances.
 		// Match the values to vscript_vgui.nut.
 		//
 		// This parameter is hidden in script, and is defined by the return value of dummy functions.
@@ -1324,6 +1361,14 @@ public:
 			case 2:
 				vparent = VGUI_GetScriptRootPanel( PANEL_CLIENTDLL );
 				break;
+#if ALLOW_SCRIPT_HUD_VIEWPORT_ROOT_PANEL
+			// Hud viewport
+			case 10:
+				Assert( g_pClientMode && g_pClientMode->GetViewport() );
+				vparent = g_pClientMode->GetViewport()->GetVPanel();
+				break;
+#endif
+			default: UNREACHABLE(); // Invalid parent panel
 		}
 
 		_base->SetParent( vparent );
@@ -1355,7 +1400,7 @@ public:
 	{
 		ivgui()->AddTickSignal( this->GetVPanel(), i );
 	}
-#if VGUI_SIGNAL_INTERFACE
+#if SCRIPT_VGUI_SIGNAL_INTERFACE
 	void AddActionSignalTarget( HSCRIPT messageTarget )
 	{
 		IScriptVGUIObject *obj = ToScriptVGUIObj( messageTarget );
@@ -1386,15 +1431,16 @@ public:
 
 #ifdef _DEBUG
 		// Is my parent one of the root panels?
-		bool b = false;
+		bool bRootParent = false;
 #if SCRIPT_ENGINE_ROOT_PANELS
-		if ( parent == g_pScriptRootPanel->GetVPanel() ||
-#if ALLOW_SCRIPT_GAMEUI_ROOT_PANEL
-			(g_pScriptGameUIDLLPanel && parent == g_pScriptGameUIDLLPanel->GetVPanel()) ||
-#endif
-			(g_pScriptClientDLLPanel && parent == g_pScriptClientDLLPanel->GetVPanel()) )
+		if ( ( parent == g_pScriptRootPanel->GetVPanel() )
+	#if ALLOW_SCRIPT_GAMEUI_ROOT_PANEL
+			|| ( g_pScriptGameUIDLLPanel && parent == g_pScriptGameUIDLLPanel->GetVPanel() )
+	#endif
+			|| ( g_pScriptClientDLLPanel && parent == g_pScriptClientDLLPanel->GetVPanel() )
+		)
 		{
-			b = true;
+			bRootParent = true;
 		}
 		else
 #endif
@@ -1402,13 +1448,16 @@ public:
 		{
 			if ( parent == enginevgui->GetPanel( (VGuiPanel_t)i ) )
 			{
-				b = true;
+				bRootParent = true;
 				break;
 			}
 		}
-
+#if ALLOW_SCRIPT_HUD_VIEWPORT_ROOT_PANEL
+		if ( g_pClientMode && g_pClientMode->GetViewport() && ( parent == g_pClientMode->GetViewport()->GetVPanel() ) )
+			bRootParent = true;
+#endif
 		// My parent wasn't registered.
-		AssertMsg1( b, "'%s'", ipanel()->GetName(parent) );
+		AssertMsg1( bRootParent, "'%s'", ipanel()->GetName(parent) );
 #endif
 
 		return NULL;
@@ -1447,8 +1496,7 @@ public:
 			{
 				g_pScriptVM->ArrayAppend( arr, obj->GetScriptInstance() );
 			}
-			// UNDONE: Register C++ created children of script created panels.
-			// It is safe to do so because their lifetime depends on their script parents.
+			// Beware of dangling pointers if C++ created children are to be registered
 		}
 	}
 
@@ -1917,15 +1965,11 @@ public:
 CLASS_HELPER_INTERFACE( Button, Label )
 {
 public:
-	// NOTE: This is used if DoClick() callback is not implemented in CScript_Button.
-	// This changes where and how button command is processed -
-	// whether in the button { DoClick() } or in an external panel { OnCommand(cmd) }.
-	// It is fine to always use DoClick() instead of vgui messages
-	// because of the dynamic nature of script closures.
-#if VGUI_SIGNAL_INTERFACE
+#if SCRIPT_VGUI_SIGNAL_INTERFACE
+	// Sets the command message to send to the action signal target when the button is pressed
 	void SetCommand( const char *command )
 	{
-		if ( !V_strncmp( command, "url ", 4 ) )
+		if ( !V_strnicmp( command, "url ", 4 ) )
 		{
 			__base()->SetCommand( (KeyValues*)NULL );
 
@@ -1970,12 +2014,7 @@ public:
 	{
 		__base()->ForceDepressed(state);
 	}
-#if 0
-	void SetBlink( bool state )
-	{
-		__base()->SetBlink(state);
-	}
-#endif
+
 	void SetMouseClickEnabled( int code, bool state )
 	{
 		__base()->SetMouseClickEnabled( (MouseCode)code, state );
@@ -2005,12 +2044,7 @@ public:
 	{
 		__base()->SetDepressedColor( Color(fr, fg, fb, fa), Color(br, bg, bb, ba) );
 	}
-#if 0
-	void SetBlinkColor( int r, int g, int b, int a )
-	{
-		__base()->SetBlinkColor( Color(r, g, b, a) );
-	}
-#endif
+
 	void SetArmedSound( const char *sound )
 	{
 		__base()->SetArmedSound( sound );
@@ -2400,7 +2434,7 @@ public:
 #endif
 //--------------------------------------------------------------
 //--------------------------------------------------------------
-#if 0
+#if VGUI_TGA_IMAGE_PANEL
 CLASS_HELPER_INTERFACE( TGAImagePanel, Panel )
 {
 public:
@@ -2437,10 +2471,12 @@ public:
 //==============================================================
 
 
-#define SetHScript( var, val ) \
-	if ( var && g_pScriptVM ) \
-		g_pScriptVM->ReleaseScript( var ); \
+static inline void SetHScript( HSCRIPT &var, HSCRIPT val )
+{
+	if ( var && g_pScriptVM )
+		g_pScriptVM->ReleaseScript( var );
 	var = val;
+}
 
 #define CheckCallback(s)\
 	if ( FStrEq( cb, #s ) )\
@@ -2479,6 +2515,9 @@ private:
 	HSCRIPT m_hfnOnKeyCodePressed;
 	HSCRIPT m_hfnOnKeyCodeReleased;
 	HSCRIPT m_hfnOnKeyCodeTyped;
+#if SCRIPT_VGUI_SIGNAL_INTERFACE
+	HSCRIPT m_hfnOnCommand;
+#endif
 
 public:
 	CScript_Panel( Panel *parent, const char *name ) :
@@ -2504,6 +2543,10 @@ public:
 		m_hfnOnKeyCodePressed(NULL),
 		m_hfnOnKeyCodeReleased(NULL),
 		m_hfnOnKeyCodeTyped(NULL)
+#if SCRIPT_VGUI_SIGNAL_INTERFACE
+		,
+		m_hfnOnCommand(NULL)
+#endif
 	{}
 
 	void Shutdown()
@@ -2530,6 +2573,9 @@ public:
 		SetHScript( m_hfnOnKeyCodePressed, NULL );
 		SetHScript( m_hfnOnKeyCodeReleased, NULL );
 		SetHScript( m_hfnOnKeyCodeTyped, NULL );
+#if SCRIPT_VGUI_SIGNAL_INTERFACE
+		SetHScript( m_hfnOnCommand, NULL );
+#endif
 	}
 
 public:
@@ -2580,7 +2626,7 @@ public:
 			g_pScriptVM->ExecuteFunction( m_hfnOnScreenSizeChanged, args, 2, NULL, NULL, true );
 		}
 	}
-#if VGUI_SIGNAL_INTERFACE
+#if SCRIPT_VGUI_SIGNAL_INTERFACE
 	void OnCommand( const char *command )
 	{
 		if ( m_hfnOnCommand )
@@ -2705,6 +2751,7 @@ public:
 
 		BaseClass::OnKeyCodeTyped( code );
 	}
+
 public:
 	void SetCallback( const char* cb, HSCRIPT fn )
 	{
@@ -2728,6 +2775,9 @@ public:
 		CheckCallback( OnKeyCodePressed );
 		CheckCallback( OnKeyCodeReleased );
 		CheckCallback( OnKeyCodeTyped );
+#if SCRIPT_VGUI_SIGNAL_INTERFACE
+		CheckCallback( OnCommand );
+#endif
 
 		g_pScriptVM->RaiseException("invalid callback");
 	}
@@ -2760,6 +2810,9 @@ private:
 	HSCRIPT m_hfnOnKeyCodePressed;
 	HSCRIPT m_hfnOnKeyCodeReleased;
 	HSCRIPT m_hfnOnKeyCodeTyped;
+#if SCRIPT_VGUI_SIGNAL_INTERFACE
+	HSCRIPT m_hfnOnCommand;
+#endif
 
 public:
 	CScript_Frame( Panel *parent, const char *name ) :
@@ -2786,6 +2839,10 @@ public:
 		m_hfnOnKeyCodePressed(NULL),
 		m_hfnOnKeyCodeReleased(NULL),
 		m_hfnOnKeyCodeTyped(NULL)
+#if SCRIPT_VGUI_SIGNAL_INTERFACE
+		,
+		m_hfnOnCommand(NULL)
+#endif
 	{
 		SetFadeEffectDisableOverride( true );
 	}
@@ -2809,6 +2866,9 @@ public:
 		SetHScript( m_hfnOnKeyCodePressed, NULL );
 		SetHScript( m_hfnOnKeyCodeReleased, NULL );
 		SetHScript( m_hfnOnKeyCodeTyped, NULL );
+#if SCRIPT_VGUI_SIGNAL_INTERFACE
+		SetHScript( m_hfnOnCommand, NULL );
+#endif
 	}
 
 public:
@@ -2854,7 +2914,22 @@ public:
 			g_pScriptVM->ExecuteFunction( m_hfnOnScreenSizeChanged, args, 2, NULL, NULL, true );
 		}
 	}
+#if SCRIPT_VGUI_SIGNAL_INTERFACE
+	void OnCommand( const char *command )
+	{
+		if ( m_hfnOnCommand )
+		{
+			ScriptVariant_t ret, arg = command;
+			g_pScriptVM->ExecuteFunction( m_hfnOnCommand, &arg, 1, &ret, NULL, true );
 
+			// Return true to swallow
+			if ( ret.m_type == FIELD_BOOLEAN && ret.m_bool )
+				return;
+		}
+
+		BaseClass::OnCommand( command );
+	}
+#endif
 	void OnCursorEntered()
 	{
 		if ( m_hfnOnCursorEntered )
@@ -2974,6 +3049,7 @@ public:
 			BaseClass::OnKeyCodeTyped( code );
 		}
 	}
+
 public:
 	void SetCallback( const char* cb, HSCRIPT fn )
 	{
@@ -2996,6 +3072,9 @@ public:
 		CheckCallback( OnKeyCodePressed );
 		CheckCallback( OnKeyCodeReleased );
 		CheckCallback( OnKeyCodeTyped );
+#if SCRIPT_VGUI_SIGNAL_INTERFACE
+		CheckCallback( OnCommand );
+#endif
 
 		g_pScriptVM->RaiseException("invalid callback");
 	}
@@ -3144,7 +3223,7 @@ public:
 #endif
 //--------------------------------------------------------------
 //--------------------------------------------------------------
-#if 0
+#if VGUI_TGA_IMAGE_PANEL
 class CTGAImagePanel : public Panel
 {
 	DECLARE_SCRIPTVGUI_CLASS_EX( CTGAImagePanel, Panel );
@@ -3313,7 +3392,7 @@ END_SCRIPTDESC()
 #endif
 //--------------------------------------------------------------
 //--------------------------------------------------------------
-#if 0
+#if VGUI_TGA_IMAGE_PANEL
 BEGIN_VGUI_HELPER_EX( TGAImagePanel, CTGAImagePanel )
 END_VGUI_HELPER()
 
@@ -3386,6 +3465,9 @@ HSCRIPT CScriptVGUI::CreatePanel( const char* panelClass, HSCRIPT parent, const 
 	Check( TextEntry );
 #if !defined(NO_STEAM)
 	Check( AvatarImage );
+#endif
+#if VGUI_TGA_IMAGE_PANEL
+	Check( TGAImagePanel );
 #endif
 
 	g_pScriptVM->RaiseException("invalid vgui class");

--- a/sp/src/game/client/mapbase/vscript_vgui.cpp
+++ b/sp/src/game/client/mapbase/vscript_vgui.cpp
@@ -143,10 +143,6 @@ CUtlVector< int > g_ScriptTextureIDs;
 CUtlLinkedList< IScriptVGUIObject*, unsigned short > g_ScriptPanels;
 
 
-// Used in hud.cpp to help scripts hide HUD elements
-int g_iVScriptHideHUD = 0;
-
-
 // Boundary is not checked in Surface, keep count manually to sanitise user input.
 static int g_nFontCount = 0;
 
@@ -3407,9 +3403,6 @@ void CScriptVGUI::LevelShutdownPostEntity()
 		surface()->DestroyTextureID( g_ScriptTextureIDs[i] );
 	}
 	g_ScriptTextureIDs.Purge();
-
-	// Reset HUD hidden bits
-	g_iVScriptHideHUD = 0;
 }
 
 void CScriptVGUI::Shutdown()
@@ -3697,29 +3690,6 @@ vgui::HFont GetScriptFont( const char *name, bool proportional )
 	return script_surface.GetFont( name, proportional, NULL );
 }
 
-//-----------------------------------------------------------------------------
-// Control which HUD elements on the screen are hidden.
-//-----------------------------------------------------------------------------
-static int ScriptGetHUDHiddenBits()
-{
-	return g_iVScriptHideHUD;
-}
-
-static void ScriptSetHUDHiddenBits( int iBits )
-{
-	g_iVScriptHideHUD = iBits;
-}
-
-static void ScriptAddHUDHiddenBits( int iBits )
-{
-	g_iVScriptHideHUD |= iBits;
-}
-
-static void ScriptClearHUDHiddenBits( int iBits )
-{
-	g_iVScriptHideHUD &= ~(iBits);
-}
-
 
 void RegisterScriptVGUI()
 {
@@ -3731,11 +3701,6 @@ void RegisterScriptVGUI()
 	ScriptRegisterFunctionNamed( g_pScriptVM, ScriptScreenToWorld, "ScreenToWorld", "Get screen pixel position [0,1] in world space." );
 	ScriptRegisterFunction( g_pScriptVM, ScreenToRay, "Get a ray from screen pixel position to world space." );
 	ScriptRegisterFunctionNamed( g_pScriptVM, ScriptScreenTransform, "ScreenTransform", "Get world position normalised in screen space. Return true if on screen." );
-
-	ScriptRegisterFunctionNamed( g_pScriptVM, ScriptGetHUDHiddenBits, "GetHUDHiddenBits", "Use with 'HIDEHUD_' constants." );
-	ScriptRegisterFunctionNamed( g_pScriptVM, ScriptSetHUDHiddenBits, "SetHUDHiddenBits", "Use with 'HIDEHUD_' constants." );
-	ScriptRegisterFunctionNamed( g_pScriptVM, ScriptAddHUDHiddenBits, "AddHUDHiddenBits", "Use with 'HIDEHUD_' constants." );
-	ScriptRegisterFunctionNamed( g_pScriptVM, ScriptClearHUDHiddenBits, "ClearHUDHiddenBits", "Use with 'HIDEHUD_' constants." );
 
 	g_pScriptVM->Run( g_Script_vgui_init );
 

--- a/sp/src/game/client/mapbase/vscript_vgui.nut
+++ b/sp/src/game/client/mapbase/vscript_vgui.nut
@@ -91,7 +91,7 @@ local _FontTall = {}
 local DoGetFont = ISurface.DoGetFont <- ISurface.GetFont;
 local DoGetFontTall = ISurface.GetFontTall;
 
-ISurface.GetFont <- function( name, proportional = false, sch = "" )
+ISurface.GetFont <- function( name, proportional, sch = "" )
 {
 	if ( sch in _Schemes )
 	{
@@ -101,6 +101,8 @@ ISurface.GetFont <- function( name, proportional = false, sch = "" )
 	}
 	else
 	{
+		if ( typeof sch != "string" )
+			throw "invalid parameter 'scheme'";
 		_Schemes[sch] <- [{}, {}];
 	}
 
@@ -152,6 +154,7 @@ ISurface.GetTextureID <- function( name )
 IVGui.GetRootPanel <- function() { return 1000 }
 //IVGui.GetGameUIRootPanel <- function() { return 1001 }
 IVGui.GetClientDLLRootPanel <- function() { return 1002 }
+//IVGui.GetHudViewportPanel <- function() { return 1010 }
 
 local CreatePanel = IVGui.CreatePanel;
 IVGui.CreatePanel <- function( type, parent, name )
@@ -167,10 +170,6 @@ IVGui.CreatePanel <- function( type, parent, name )
 		{
 			case 1000:
 				root = 0;
-				break;
-
-			case 1001:
-				root = 1;
 				break;
 
 			case 1002:

--- a/sp/src/game/client/viewrender.h
+++ b/sp/src/game/client/viewrender.h
@@ -454,7 +454,7 @@ private:
 #ifdef MAPBASE
 	bool			DrawFakeWorldPortal( ITexture *pRenderTarget, C_FuncFakeWorldPortal *pCameraEnt, const CViewSetup &cameraView, C_BasePlayer *localPlayer, 
 						int x, int y, int width, int height,
-						const CViewSetup &mainView, cplane_t &ourPlane, const Vector &vecPlaneOrigin );
+						const CViewSetup &mainView, const Vector &vecAbsPlaneNormal, const Vector &vecPlaneOrigin );
 #endif
 
 	// Drawing primitives

--- a/sp/src/game/client/viewrender.h
+++ b/sp/src/game/client/viewrender.h
@@ -454,7 +454,7 @@ private:
 #ifdef MAPBASE
 	bool			DrawFakeWorldPortal( ITexture *pRenderTarget, C_FuncFakeWorldPortal *pCameraEnt, const CViewSetup &cameraView, C_BasePlayer *localPlayer, 
 						int x, int y, int width, int height,
-						const CViewSetup &mainView, const Vector &vecAbsPlaneNormal, const Vector &vecPlaneOrigin );
+						const CViewSetup &mainView, const Vector &vecAbsPlaneNormal, float flLocalPlaneDist );
 #endif
 
 	// Drawing primitives

--- a/sp/src/game/shared/mapbase/vscript_consts_shared.cpp
+++ b/sp/src/game/shared/mapbase/vscript_consts_shared.cpp
@@ -604,25 +604,6 @@ void RegisterSharedScriptConstants()
 	ScriptRegisterConstant( g_pScriptVM, D_NU, "Denotes a 'Neutral' relationship. Used by NPCs and players for relationship disposition." );
 #endif
 
-#ifdef CLIENT_DLL
-	// 
-	// HUD
-	// 
-	ScriptRegisterConstant( g_pScriptVM, HIDEHUD_WEAPONSELECTION, "Hide ammo count & weapon selection" );
-	ScriptRegisterConstant( g_pScriptVM, HIDEHUD_FLASHLIGHT, "" );
-	ScriptRegisterConstant( g_pScriptVM, HIDEHUD_ALL, "" );
-	ScriptRegisterConstant( g_pScriptVM, HIDEHUD_HEALTH, "Hide health & armor / suit battery" );
-	ScriptRegisterConstant( g_pScriptVM, HIDEHUD_PLAYERDEAD, "Hide when local player's dead" );
-	ScriptRegisterConstant( g_pScriptVM, HIDEHUD_NEEDSUIT, "Hide when the local player doesn't have the HEV suit" );
-	ScriptRegisterConstant( g_pScriptVM, HIDEHUD_MISCSTATUS, "Hide miscellaneous status elements (trains, pickup history, death notices, etc)" );
-	ScriptRegisterConstant( g_pScriptVM, HIDEHUD_CHAT, "Hide all communication elements (saytext, voice icon, etc)" );
-	ScriptRegisterConstant( g_pScriptVM, HIDEHUD_CROSSHAIR, "Hide crosshairs" );
-	ScriptRegisterConstant( g_pScriptVM, HIDEHUD_VEHICLE_CROSSHAIR, "Hide vehicle crosshair" );
-	ScriptRegisterConstant( g_pScriptVM, HIDEHUD_INVEHICLE, "" );
-	ScriptRegisterConstant( g_pScriptVM, HIDEHUD_BONUS_PROGRESS, "Hide bonus progress display (for bonus map challenges)" );
-	ScriptRegisterConstant( g_pScriptVM, HIDEHUD_BITCOUNT, "" );
-#endif
-
 	// 
 	// Misc. General
 	// 

--- a/sp/src/game/shared/mapbase/vscript_singletons.cpp
+++ b/sp/src/game/shared/mapbase/vscript_singletons.cpp
@@ -1277,9 +1277,11 @@ CNetMsgScriptHelper *g_ScriptNetMsg = &scriptnetmsg;
 
 #ifdef _DEBUG
 #ifdef GAME_DLL
-#define DebugNetMsg( l, ... ) do { extern ConVar developer; if (developer.GetInt() >= l) ConColorMsg( Color(100, 225, 255, 255), __VA_ARGS__ ); } while (0);
+ConVar script_net_debug("script_net_debug", "0");
+#define DebugNetMsg( l, ... ) do { if (script_net_debug.GetInt() >= l) ConColorMsg( Color(100, 225, 255, 255), __VA_ARGS__ ); } while (0);
 #else
-#define DebugNetMsg( l, ... ) do { extern ConVar developer; if (developer.GetInt() >= l) ConColorMsg( Color(100, 225, 175, 255), __VA_ARGS__ ); } while (0);
+ConVar script_net_debug("script_net_debug_client", "0");
+#define DebugNetMsg( l, ... ) do { if (script_net_debug.GetInt() >= l) ConColorMsg( Color(100, 225, 175, 255), __VA_ARGS__ ); } while (0);
 #endif
 #define DebugWarning(...) Warning( __VA_ARGS__ )
 #else
@@ -1428,7 +1430,7 @@ void CNetMsgScriptHelper::ReceiveMessage( bf_read &msg )
 	m_MsgIn.StartReading( msg.m_pData, msg.m_nDataBytes );
 #endif
 
-	DebugNetMsg( 2, DLL_LOC_STR " %s()", __FUNCTION__ );
+	DebugNetMsg( 2, DLL_LOC_STR " %s()\n", __FUNCTION__ );
 
 	// Don't do anything if there's no VM here. This can happen if a message from the server goes to a VM-less client, or vice versa.
 	if ( !g_pScriptVM )

--- a/sp/src/vscript/vscript_bindings_base.cpp
+++ b/sp/src/vscript/vscript_bindings_base.cpp
@@ -539,11 +539,12 @@ void RegisterBaseBindings( IScriptVM *pVM )
 	ScriptRegisterConstant( pVM, FCVAR_SPONLY, "If this convar flag is set, it can't be changed by clients connected to a multiplayer server." );
 	ScriptRegisterConstant( pVM, FCVAR_ARCHIVE, "If this convar flag is set, its value will be saved when the game is exited." );
 	ScriptRegisterConstant( pVM, FCVAR_NOTIFY, "If this convar flag is set, it will notify players when it is changed." );
+	ScriptRegisterConstant( pVM, FCVAR_CHEAT, "Only useable in singleplayer / debug / multiplayer & sv_cheats" );
 	ScriptRegisterConstant( pVM, FCVAR_USERINFO, "If this convar flag is set, it will be marked as info which plays a part in how the server identifies a client." );
 	ScriptRegisterConstant( pVM, FCVAR_PRINTABLEONLY, "If this convar flag is set, it cannot contain unprintable characters. Used for player name cvars, etc." );
 	ScriptRegisterConstant( pVM, FCVAR_UNLOGGED, "If this convar flag is set, it will not log its changes if a log is being created." );
 	ScriptRegisterConstant( pVM, FCVAR_NEVER_AS_STRING, "If this convar flag is set, it will never be printed as a string." );
-	ScriptRegisterConstant( pVM, FCVAR_REPLICATED, "If this convar flag is set, it will enforce a serverside value on any clientside counterparts. (also known as FCAR_SERVER)" );
+	ScriptRegisterConstant( pVM, FCVAR_REPLICATED, "If this convar flag is set, it will enforce a serverside value on any clientside counterparts. (also known as FCVAR_SERVER)" );
 	ScriptRegisterConstant( pVM, FCVAR_DEMO, "If this convar flag is set, it will be recorded when starting a demo file." );
 	ScriptRegisterConstant( pVM, FCVAR_DONTRECORD, "If this convar flag is set, it will NOT be recorded when starting a demo file." );
 	ScriptRegisterConstant( pVM, FCVAR_RELOAD_MATERIALS, "If this convar flag is set, it will force a material reload when it changes." );

--- a/sp/src/vscript/vscript_squirrel.cpp
+++ b/sp/src/vscript/vscript_squirrel.cpp
@@ -2970,6 +2970,14 @@ int SquirrelVM::GetKeyValue(HSCRIPT hScope, int nIterator, ScriptVariant_t* pKey
 
 bool SquirrelVM::GetValue(HSCRIPT hScope, const char* pszKey, ScriptVariant_t* pValue)
 {
+#ifdef _DEBUG
+	AssertMsg( pszKey, "FATAL: cannot get NULL" );
+
+	// Don't crash on debug
+	if ( !pszKey )
+		return GetValue( hScope, ScriptVariant_t(0), pValue );
+#endif
+
 	SquirrelSafeCheck safeCheck(vm_);
 
 	Assert(pValue);


### PR DESCRIPTION
I think this might be the best way to handle HUD visibility; this wasn't part of the main PR because I just hadn't thought about this issue for many months.

Global hidehud bits set the visibility of multiple elements at once, which is not ideal at all. For example with the existing custom HUDs (CSGO and TF2) using the previous method, there is no item pickup icons, no zoom or damage indicators.

This allows individual management of every HUD element listed below
```
CAchievementNotificationPanel
CHUDAutoAim
CHUDQuickInfo
CHudAmmo
CHudAnimationInfo
CHudBattery
CHudChat
CHudCloseCaption
CHudCommentary
CHudCredits
CHudCrosshair
CHudDamageIndicator
CHudDeathNotice
CHudFilmDemo
CHudFlashlight
CHudGeiger
CHudHDRDemo
CHudHealth
CHudHintDisplay
CHudHintKeyDisplay
CHudHistoryResource
CHudLocator
CHudMenu
CHudMessage
CHudPoisonDamageIndicator
CHudPosture
CHudSecondaryAmmo
CHudSquadStatus
CHudSuitPower
CHudTrain
CHudVehicle
CHudWeapon
CHudWeaponSelection
CHudZoom
CMapOverview
CPDumpPanel
```

Two things I'm uncertain about,

the namespace of this function:
```cs
vgui.SetHudElementVisible( "CHudCrosshair", false );

SetHudElementVisible( "CHudCrosshair", false );
```

and the capitalisation of 'hud':
```cs
SetHudElementVisible( "CHudCrosshair", false );

SetHUDElementVisible( "CHudCrosshair", false );
```

---

#### PR Checklist
- [x] **My PR follows all guidelines in the CONTRIBUTING.md file**
- [x] My PR targets a `develop` branch OR targets another branch with a specific goal in mind
