### PR TITLE
Implement "OnPhysGunPull" output in CPhysicsProp

### DIFF
--- a/sp/src/game/server/hl2/weapon_physcannon.cpp
+++ b/sp/src/game/server/hl2/weapon_physcannon.cpp
@@ -2723,6 +2723,11 @@ CWeaponPhysCannon::FindObjectResult_t CWeaponPhysCannon::FindObject( void )
 		pullDir *= (mass + 0.5) * (1/50.0f);
 	}
 
+	CPhysicsProp* pProp = dynamic_cast<CPhysicsProp*>(pObj);
+	if (pProp) {
+		pProp->OnPhysGunPull( pOwner, pullDir );
+	}
+
 	// Nudge it towards us
 	pObj->ApplyForceCenter( pullDir );
 	return OBJECT_NOT_FOUND;

--- a/sp/src/game/server/props.cpp
+++ b/sp/src/game/server/props.cpp
@@ -3021,6 +3021,7 @@ BEGIN_DATADESC( CPhysicsProp )
 	DEFINE_OUTPUT( m_MotionEnabled, "OnMotionEnabled" ),
 	DEFINE_OUTPUT( m_OnPhysGunPickup, "OnPhysGunPickup" ),
 	DEFINE_OUTPUT( m_OnPhysGunOnlyPickup, "OnPhysGunOnlyPickup" ),
+	DEFINE_OUTPUT( m_OnPhysGunPull, "OnPhysGunPull" ),
 	DEFINE_OUTPUT( m_OnPhysGunPunt, "OnPhysGunPunt" ),
 	DEFINE_OUTPUT( m_OnPhysGunDrop, "OnPhysGunDrop" ),
 	DEFINE_OUTPUT( m_OnPlayerUse, "OnPlayerUse" ),
@@ -3389,6 +3390,13 @@ void CPhysicsProp::OnPhysGunPickup( CBasePlayer *pPhysGunUser, PhysGunPickup_t r
 	}
 
 	CheckRemoveRagdolls();
+}
+
+//-----------------------------------------------------------------------------
+// Purpose: 
+//-----------------------------------------------------------------------------
+void CPhysicsProp::OnPhysGunPull( CBasePlayer* pPhysGunUser, Vector pullDir ) {
+	m_OnPhysGunPull.FireOutput(pPhysGunUser, this);
 }
 
 //-----------------------------------------------------------------------------

--- a/sp/src/game/server/props.h
+++ b/sp/src/game/server/props.h
@@ -413,6 +413,7 @@ public:
 	void EnableMotion( void );
 	bool CanBePickedUpByPhyscannon( void );
 	void OnPhysGunPickup( CBasePlayer *pPhysGunUser, PhysGunPickup_t reason );
+	void OnPhysGunPull( CBasePlayer *pPhysGunUser, Vector pullDir );
 	void OnPhysGunDrop( CBasePlayer *pPhysGunUser, PhysGunDrop_t reason );
 
 	bool GetPropDataAngles( const char *pKeyName, QAngle &vecAngles );
@@ -446,6 +447,7 @@ private:
 	COutputEvent m_OnPhysGunPickup;
 	COutputEvent m_OnPhysGunPunt;
 	COutputEvent m_OnPhysGunOnlyPickup;
+	COutputEvent m_OnPhysGunPull;
 	COutputEvent m_OnPhysGunDrop;
 	COutputEvent m_OnPlayerUse;
 	COutputEvent m_OnPlayerPickup;


### PR DESCRIPTION
The new output allows mappers to fire events when a physics prop is pulled by the gravity gun (secondary fire from afar).

---

<!-- Replace [ ] with [x] for each item your PR satisfies -->
#### PR Checklist
- [x] **My PR follows all guidelines in the CONTRIBUTING.md file**
- [x] My PR targets a `develop` branch OR targets another branch with a specific goal in mind
