### PR TITLE
Better circumstantial criteria for followup responses

### DIFF
--- a/sp/src/game/server/ai_expresserfollowup.cpp
+++ b/sp/src/game/server/ai_expresserfollowup.cpp
@@ -88,6 +88,15 @@ static void DispatchComeback( CAI_ExpresserWithFollowup *pExpress, CBaseEntity *
 	// add in any provided contexts from the parameters onto the ones stored in the followup
 	criteria.Merge( followup.followup_contexts );
 
+#ifdef MAPBASE
+	if (CAI_ExpresserSink *pSink = dynamic_cast<CAI_ExpresserSink *>(pRespondent))
+	{
+		criteria.AppendCriteria( "dist_from_issuer",  UTIL_VarArgs( "%f", (pRespondent->GetAbsOrigin() - pSpeaker->GetAbsOrigin()).Length() ) );
+		g_ResponseQueueManager.GetQueue()->AppendFollowupCriteria( followup.followup_concept, criteria, pSink->GetSinkExpresser(), pSink, pRespondent, pSpeaker, kDRT_SPECIFIC );
+
+		pSink->Speak( followup.followup_concept, &criteria );
+	}
+#else
 	// This is kludgy and needs to be fixed in class hierarchy, but for now, try to guess at the most likely
 	// kinds of targets and dispatch to them.
 	if (CBaseMultiplayerPlayer *pPlayer = dynamic_cast<CBaseMultiplayerPlayer *>(pRespondent))
@@ -99,6 +108,7 @@ static void DispatchComeback( CAI_ExpresserWithFollowup *pExpress, CBaseEntity *
 	{
 		pActor->Speak( followup.followup_concept, &criteria );
 	}
+#endif
 }
 
 #if 0

--- a/sp/src/game/server/ai_playerally.h
+++ b/sp/src/game/server/ai_playerally.h
@@ -392,6 +392,9 @@ public:
 	
 	bool		ShouldSpeakRandom( AIConcept_t concept, int iChance );
 	bool		IsAllowedToSpeak( AIConcept_t concept, bool bRespondingToPlayer = false );
+#ifdef MAPBASE
+	bool		IsAllowedToSpeakFollowup( AIConcept_t concept, CBaseEntity *pIssuer, bool bSpecific );
+#endif
 	virtual bool SpeakIfAllowed( AIConcept_t concept, const char *modifiers = NULL, bool bRespondingToPlayer = false, char *pszOutResponseChosen = NULL, size_t bufsize = 0 );
 #ifdef MAPBASE
 	virtual bool SpeakIfAllowed( AIConcept_t concept, AI_CriteriaSet& modifiers, bool bRespondingToPlayer = false, char *pszOutResponseChosen = NULL, size_t bufsize = 0 );

--- a/sp/src/game/server/ai_speech_new.h
+++ b/sp/src/game/server/ai_speech_new.h
@@ -126,6 +126,13 @@ public:
 	virtual void OnSpokeConcept( AIConcept_t concept, AI_Response *response )	{};
 	virtual void OnStartSpeaking()						{}
 	virtual bool UseSemaphore()							{ return true; }
+
+#ifdef MAPBASE
+	// Works around issues with CAI_ExpresserHost<> class hierarchy
+	virtual CAI_Expresser *GetSinkExpresser() { return NULL; }
+	virtual bool IsAllowedToSpeakFollowup( AIConcept_t concept, CBaseEntity *pIssuer, bool bSpecific ) { return true; }
+	virtual bool Speak( AIConcept_t concept, AI_CriteriaSet *pCriteria, char *pszOutResponseChosen = NULL, size_t bufsize = 0, IRecipientFilter *filter = NULL ) { return false; }
+#endif
 };
 
 struct ConceptHistory_t
@@ -244,8 +251,14 @@ public:
 	static bool RunScriptResponse( CBaseEntity *pTarget, const char *response, AI_CriteriaSet *criteria, bool file );
 #endif
 
+#ifdef MAPBASE
+public:
+#else
 protected:
+#endif
 	CAI_TimedSemaphore *GetMySpeechSemaphore( CBaseEntity *pNpc );
+
+protected:
 
 	bool SpeakRawScene( const char *pszScene, float delay, AI_Response *response, IRecipientFilter *filter = NULL );
 	// This will create a fake .vcd/CChoreoScene to wrap the sound to be played
@@ -311,11 +324,15 @@ private:
 //
 
 template <class BASE_NPC>
-class CAI_ExpresserHost : public BASE_NPC, protected CAI_ExpresserSink
+class CAI_ExpresserHost : public BASE_NPC, public CAI_ExpresserSink
 {
 	DECLARE_CLASS_NOFRIEND( CAI_ExpresserHost, BASE_NPC );
 
 public:
+#ifdef MAPBASE
+	CAI_Expresser *GetSinkExpresser() { return this->GetExpresser(); }
+#endif
+
 	virtual void	NoteSpeaking( float duration, float delay );
 
 	virtual bool 	Speak( AIConcept_t concept, const char *modifiers = NULL, char *pszOutResponseChosen = NULL, size_t bufsize = 0, IRecipientFilter *filter = NULL );

--- a/sp/src/game/server/ai_speechqueue.h
+++ b/sp/src/game/server/ai_speechqueue.h
@@ -116,6 +116,11 @@ public:
 	inline int GetNumExpresserTargets() const;
 	inline CBaseEntity *GetExpresserHost(int which) const;
 
+#ifdef MAPBASE
+	void AppendFollowupCriteria( AIConcept_t concept, AI_CriteriaSet &set, CAI_Expresser *pEx,
+		CAI_ExpresserSink *pSink, CBaseEntity *pTarget, CBaseEntity *pIssuer, DeferredResponseTarget_t nTargetType );
+#endif
+
 protected:
 	/// Actually send off one response to a consumer
 	/// Return true if dispatch succeeded


### PR DESCRIPTION
Adds the following criteria to followup responses:

* `dist_from_issuer` — The distance to the issuer of the original response. This already existed on `any` type responses, but it will now exist for all followups.
* `is_speaking` — Whether or not the person speaking the followup is already speaking.
* `followup_allowed_to_speak` — Whether or not the speaker's AI would allow this followup to play as a regular response concept. This includes whether the speaker is already speaking.
* `followup_target_type` — The method in which this speaker was selected for a followup response (i.e. whether it was specifically targeting the NPC, whether it was dispatched to all NPCs, or whether it was dispatched to one of any NPCs)

These criteria are meant to provide better control over when followups play in relation to HL2's existing speech AI without restricting the behavior that has existed since they were added.

Note that `followup_allowed_to_speak` currently only applies to entities derived from `CAI_PlayerAlly`.

---

<!-- Replace [ ] with [x] for each item your PR satisfies -->
#### PR Checklist
- [x] **My PR follows all guidelines in the CONTRIBUTING.md file**
- [x] My PR targets a `develop` branch OR targets another branch with a specific goal in mind
