### PR TITLE
Cvar to disable zombie flinching during actbusies or scripted sequences

### DIFF
--- a/sp/src/game/server/hl2/npc_BaseZombie.cpp
+++ b/sp/src/game/server/hl2/npc_BaseZombie.cpp
@@ -159,6 +159,10 @@ ConVar zombie_decaymax( "zombie_decaymax", "0.4" );
 
 ConVar zombie_ambushdist( "zombie_ambushdist", "16000" );
 
+#ifdef MAPBASE
+ConVar	zombie_no_flinch_during_unique_anim( "zombie_no_flinch_during_unique_anim", "1", FCVAR_NONE, "Prevents zombies from flinching during actbusies and scripted sequences." );
+#endif
+
 //=========================================================
 // For a couple of reasons, we keep a running count of how
 // many zombies in the world are angry at any given time.
@@ -1924,6 +1928,31 @@ void CNPC_BaseZombie::OnScheduleChange( void )
 	} 
 
 	BaseClass::OnScheduleChange();
+}
+
+
+//---------------------------------------------------------
+//---------------------------------------------------------
+
+bool CNPC_BaseZombie::CanFlinch( void )
+{
+	if (!BaseClass::CanFlinch())
+		return false;
+
+#ifdef MAPBASE
+	if (zombie_no_flinch_during_unique_anim.GetBool())
+	{
+		// Don't flinch if currently playing actbusy animation (navigating to or from one is fine)
+		if (m_ActBusyBehavior.IsInsideActBusy())
+			return false;
+
+		// Don't flinch if currently playing scripted sequence (navigating to or from one is fine)
+		if (m_NPCState == NPC_STATE_SCRIPT && (IsCurSchedule( SCHED_SCRIPTED_WAIT, false ) || IsCurSchedule( SCHED_SCRIPTED_FACE, false )))
+			return false;
+	}
+#endif
+
+	return true;
 }
 
 

--- a/sp/src/game/server/hl2/npc_BaseZombie.h
+++ b/sp/src/game/server/hl2/npc_BaseZombie.h
@@ -151,6 +151,8 @@ public:
 	int OnTakeDamage_Alive( const CTakeDamageInfo &info );
 	virtual float	GetReactionDelay( CBaseEntity *pEnemy ) { return 0.0; }
 
+	bool CanFlinch( void );
+
 	virtual int SelectSchedule ( void );
 	virtual int	SelectFailSchedule( int failedSchedule, int failedTask, AI_TaskFailureCode_t taskFailCode );
 	virtual void BuildScheduleTestBits( void );


### PR DESCRIPTION
This pull request adds a cvar to prevent zombies from flinching while playing actbusy or scripted sequence animations. This is a hack which tries to prevent zombies from suddenly changing their model's position while flinching during a unique animation, which is a common issue in the HL2 episodes and mods which draw from it. This is caused by pelvic motion in the zombie flinch gestures. and it can be fixed by overriding the zombie animations, but Mapbase has no zombie animation overrides at this time. If custom zombie animations are ever added in the future and this issue is amended at the source, then this cvar should be disabled.

---

<!-- Replace [ ] with [x] for each item your PR satisfies -->
#### PR Checklist
- [x] **My PR follows all guidelines in the CONTRIBUTING.md file**
- [x] My PR targets a `develop` branch OR targets another branch with a specific goal in mind
