### PR TITLE
Extend point_bugbait functionality

### DIFF
--- a/sp/src/game/server/hl2/grenade_bugbait.cpp
+++ b/sp/src/game/server/hl2/grenade_bugbait.cpp
@@ -63,6 +63,9 @@ BEGIN_DATADESC( CBugBaitSensor )
 #ifdef MAPBASE
 	DEFINE_INPUTFUNC( FIELD_VOID, "EnableRadius", InputEnableRadius ),
 	DEFINE_INPUTFUNC( FIELD_VOID, "DisableRadius", InputDisableRadius ),
+	DEFINE_INPUTFUNC( FIELD_INTEGER, "SetRadius", InputSetRadius ),
+	DEFINE_INPUTFUNC( FIELD_VECTOR, "SetMins", InputSetMins ),
+	DEFINE_INPUTFUNC( FIELD_VECTOR, "SetMaxs", InputSetMaxs ),
 #endif
 
 	// Function Pointers

--- a/sp/src/game/server/hl2/grenade_bugbait.cpp
+++ b/sp/src/game/server/hl2/grenade_bugbait.cpp
@@ -50,9 +50,20 @@ BEGIN_DATADESC( CBugBaitSensor )
 	DEFINE_KEYFIELD( m_bEnabled, FIELD_BOOLEAN, "Enabled" ),
 	DEFINE_KEYFIELD( m_flRadius, FIELD_FLOAT, "radius" ),
 
+#ifdef MAPBASE
+	DEFINE_KEYFIELD( m_bUseRadius, FIELD_BOOLEAN, "useradius" ),
+	DEFINE_KEYFIELD( m_vecMins, FIELD_VECTOR, "bmins" ),
+	DEFINE_KEYFIELD( m_vecMaxs, FIELD_VECTOR, "bmaxs" ),
+#endif
+
 	DEFINE_INPUTFUNC( FIELD_VOID, "Enable", InputEnable ),
 	DEFINE_INPUTFUNC( FIELD_VOID, "Disable", InputDisable ),
 	DEFINE_INPUTFUNC( FIELD_VOID, "Toggle", InputToggle ),
+
+#ifdef MAPBASE
+	DEFINE_INPUTFUNC( FIELD_VOID, "EnableRadius", InputEnableRadius ),
+	DEFINE_INPUTFUNC( FIELD_VOID, "DisableRadius", InputDisableRadius ),
+#endif
 
 	// Function Pointers
 	DEFINE_OUTPUT( m_OnBaited, "OnBaited" ),
@@ -267,18 +278,42 @@ bool CGrenadeBugBait::ActivateBugbaitTargets( CBaseEntity *pOwner, Vector vecOri
 			continue;
 
 		//Make sure we're within range of the sensor
-		if ( pSensor->GetRadius() > ( pSensor->GetAbsOrigin() - vecOrigin ).Length() )
-		{
-			//Tell the sensor it's been hit
-			if ( pSensor->Baited( pOwner ) )
+#ifdef MAPBASE
+		if ( pSensor->UsesRadius() ){
+#endif
+			if ( pSensor->GetRadius() > (pSensor->GetAbsOrigin() - vecOrigin).Length() )
 			{
-				//If we're suppressing the call to antlions, then don't make a bugbait sound
-				if ( pSensor->SuppressCall() )
+				//Tell the sensor it's been hit
+				if ( pSensor->Baited( pOwner ) )
 				{
-					suppressCall = true;
+					//If we're suppressing the call to antlions, then don't make a bugbait sound
+					if ( pSensor->SuppressCall() )
+					{
+						suppressCall = true;
+					}
+				}
+			}
+#ifdef MAPBASE
+		}
+		else{
+			Vector vMins = pSensor->GetAbsMins();
+			Vector vMaxs = pSensor->GetAbsMaxs();
+			bool inBox = ((vecOrigin.x >= vMins.x && vecOrigin.x <= vMaxs.x) &&
+				(vecOrigin.y >= vMins.y && vecOrigin.y <= vMaxs.y) &&
+				(vecOrigin.z >= vMins.z && vecOrigin.z <= vMaxs.z));
+			if ( inBox ){
+				//Tell the sensor it's been hit
+				if ( pSensor->Baited( pOwner ) )
+				{
+					//If we're suppressing the call to antlions, then don't make a bugbait sound
+					if ( pSensor->SuppressCall() )
+					{
+						suppressCall = true;
+					}
 				}
 			}
 		}
+#endif
 	}
 
 	return suppressCall;

--- a/sp/src/game/server/hl2/grenade_bugbait.cpp
+++ b/sp/src/game/server/hl2/grenade_bugbait.cpp
@@ -35,6 +35,9 @@ CBugBaitSensor* GetBugBaitSensorList()
 CBugBaitSensor::CBugBaitSensor( void )
 {
 	g_BugBaitSensorList.Insert( this );
+#ifdef MAPBASE
+	m_bUseRadius = true;
+#endif
 }
 
 CBugBaitSensor::~CBugBaitSensor( void )

--- a/sp/src/game/server/hl2/grenade_bugbait.h
+++ b/sp/src/game/server/hl2/grenade_bugbait.h
@@ -71,6 +71,18 @@ public:
 	void InputDisableRadius( inputdata_t &data ){
 		m_bUseRadius = false;
 	}
+
+	void InputSetRadius( inputdata_t &data ){
+		m_flRadius = data.value.Int();
+	}
+
+	void InputSetMins( inputdata_t &data ){
+		data.value.Vector3D( m_vecMins );
+	}
+
+	void InputSetMaxs( inputdata_t &data ){
+		data.value.Vector3D( m_vecMaxs );
+	}
 #endif
 
 	bool SuppressCall( void )

--- a/sp/src/game/server/hl2/grenade_bugbait.h
+++ b/sp/src/game/server/hl2/grenade_bugbait.h
@@ -63,6 +63,16 @@ public:
 		m_bEnabled = !m_bEnabled;
 	}
 
