### PR TITLE
Fix $bumpmap2 using wrong sampler in custom WorldVertexTransition shader

### DIFF
--- a/sp/src/materialsystem/stdshaders/lightmappedgeneric_dx9_helper.cpp
+++ b/sp/src/materialsystem/stdshaders/lightmappedgeneric_dx9_helper.cpp
@@ -447,7 +447,7 @@ void DrawLightmappedGenericFlashlight_DX9_Internal( CBaseVSShader *pShader, IMat
 		if( bBump2 )
 		{
 			// Normalmap2 sampler
-			pShaderShadow->EnableTexture( SHADER_SAMPLER6, true );
+			pShaderShadow->EnableTexture( SHADER_SAMPLER5, true );
 		}
 		if( bDetail )
 		{
@@ -648,7 +648,7 @@ void DrawLightmappedGenericFlashlight_DX9_Internal( CBaseVSShader *pShader, IMat
 
 		if( bBump2 )
 		{
-			pShader->BindTexture( SHADER_SAMPLER6, vars.m_nBumpmap2Var, vars.m_nBumpmap2Frame );
+			pShader->BindTexture( SHADER_SAMPLER5, vars.m_nBumpmap2Var, vars.m_nBumpmap2Frame );
 		}
 
 		if( nPhongMaskVariant == PHONGMASK_STANDALONE )


### PR DESCRIPTION
Fixes https://github.com/mapbase-source/source-sdk-2013/issues/256