### PR TITLE
Fix antlions using wrong angles for dynamic interactions

### DIFF
--- a/sp/src/game/server/hl2/npc_antlion.cpp
+++ b/sp/src/game/server/hl2/npc_antlion.cpp
@@ -378,13 +378,14 @@ void CNPC_Antlion::Spawn( void )
 
 		sInteraction01.vecRelativeOrigin = Vector(224, 0, 0);
 		sInteraction01.angRelativeAngles = QAngle(0, 180, 0);
-		//sInteraction01.iFlags |= SCNPC_FLAG_TEST_OTHER_ANGLES;
+		sInteraction01.iFlags |= SCNPC_FLAG_TEST_OTHER_ANGLES;
 		sInteraction01.iFlags |= SCNPC_FLAG_TEST_END_POSITION;
 		sInteraction01.vecRelativeEndPos = Vector(312, -10, 0);
 		sInteraction01.iTriggerMethod = SNPCINT_AUTOMATIC_IN_COMBAT;
 		sInteraction01.flDelay = 15.0f;
 		sInteraction01.iFlags |= SCNPC_FLAG_MAPBASE_ADDITION;
 		sInteraction01.flDistSqr = (8 * 8);
+		sInteraction01.flMaxAngleDiff = 180.0f; // Initiate from any angle
 
 
 		ScriptedNPCInteraction_t sInteraction02;
@@ -393,11 +394,12 @@ void CNPC_Antlion::Spawn( void )
 
 		sInteraction02.vecRelativeOrigin = Vector(64, 0, 0);
 		sInteraction02.angRelativeAngles = QAngle(0, 180, 0);
-		//sInteraction01.iFlags |= SCNPC_FLAG_TEST_OTHER_ANGLES;
+		sInteraction02.iFlags |= SCNPC_FLAG_TEST_OTHER_ANGLES;
 		sInteraction02.iTriggerMethod = SNPCINT_AUTOMATIC_IN_COMBAT;
 		sInteraction02.flDelay = 7.5f;
 		sInteraction02.iFlags |= SCNPC_FLAG_MAPBASE_ADDITION;
 		sInteraction02.flDistSqr = (8 * 8);
+		sInteraction02.flMaxAngleDiff = 180.0f; // Initiate from any angle
 
 
 		AddScriptedNPCInteraction(&sInteraction01);


### PR DESCRIPTION
In the latest update, the functionality of interactions which don't use `SCNPC_FLAG_TEST_OTHER_ANGLES` was changed to make interaction partners continue to face their current angle, rather than face the angle stored in `angRelativeAngles`. This was done because there is no interaction in stock HL2/EP1/EP2 which doesn't use `SCNPC_FLAG_TEST_OTHER_ANGLES`, and the lack of that flag shouldn't force the interaction partner face a specific angle if it's not needed for the interaction to play.

The antlion interactions previously restored by Mapbase used `angRelativeAngles`, but did not use `SCNPC_FLAG_TEST_OTHER_ANGLES`. This is a hack which wouldn't have been possible with the actual model KV interaction syntax, and was done so that they could initiate the interactions at any angle while still correctly facing each other. However, this was not adjusted after the functionality of non-`SCNPC_FLAG_TEST_OTHER_ANGLES` interactions was changed, so they no longer face each other when initiating interactions.

The new `flMaxAngleDiff` value, which was also part of the latest update, allows for `SCNPC_FLAG_TEST_OTHER_ANGLES` interactions to initiate at broader angles, so by adding `SCNPC_FLAG_TEST_OTHER_ANGLES` and just setting that value to encompass any angle, it provides a "proper" way of doing what the antlion interactions did before.

---

<!-- Replace [ ] with [x] for each item your PR satisfies -->
#### PR Checklist
- [x] **My PR follows all guidelines in the CONTRIBUTING.md file**
- [x] My PR targets a `develop` branch OR targets another branch with a specific goal in mind