+#ifdef MAPBASE
+	void InputEnableRadius( inputdata_t &data ){
+		m_bUseRadius = true;
+	}
+
+	void InputDisableRadius( inputdata_t &data ){
+		m_bUseRadius = false;
+	}
+#endif
+
 	bool SuppressCall( void )
 	{
 		return ( HasSpawnFlags( SF_BUGBAIT_SUPPRESS_CALL ) );
@@ -91,10 +101,28 @@ public:
 		return !m_bEnabled;
 	}
 
+#ifdef MAPBASE
+	bool UsesRadius( void ) const {
+		return m_bUseRadius;
+	}
+
+	Vector GetAbsMins( void ) const {
+		return GetAbsOrigin() + m_vecMins;
+	}
+	Vector GetAbsMaxs( void ) const {
+		return GetAbsOrigin() + m_vecMaxs;
+	}
+#endif
+
 protected:
 
 	float			m_flRadius;
 	bool			m_bEnabled;
+#ifdef MAPBASE
+	bool			m_bUseRadius;
+	Vector			m_vecMins;
+	Vector			m_vecMaxs;
+#endif
 	COutputEvent	m_OnBaited;
 
 public:


### PR DESCRIPTION
This PR adds a SetRadius input to `point_bugbait`, as well as a new functionality that allows `point_bugbait` to use mins and maxs. This is a super-niche situation where spheres don't work well but a big box does. It annoyed me enough for me to add such a functionality.

Possible uses for this:
- Throwing bugbait into areas (like big targets, or hallways) where a sphere would allow the output to be triggered erroneously (e.g. on the other side of a brush), but smaller spheres miss a small area (and/or take up many entities)
- Squeezing bugbait while standing on a platform or set of platforms
- Dynamic `point_bugbait` zones that change depending on gamestate.

One could theoretically use a `trigger_multiple` with a filter set to `npc_grenade_bugbait`, but this only covers thrown bugbait and would need to conform to the geometry very tightly, making it somewhat infeasible.

---

#### Does this PR close any issues?
None.

#### PR Checklist
- [x] **My PR follows all guidelines in the CONTRIBUTING.md file**
- [x] My PR targets a `develop` branch OR targets another branch with a specific goal in mind

---

FGD entry:

```
@PointClass base(Targetname, Parentname) size(16 16 16) wirebox(bmins, bmaxs) sphere(radius) color( 255 255 0 ) = point_bugbait : "Bugbait sensor point"
[

	Enabled(choices) : "Start Enabled" : 1 =
	[
		0 : "No"
		1 : "Yes"
	]

	spawnflags(Flags) =
	[
		1: "[1] Do not call antlions to position" : 0
		2: "[2] Don't activate on thrown bugbait splashes" : 0
		4: "[4] Don't activate on squeezed bugbait" : 0
	]
	
	useradius(choices) : "Use Radius Keyvalue" : 1 : "If disabled, use mins and maxs." =
	[
		0 : "No"
		1 : "Yes"
	]
	
	radius(integer) : "Sensor Radius" : 512
	
	bmins(vector) : "Mins" : "0 0 0"
	bmaxs(vector) : "Maxs" : "0 0 0"

	// Inputs
	input	Enable(void) : "Enable the sensor."
	input	Disable(void): "Disable the sensor."
	input	Toggle(void) : "Toggle the sensor."
	input 	EnableRadius(void) : "Use the Radius keyvalue of the sensor."
	input	DisableRadius(void) : "Use the mins/maxs keyvalues of the sensor."
	input	SetRadius(integer) : "Sets the radius of the sensor."
	input	SetMins(vector) : "Sets the mins of the sensor."
	input	SetMaxs(vector) : "Sets the maxs of the sensor."

	// Outputs
	output OnBaited(void) : "Fires when bugbait lands within a radius of the sensor"
]
```