### PR TITLE
Fix soundlevel_t compile error on VS2013

### DIFF
--- a/sp/src/public/soundflags.h
+++ b/sp/src/public/soundflags.h
@@ -102,6 +102,10 @@ enum soundlevel_t
 #define MAX_SNDLVL_VALUE	((1<<MAX_SNDLVL_BITS)-1)
 
 
+#if !defined(LINUX)
+#define ATTN_TO_SNDLVL( a ) (soundlevel_t)(int)((a) ? (50 + 20 / ((float)a)) : 0 )
+#define SNDLVL_TO_ATTN( a ) ((a > 50) ? (20.0f / (float)(a - 50)) : 4.0 )
+#else
 inline soundlevel_t ATTN_TO_SNDLVL(float a)
 {
 	soundlevel_t sndlvl = soundlevel_t::SNDLVL_NONE;
@@ -118,6 +122,7 @@ inline float SNDLVL_TO_ATTN(soundlevel_t s)
 {
 	return (s > soundlevel_t::SNDLVL_50dB)? (20.0f / float(s - soundlevel_t::SNDLVL_50dB)) : 4.0f;
 }
+#endif
 
 // This is a limit due to network encoding.
 // It encodes attenuation * 64 in 8 bits, so the maximum is (255 / 64)


### PR DESCRIPTION
Fixes a regression in the latest update which causes compilation to fail on VS2013.

This branch will be rebased.