### PR TITLE
Fix serverside zombie headcrab ragdoll not using correct origin

### DIFF
--- a/sp/src/game/server/hl2/npc_BaseZombie.h
+++ b/sp/src/game/server/hl2/npc_BaseZombie.h
@@ -188,7 +188,7 @@ public:
 	virtual void SetZombieModel( void ) { };
 	virtual void BecomeTorso( const Vector &vecTorsoForce, const Vector &vecLegsForce );
 	virtual bool CanBecomeLiveTorso() { return false; }
-	virtual bool HeadcrabFits( CBaseAnimating *pCrab );
+	virtual bool HeadcrabFits( CBaseAnimating *pCrab, const Vector *vecOrigin = NULL );
 	void ReleaseHeadcrab( const Vector &vecOrigin, const Vector &vecVelocity, bool fRemoveHead, bool fRagdollBody, bool fRagdollCrab = false );
 	void SetHeadcrabSpawnLocation( int iCrabAttachment, CBaseAnimating *pCrab );
 


### PR DESCRIPTION
This fixes problems with headcrab zombies not releasing their headcrabs properly when using serverside ragdolls. Previously, it used the direct origin of the newly created headcrab ragdoll gib, which isn't valid with serverside ragdolls. It would instead test a random position near the world origin which may or may not be clear. It would also show blood impacts at this location instead of near the zombie.

This adds a new parameter to the `CNPC_BaseZombie::HeadcrabFits()` function to accept a separate origin, and while this function is virtual, it does not appear to be overridden by any zombie class in HL2.

---

<!-- Replace [ ] with [x] for each item your PR satisfies -->
#### PR Checklist
- [x] **My PR follows all guidelines in the CONTRIBUTING.md file**
- [x] My PR targets a `develop` branch OR targets another branch with a specific goal in mind
