### PR TITLE
NPC dynamic interaction improvements and fixes

### DIFF
--- a/sp/src/game/server/ai_activity.cpp
+++ b/sp/src/game/server/ai_activity.cpp
@@ -76,6 +76,23 @@ int CAI_BaseNPC::GetActivityID(const char* actName)
 	return m_pActivitySR->GetStringID(actName);
 }
 
+#ifdef MAPBASE
+//-----------------------------------------------------------------------------
+// Purpose: Gets an activity ID or registers a new private one if it doesn't exist
+//-----------------------------------------------------------------------------
+int CAI_BaseNPC::GetOrRegisterActivity( const char *actName )
+{
+	int actID = GetActivityID( actName );
+	if (actID == ACT_INVALID)
+	{
+		actID = ActivityList_RegisterPrivateActivity( actName );
+		AddActivityToSR( actName, actID );
+	}
+
+	return actID;
+}
+#endif
+
 #define ADD_ACTIVITY_TO_SR(activityname) AddActivityToSR(#activityname,activityname)
 
 //-----------------------------------------------------------------------------

--- a/sp/src/game/server/ai_basenpc.cpp
+++ b/sp/src/game/server/ai_basenpc.cpp
@@ -13515,6 +13515,10 @@ bool CAI_BaseNPC::CineCleanup()
 		}
 
 		// Clear interaction partner, because we're not running a scripted sequence anymore
+#ifdef MAPBASE
+		// We need the interaction partner for server ragdoll death cleanup, so don't clear if we're not alive
+		if (IsAlive())
+#endif
 		m_hInteractionPartner = NULL;
 		CleanupForcedInteraction();
 	}

