### PR TITLE
weapon_pistol upwards view kick cvar

### DIFF
--- a/sp/src/game/server/hl2/weapon_pistol.cpp
+++ b/sp/src/game/server/hl2/weapon_pistol.cpp
@@ -526,6 +526,10 @@ bool CWeaponPistol::Reload( void )
 	return fRet;
 }
 
+#ifdef MAPBASE
+ConVar weapon_pistol_upwards_viewkick( "weapon_pistol_upwards_viewkick", "0" );
+#endif
+
 //-----------------------------------------------------------------------------
 // Purpose: 
 //-----------------------------------------------------------------------------
@@ -538,7 +542,11 @@ void CWeaponPistol::AddViewKick( void )
 
 	QAngle	viewPunch;
 
+#ifdef MAPBASE
+	viewPunch.x = weapon_pistol_upwards_viewkick.GetBool() ? random->RandomFloat( -0.5f, -0.25f ) : random->RandomFloat( 0.25f, 0.5f );
+#else
 	viewPunch.x = random->RandomFloat( 0.25f, 0.5f );
+#endif
 	viewPunch.y = random->RandomFloat( -.6f, .6f );
 	viewPunch.z = 0.0f;
 


### PR DESCRIPTION
This adds a cvar which changes `weapon_pistol`'s view kick code to tilt the screen upwards. Normally, the pistol's view kick tilts the screen downwards, which is unlike any other HL2 weapon and is most likely a bug. However, since this subtly changes the feeling of using the pistol, it has been tied to a cvar that is disabled by default.

The downwards view kick is a much more noticeable problem in mods which allow shooting while zoomed, and the justification behind this cvar is that it can be easily enabled in those cases.

---

<!-- Replace [ ] with [x] for each item your PR satisfies -->
#### PR Checklist
- [x] **My PR follows all guidelines in the CONTRIBUTING.md file**
- [x] My PR targets a `develop` branch OR targets another branch with a specific goal in mind
