### PR TITLE
weapon_custom_scripted fixes

### DIFF
--- a/sp/src/game/shared/mapbase/weapon_custom_scripted.cpp
+++ b/sp/src/game/shared/mapbase/weapon_custom_scripted.cpp
@@ -179,7 +179,7 @@ bool CWeaponCustomScripted::RunWeaponHook( ScriptHook_t &hook, HSCRIPT &cached, 
 {
 	if ( !cached )
 	{
-		if ( hook.CanRunInScope( m_ScriptScope ) )
+		if ( m_ScriptScope.IsInitialized() && hook.CanRunInScope( m_ScriptScope ) )
 		{
 			cached = hook.m_hFunc;
 		}
@@ -187,6 +187,7 @@ bool CWeaponCustomScripted::RunWeaponHook( ScriptHook_t &hook, HSCRIPT &cached, 
 
 	if (cached)
 	{
+		hook.m_hFunc = cached;
 		return hook.Call( m_ScriptScope, retVal, pArgs, false );
 	}
 

--- a/sp/src/game/shared/mapbase/weapon_custom_scripted.cpp
+++ b/sp/src/game/shared/mapbase/weapon_custom_scripted.cpp
@@ -334,7 +334,7 @@ void CWeaponCustomScripted::ItemPreFrame( void )
 {
 	SIMPLE_VOID_OVERRIDE( ItemPreFrame, NULL );
 
-	BaseClass::ItemPostFrame();
+	BaseClass::ItemPreFrame();
 }
 
 void CWeaponCustomScripted::ItemPostFrame( void )


### PR DESCRIPTION
Fixes a regression in hook calls. This was caused by putting `CanRunInScope()`, which looks up the hook function, behind an assertion inside `ScriptHook_t::Call()`, so this would only work in debug builds. This was only an issue in weapon_custom_scripted because this is the only place hook functions are manually cached. Quite messy...

---

#### PR Checklist
- [x] **My PR follows all guidelines in the CONTRIBUTING.md file**
- [x] My PR targets a `develop` branch OR targets another branch with a specific goal in mind