--- a/sp/src/game/server/ai_basenpc.cpp
+++ b/sp/src/game/server/ai_basenpc.cpp
@@ -15303,7 +15303,8 @@ void CAI_BaseNPC::StartScriptedNPCInteraction( CAI_BaseNPC *pOtherNPC, ScriptedN
 
 				if ( Matcher_NamesMatch( pszInteraction, STRING( pOtherInteraction->iszInteractionName ) ) && pOtherInteraction != pInteraction )
 				{
-					pOtherInteraction->flNextAttemptTime = pInteraction->flNextAttemptTime;
+					if (pOtherInteraction->flNextAttemptTime < pInteraction->flNextAttemptTime)
+						pOtherInteraction->flNextAttemptTime = pInteraction->flNextAttemptTime;
 
 					// Not looking for multiple
 					if (!bWildCard)

--- a/sp/src/game/server/ai_basenpc.cpp
+++ b/sp/src/game/server/ai_basenpc.cpp
@@ -16142,6 +16142,7 @@ bool CAI_BaseNPC::InteractionCouldStart( CAI_BaseNPC *pOtherNPC, ScriptedNPCInte
 			if ( bDebug )
 			{
 				NDebugOverlay::Box( vecPos, GetHullMins(), GetHullMaxs(), 255,0,0, 100, 1.0 );
+				NDebugOverlay::HorzArrow( GetAbsOrigin(), vecPos, 16.0f, 255, 0, 0, 255, true, 1.0f );
 			}
 			return false;
 		}
@@ -16149,7 +16150,39 @@ bool CAI_BaseNPC::InteractionCouldStart( CAI_BaseNPC *pOtherNPC, ScriptedNPCInte
 		{
 			//NDebugOverlay::Box( vecPos, GetHullMins(), GetHullMaxs(), 0,255,0, 100, 1.0 );
 
-			NDebugOverlay::Axis( vecPos, angAngles, 20, true, 10.0 );
+			NDebugOverlay::Axis( vecPos, angAngles, 20, true, 1.0 );
+		}
+	}
+	else
+	{
+		// Instead, make sure we fit into where the sequence movement ends at
+		const char *pszSequence = GetScriptedNPCInteractionSequence( pInteraction, SNPCINT_SEQUENCE );
+		int nSeq = LookupSequence( pszSequence );
+		if ( pszSequence && nSeq != -1 )
+		{
+			Vector vecDeltaPos;
+			QAngle angDeltaAngles;
+			GetSequenceMovement( nSeq, 0.0f, 1.0f, vecDeltaPos, angDeltaAngles );
+			if (!vecDeltaPos.IsZero())
+			{
+				QAngle angInteraction = GetAbsAngles();
+				angInteraction[YAW] = m_flInteractionYaw;
+
+				Vector vecPos;
+				VectorRotate( vecDeltaPos, angInteraction, vecPos );
+				vecPos += GetAbsOrigin();
+
+				AI_TraceHull( vecPos, vecPos, GetHullMins(), GetHullMaxs(), MASK_SOLID, &traceFilter, &tr);
+				if ( tr.fraction != 1.0 )
+				{
+					if ( bDebug )
+					{
+						NDebugOverlay::Box( vecPos, GetHullMins(), GetHullMaxs(), 255,0,0, 100, 1.0 );
+						NDebugOverlay::HorzArrow( GetAbsOrigin(), vecPos, 16.0f, 255, 0, 0, 255, true, 1.0f );
+					}
+					return false;
+				}
+			}
 		}
 	}
 #endif

--- a/sp/src/game/server/ai_basenpc.cpp
+++ b/sp/src/game/server/ai_basenpc.cpp
@@ -14873,23 +14873,29 @@ void CAI_BaseNPC::ParseScriptedNPCInteractions(void)
 
 						else if (!Q_strncmp(szName, "their_", 6))
 						{
-							szName += 6;
+							const char *szTheirName = szName + 6;
 							sInteraction.bHasSeparateSequenceNames = true;
 
-							if (!Q_strncmp(szName, "entry_sequence", 14))
+							if (!Q_strncmp(szTheirName, "entry_sequence", 14))
 								sInteraction.sTheirPhases[SNPCINT_ENTRY].iszSequence = AllocPooledString(szValue);
-							else if (!Q_strncmp(szName, "entry_activity", 14))
+							else if (!Q_strncmp(szTheirName, "entry_activity", 14))
 								sInteraction.sTheirPhases[SNPCINT_ENTRY].iActivity = GetOrRegisterActivity(szValue);
 
-							else if (!Q_strncmp(szName, "sequence", 8))
+							else if (!Q_strncmp(szTheirName, "sequence", 8))
 								sInteraction.sTheirPhases[SNPCINT_SEQUENCE].iszSequence = AllocPooledString(szValue);
-							else if (!Q_strncmp(szName, "activity", 8))
+							else if (!Q_strncmp(szTheirName, "activity", 8))
 								sInteraction.sTheirPhases[SNPCINT_SEQUENCE].iActivity = GetOrRegisterActivity(szValue);
 
-							else if (!Q_strncmp(szName, "exit_sequence", 13))
+							else if (!Q_strncmp(szTheirName, "exit_sequence", 13))
 								sInteraction.sTheirPhases[SNPCINT_EXIT].iszSequence = AllocPooledString(szValue);
-							else if (!Q_strncmp(szName, "exit_activity", 13))
+							else if (!Q_strncmp(szTheirName, "exit_activity", 13))
 								sInteraction.sTheirPhases[SNPCINT_EXIT].iActivity = GetOrRegisterActivity(szValue);
+
+							// Add anything else to our miscellaneous criteria
+							else
+							{
+								szCriteria = UTIL_VarArgs("%s,%s:%s", szCriteria, szName, szValue);
+							}
 						}
 
 						else if (!Q_strncmp(szName, "delay", 5))

--- a/sp/src/game/server/ai_basenpc.cpp
+++ b/sp/src/game/server/ai_basenpc.cpp
@@ -15989,6 +15989,11 @@ bool CAI_BaseNPC::InteractionCouldStart( CAI_BaseNPC *pOtherNPC, ScriptedNPCInte
 				{
 					Msg("   %s distsqr: %0.2f (%0.2f %0.2f %0.2f), desired: <%0.2f (%0.2f %0.2f %0.2f)\n", GetDebugName(), flDistSqr,
 						pOtherNPC->GetAbsOrigin().x, pOtherNPC->GetAbsOrigin().y, pOtherNPC->GetAbsOrigin().z, pInteraction->flDistSqr, vecOrigin.x, vecOrigin.y, vecOrigin.z );
+#ifdef MAPBASE
+					Vector vecForward, vecRight;
+					GetVectors( &vecForward, &vecRight, NULL );
+					NDebugOverlay::Circle( vecOrigin + Vector(0,0,2), vecForward, vecRight, FastSqrt(pInteraction->flDistSqr), 255, 0, 0, 255, true, 0.1f );
+#endif
 				}
 			}
 		}
@@ -16001,6 +16006,11 @@ bool CAI_BaseNPC::InteractionCouldStart( CAI_BaseNPC *pOtherNPC, ScriptedNPCInte
 		Msg("   %s is at: %0.2f %0.2f %0.2f\n", GetDebugName(), GetAbsOrigin().x, GetAbsOrigin().y, GetAbsOrigin().z );
 		Msg("   %s distsqr: %0.2f (%0.2f %0.2f %0.2f), desired: (%0.2f %0.2f %0.2f)\n", GetDebugName(), flDistSqr,
 			pOtherNPC->GetAbsOrigin().x, pOtherNPC->GetAbsOrigin().y, pOtherNPC->GetAbsOrigin().z, vecOrigin.x, vecOrigin.y, vecOrigin.z );
+#ifdef MAPBASE
+		Vector vecForward, vecRight;
+		GetVectors( &vecForward, &vecRight, NULL );
+		NDebugOverlay::Circle( vecOrigin + Vector( 0, 0, 2 ), vecForward, vecRight, FastSqrt( pInteraction->flDistSqr ), 255, 0, 0, 255, true, 0.1f );
+#endif
 
 		if ( pOtherNPC )
 		{

--- a/sp/src/game/server/ai_basenpc.h
+++ b/sp/src/game/server/ai_basenpc.h
@@ -425,6 +425,9 @@ struct ScriptedNPCInteraction_t
 		iszTheirWeapon = NULL_STRING;
 #ifdef MAPBASE
 		vecRelativeEndPos = vec3_origin;
+		bHasSeparateSequenceNames = false;
+		flMaxAngleDiff = DSS_MAX_ANGLE_DIFF;
+		iszRelatedInteractions = NULL_STRING;
 		MiscCriteria = NULL_STRING;
 #endif
 
@@ -432,6 +435,10 @@ struct ScriptedNPCInteraction_t
 		{
 			sPhases[i].iszSequence = NULL_STRING;
 			sPhases[i].iActivity = ACT_INVALID;
+#ifdef MAPBASE
+			sTheirPhases[i].iszSequence = NULL_STRING;
+			sTheirPhases[i].iActivity = ACT_INVALID;
+#endif
 		}
 	}
 
@@ -459,10 +466,14 @@ struct ScriptedNPCInteraction_t
 	float		flNextAttemptTime;
 
 #ifdef MAPBASE
-	// Unrecognized keyvalues are tested against response criteria later.
-	// This was originally a CUtlVector that carries response contexts, but I couldn't get it working due to some CUtlVector-struct shenanigans.
-	// It works when we use a single string_t that's split and read each time the code runs, but feel free to improve on this.
-	string_t	MiscCriteria; // CUtlVector<ResponseContext_t>
+	ScriptedNPCInteraction_Phases_t sTheirPhases[SNPCINT_NUM_PHASES];	// The animations played by the target NPC, if they are different
+	bool		bHasSeparateSequenceNames;
+
+	float		flMaxAngleDiff;
+	string_t	iszRelatedInteractions;	// These interactions will be delayed as well when this interaction is used.
+
+	// Unrecognized keyvalues which are tested against response criteria later.
+	string_t	MiscCriteria;
 #endif
 
 	DECLARE_SIMPLE_DATADESC();
@@ -1304,10 +1315,14 @@ private:
 public:
 	float GetInteractionYaw( void ) const { return m_flInteractionYaw; }
 
+	bool IsRunningDynamicInteraction( void ) { return (m_iInteractionState != NPCINT_NOT_RUNNING && (m_hCine != NULL)); }
+	bool IsActiveDynamicInteraction( void ) { return (m_iInteractionState == NPCINT_RUNNING_ACTIVE && (m_hCine != NULL)); }
+	CAI_BaseNPC *GetInteractionPartner( void );
+
 protected:
 	void ParseScriptedNPCInteractions( void );
 	void AddScriptedNPCInteraction( ScriptedNPCInteraction_t *pInteraction  );
-	const char *GetScriptedNPCInteractionSequence( ScriptedNPCInteraction_t *pInteraction, int iPhase );
+	const char *GetScriptedNPCInteractionSequence( ScriptedNPCInteraction_t *pInteraction, int iPhase, bool bOtherNPC = false );
 	void StartRunningInteraction( CAI_BaseNPC *pOtherNPC, bool bActive );
 	void StartScriptedNPCInteraction( CAI_BaseNPC *pOtherNPC, ScriptedNPCInteraction_t *pInteraction, Vector vecOtherOrigin, QAngle angOtherAngles );
 	void CheckForScriptedNPCInteractions( void );
@@ -1320,17 +1335,16 @@ protected:
 #endif
 	bool InteractionCouldStart( CAI_BaseNPC *pOtherNPC, ScriptedNPCInteraction_t *pInteraction, Vector &vecOrigin, QAngle &angAngles );
 	virtual bool CanRunAScriptedNPCInteraction( bool bForced = false );
-	bool IsRunningDynamicInteraction( void ) { return (m_iInteractionState != NPCINT_NOT_RUNNING && (m_hCine != NULL)); }
-	bool IsActiveDynamicInteraction( void ) { return (m_iInteractionState == NPCINT_RUNNING_ACTIVE && (m_hCine != NULL)); }
 	ScriptedNPCInteraction_t *GetRunningDynamicInteraction( void ) { return &(m_ScriptedInteractions[m_iInteractionPlaying]); }
 	void SetInteractionCantDie( bool bCantDie ) { m_bCannotDieDuringInteraction = bCantDie; }
 	bool HasInteractionCantDie( void );
+	bool HasValidInteractionsOnCurrentEnemy( void );
+	virtual bool CanStartDynamicInteractionDuringMelee() { return false; }
 
 	void InputForceInteractionWithNPC( inputdata_t &inputdata );
 	void StartForcedInteraction( CAI_BaseNPC *pNPC, int iInteraction );
 	void CleanupForcedInteraction( void );
 	void CalculateForcedInteractionPosition( void );
-	CAI_BaseNPC *GetInteractionPartner( void );
 
 private:
 	// Forced interactions
@@ -2228,6 +2242,9 @@ public:
 	static const char*	GetActivityName	(int actID);	
 
 	static void			AddActivityToSR(const char *actName, int conID);
+#ifdef MAPBASE
+	static int			GetOrRegisterActivity( const char *actName );
+#endif
 	
 	static void			AddEventToSR(const char *eventName, int conID);
 	static const char*	GetEventName	(int actID);

--- a/sp/src/game/server/ai_basenpc.h
+++ b/sp/src/game/server/ai_basenpc.h
@@ -849,6 +849,9 @@ protected: // pose parameters
 	int					m_poseAim_Pitch;
 	int					m_poseAim_Yaw;
 	int					m_poseMove_Yaw;
+#ifdef MAPBASE
+	int					m_poseInteractionRelativeYaw;
+#endif
 	virtual void		PopulatePoseParameters( void );
 
 public:
@@ -856,6 +859,10 @@ public:
 
 	// Return the stored pose parameter for "move_yaw"
 	inline int			LookupPoseMoveYaw()		{ return m_poseMove_Yaw; }
+
+#ifdef MAPBASE
+	inline int			LookupPoseInteractionRelativeYaw()	{ return m_poseInteractionRelativeYaw; }
+#endif
  
 
 	//-----------------------------------------------------

--- a/sp/src/game/server/ai_basenpc_schedule.cpp
+++ b/sp/src/game/server/ai_basenpc_schedule.cpp
@@ -1610,6 +1610,12 @@ void CAI_BaseNPC::StartTask( const Task_t *pTask )
 			// as this should only run with the NPC "receiving" the interaction
 			ScriptedNPCInteraction_t *pInteraction = m_hForcedInteractionPartner->GetRunningDynamicInteraction();
 
+			if ( !(pInteraction->iFlags & SCNPC_FLAG_TEST_OTHER_ANGLES) )
+			{
+				TaskComplete();
+				return;
+			}
+
 			// Get our target's origin
 			Vector vecTarget = m_hForcedInteractionPartner->GetAbsOrigin();
 
@@ -1617,7 +1623,7 @@ void CAI_BaseNPC::StartTask( const Task_t *pTask )
 			float angInteractionAngle = pInteraction->angRelativeAngles.y;
 			angInteractionAngle += 180.0f;
 
-			GetMotor()->SetIdealYaw( CalcIdealYaw( vecTarget ) + angInteractionAngle );
+			GetMotor()->SetIdealYaw( AngleNormalize( CalcIdealYaw( vecTarget ) + angInteractionAngle ) );
 
 			if (FacingIdeal())
 				TaskComplete();
@@ -4113,6 +4119,15 @@ void CAI_BaseNPC::RunTask( const Task_t *pTask )
 					m_hCine->SynchronizeSequence( this );
 				}
 			}
