### PR TITLE
Fix GitHub workflow not installing packages properly

### DIFF
--- a/.github/workflows/mapbase_build-base.yml
+++ b/.github/workflows/mapbase_build-base.yml
@@ -194,7 +194,9 @@ jobs:
     - uses: actions/checkout@v3
 
     - name: Install GCC/G++ multilib
-      run: sudo apt-get install gcc-multilib g++-multilib
+      run: |
+        sudo apt-get update
+        sudo apt-get install gcc-multilib g++-multilib
 
     - name: Pick game
       if: inputs.project-group == 'game' || inputs.project-group == 'shaders'


### PR DESCRIPTION
This PR fixes an emergent issue in Mapbase's GitHub workflows in which `apt-get update` was missing.

Due to the nature of this issue, this is a "hotfix" branch which is being merged into `master` directly rather than following the regular `develop` update pipeline.

This branch will most likely be rebased, and other branches (e.g. `develop` and new PRs) will need to merge `master` for workflows to work properly again.