### PR TITLE
Add raw scene file support to GetSceneDuration()

### DIFF
--- a/sp/src/game/server/sceneentity.cpp
+++ b/sp/src/game/server/sceneentity.cpp
@@ -5298,6 +5298,23 @@ float GetSceneDuration( char const *pszScene )
 	{
 		msecs = cachedData.msecs;
 	}
+#ifdef MAPBASE
+	else
+	{
+		// Raw scene file support
+		void *pBuffer = NULL;
+		if (filesystem->ReadFileEx( pszScene, "MOD", &pBuffer, true ))
+		{
+			g_TokenProcessor.SetBuffer((char*)pBuffer);
+			CChoreoScene *pScene = ChoreoLoadScene( pszScene, NULL, &g_TokenProcessor, LocalScene_Printf );
+			g_TokenProcessor.SetBuffer(NULL);
+
+			float flDuration = pScene->GetDuration();
+			delete pScene;
+			return flDuration;
+		}
+	}
+#endif
 
 	return (float)msecs * 0.001f;
 }


### PR DESCRIPTION
This change allows `GetSceneDuration()` to draw from raw scene files when the requested VCD is not in the `scenes.image`. This fixes a few issues with Mapbase's pre-existing raw VCD file support, such as them not functioning properly as responses.

---

<!-- Replace [ ] with [x] for each item your PR satisfies -->
#### PR Checklist
- [x] **My PR follows all guidelines in the CONTRIBUTING.md file**
- [x] My PR targets a `develop` branch OR targets another branch with a specific goal in mind