+
+#ifdef MAPBASE
+			if ( IsRunningDynamicInteraction() && m_poseInteractionRelativeYaw > -1 )
+			{
+				// Animations in progress require pose parameters to be set every frame, so keep setting the interaction relative yaw pose.
+				// The random value is added to help it pass server transmit checks.
+				SetPoseParameter( m_poseInteractionRelativeYaw, GetPoseParameter( m_poseInteractionRelativeYaw ) + RandomFloat( -0.1f, 0.1f ) );
+			}
+#endif
 			break;
 		}
 

--- a/sp/src/game/server/hl2/npc_BaseZombie.cpp
+++ b/sp/src/game/server/hl2/npc_BaseZombie.cpp
@@ -2435,6 +2435,20 @@ void CNPC_BaseZombie::RemoveHead( void )
 }
 
 
+//---------------------------------------------------------
+//---------------------------------------------------------
+void CNPC_BaseZombie::SetModel( const char *szModelName )
+{
+#ifdef MAPBASE
+	// Zombies setting the same model again is a problem when they should maintain their current sequence (e.g. during dynamic interactions)
+	if ( IsRunningDynamicInteraction() && GetModelIndex() != 0 && FStrEq( szModelName, STRING(GetModelName()) ) )
+		return;
+#endif
+
+	BaseClass::SetModel( szModelName );
+}
+
+
 bool CNPC_BaseZombie::ShouldPlayFootstepMoan( void )
 {
 	if( random->RandomInt( 1, zombie_stepfreq.GetInt() * s_iAngryZombies ) == 1 )

--- a/sp/src/game/server/hl2/npc_BaseZombie.cpp
+++ b/sp/src/game/server/hl2/npc_BaseZombie.cpp
@@ -1745,7 +1745,11 @@ void CNPC_BaseZombie::HandleAnimEvent( animevent_t *pEvent )
 
 		dmgInfo.SetDamagePosition( vecHeadCrabPosition );
 
+#ifdef MAPBASE
+		ReleaseHeadcrab( vecHeadCrabPosition, vVelocity *iSpeed, true, false, true );
+#else
 		ReleaseHeadcrab( EyePosition(), vVelocity * iSpeed, true, false, true );
+#endif
 
 		GuessDamageForce( &dmgInfo, vVelocity, vecHeadCrabPosition, 0.5f );
 		TakeDamage( dmgInfo );

--- a/sp/src/game/server/hl2/npc_BaseZombie.h
+++ b/sp/src/game/server/hl2/npc_BaseZombie.h
@@ -186,6 +186,7 @@ public:
 	// Headcrab releasing/breaking apart
 	void RemoveHead( void );
 	virtual void SetZombieModel( void ) { };
+	virtual void SetModel( const char *szModelName );
 	virtual void BecomeTorso( const Vector &vecTorsoForce, const Vector &vecLegsForce );
 	virtual bool CanBecomeLiveTorso() { return false; }
 	virtual bool HeadcrabFits( CBaseAnimating *pCrab );

--- a/sp/src/game/server/hl2/npc_combine.cpp
+++ b/sp/src/game/server/hl2/npc_combine.cpp
@@ -47,6 +47,8 @@ ConVar npc_combine_protected_run( "npc_combine_protected_run", "0", FCVAR_NONE, 
 ConVar npc_combine_altfire_not_allies_only( "npc_combine_altfire_not_allies_only", "1", FCVAR_NONE, "Mapbase: Elites are normally only allowed to fire their alt-fire attack at the player and the player's allies; This allows elites to alt-fire at other enemies too." );
 
 ConVar npc_combine_new_cover_behavior( "npc_combine_new_cover_behavior", "1", FCVAR_NONE, "Mapbase: Toggles small patches for parts of npc_combine AI related to soldiers failing to take cover. These patches are minimal and only change cases where npc_combine would otherwise look at an enemy without shooting or run up to the player to melee attack when they don't have to. Consult the Mapbase wiki for more information." );
+
+ConVar npc_combine_fixed_shootpos( "npc_combine_fixed_shootpos", "0", FCVAR_NONE, "Mapbase: Toggles fixed Combine soldier shoot position." )
 #endif
 
 #define COMBINE_SKIN_DEFAULT		0
@@ -2958,6 +2960,28 @@ Vector CNPC_Combine::Weapon_ShootPosition( )
 
 	// FIXME: rename this "estimated" since it's not based on animation
 	// FIXME: the orientation won't be correct when testing from arbitary positions for arbitary angles
+
+#ifdef MAPBASE
+	// HACKHACK: This weapon shoot position code does not work properly when in close range, causing the aim
+	// to drift to the left as the enemy gets closer to it.
+	// This problem is usually bearable for regular combat, but it causes dynamic interaction yaw to be offset
+	// as well, preventing most from ever being triggered.
+	// Ideally, this should be fixed from the root cause, but due to the sensitivity of such a change, this is
+	// currently being tied to a cvar which is off by default.
+	// 
+	// If the cvar is disabled but the soldier has valid interactions on its current enemy, then a separate hack
+	// will still attempt to correct the drift as the enemy gets closer.
+	if ( npc_combine_fixed_shootpos.GetBool() )
+	{
+		right *= 0.0f;
+	}
+	else if ( HasValidInteractionsOnCurrentEnemy() )
+	{
+		float flDistSqr = GetEnemy()->WorldSpaceCenter().DistToSqr( WorldSpaceCenter() );
+		if (flDistSqr < Square( 128.0f ))
+			right *= (flDistSqr / Square( 128.0f ));
+	}
+#endif
 
 	if  ( bStanding )
 	{

--- a/sp/src/game/server/hl2/npc_combine.cpp
+++ b/sp/src/game/server/hl2/npc_combine.cpp
@@ -48,7 +48,7 @@ ConVar npc_combine_altfire_not_allies_only( "npc_combine_altfire_not_allies_only
 
 ConVar npc_combine_new_cover_behavior( "npc_combine_new_cover_behavior", "1", FCVAR_NONE, "Mapbase: Toggles small patches for parts of npc_combine AI related to soldiers failing to take cover. These patches are minimal and only change cases where npc_combine would otherwise look at an enemy without shooting or run up to the player to melee attack when they don't have to. Consult the Mapbase wiki for more information." );
 
-ConVar npc_combine_fixed_shootpos( "npc_combine_fixed_shootpos", "0", FCVAR_NONE, "Mapbase: Toggles fixed Combine soldier shoot position." )
+ConVar npc_combine_fixed_shootpos( "npc_combine_fixed_shootpos", "0", FCVAR_NONE, "Mapbase: Toggles fixed Combine soldier shoot position." );
 #endif
 
 #define COMBINE_SKIN_DEFAULT		0

--- a/sp/src/game/server/physics_prop_ragdoll.cpp
+++ b/sp/src/game/server/physics_prop_ragdoll.cpp
@@ -1557,6 +1557,16 @@ CBaseEntity *CreateServerRagdoll( CBaseAnimating *pAnimating, int forceBone, con
 	pRagdoll->CollisionProp()->SetCollisionBounds( mins, maxs );
 
 #ifdef MAPBASE
+	// If this was a NPC running a dynamic interaction, disable collisions with the interaction partner
+	if (pAnimating->IsNPC() /*&& pAnimating->MyNPCPointer()->IsRunningDynamicInteraction()*/)
+	{
+		CAI_BaseNPC *pNPC = pAnimating->MyNPCPointer();
+		if (pNPC->GetInteractionPartner() && pNPC->GetInteractionPartner()->VPhysicsGetObject())
+		{
+			PhysDisableEntityCollisions( pRagdoll, pNPC->GetInteractionPartner() );
+		}
+	}
+
 	variant_t variant;
 	variant.SetEntity(pRagdoll);
 	pAnimating->FireNamedOutput("OnServerRagdoll", variant, pRagdoll, pAnimating);

--- a/sp/src/game/server/scripted.cpp
+++ b/sp/src/game/server/scripted.cpp
@@ -1396,11 +1396,31 @@ void CAI_ScriptedSequence::ModifyScriptedAutoMovement( Vector *vecNewPos )
 			}
 		}
 
+		VMatrix matInteractionPosition = m_matInteractionPosition;
+
+#ifdef MAPBASE
+		// Account for our own sequence movement
+		pAnimating = m_hTargetEnt->GetBaseAnimating();
+		if (pAnimating)
+		{
+			Vector vecDeltaPos;
+			QAngle angDeltaAngles;
+
+			pAnimating->GetSequenceMovement( pAnimating->GetSequence(), 0.0f, pAnimating->GetCycle(), vecDeltaPos, angDeltaAngles );
+			if (!vecDeltaPos.IsZero())
+			{
+				VMatrix matLocalMovement;
+				matLocalMovement.SetupMatrixOrgAngles( vecDeltaPos, angDeltaAngles );
+				MatrixMultiply( m_matInteractionPosition, matLocalMovement, matInteractionPosition );
+			}
+		}
+#endif
+
 		// We've been asked to maintain a specific position relative to the other NPC
 		// we're interacting with. Lerp towards the relative position.
  		VMatrix matMeToWorld, matLocalToWorld;
 		matMeToWorld.SetupMatrixOrgAngles( vecRelativeOrigin, angRelativeAngles );
-		MatrixMultiply( matMeToWorld, m_matInteractionPosition, matLocalToWorld );
+		MatrixMultiply( matMeToWorld, matInteractionPosition, matLocalToWorld );
 
 		// Get the desired NPC position in worldspace
 		Vector vecOrigin;


### PR DESCRIPTION
This PR adds several improvements and fixes for NPC dynamic interactions, especially for increasing the capabilities of custom ones.

---

### Keyvalues

Dynamic interactions now support the following new keyvalues:

* `angles_max_diff` — The maximum difference from `angles_relative` required in order to perform the interaction. Previously, this was hardcoded as `4`, and that will be the default if this keyvalue is not specified.
* `their_sequence`, `their_activity`, etc. — Optional separate sequence or activity names to use on the target NPC, rather than using the same sequence or activity name as the triggering NPC. This allows for interactions between two NPCs which use the same model.
* `related_interactions` — Other interactions which should be delayed as well when this interaction runs. Separated by comma, but also supports wildcards.

### Better sequence movement handling

Dynamic interaction testing was not designed with sequence walkframe movement (i.e. sequences which literally move the NPC to another location) in mind. This was previously amended with the new `end_position` keyvalue, but this is not always appropriate and is sometimes unnecessary when the sequence's end position can be calculated through movement. This also did not retroactively apply to existing interactions which may need end position testing.

Now, if the `end_position` keyvalue is not specified, dynamic interactions will directly test sequence movement before running. This will occur on *all* interactions with sequence movement, including existing ones, but only a small number of them actually have it. One set of interactions which does have it is the Combine Hunter's interactions with citizens, which sometimes result in the hunter being stuck in walls if there wasn't enough room at their end position. This change will fix that.

The `end_position` keyvalue is still functional and will override the sequence movement check. It can be used for sequences with different end positions which do not use sequence walkframe movement, or to prevent the sequence movement check from occurring.

### Specific NPC hacks

This PR integrates the following minor hacks for HL2 NPCs running dynamic interactions:

1. Combine soldiers will use a hack to correct weapon position drift when a NPC it can run a dynamic interaction on comes within 128 units. `npc_combine_fixed_shootpos` can be used to make this fix occur under all cases.
2. Zombies will not reset their model after their headcrab is removed if they are running a dynamic interaction. This fixes zombies suddenly snapping to another position during interactions in which the headcrab is specifically removed.
3. NPCs will not reset their interaction partner if they are dead during script cleanup. This is then used by serverside death ragdoll code to disable collisions with the NPC's interaction partner, fixing serverside ragdolls drifting away from the partner after death.

---

I tried to separate most of these changes into separate commits to make them easier to understand, although the heavily specialized nature of this subject may make it difficult to do a thorough review.

---

<!-- Replace [ ] with [x] for each item your PR satisfies -->
#### PR Checklist
- [x] **My PR follows all guidelines in the CONTRIBUTING.md file**
- [x] My PR targets a `develop` branch OR targets another branch with a specific goal in mind
