### PR TITLE
Fix dynamic interactions using "their_" keyvalues always assuming separate sequence names

### DIFF
--- a/sp/src/game/server/ai_basenpc.cpp
+++ b/sp/src/game/server/ai_basenpc.cpp
@@ -14895,22 +14895,39 @@ void CAI_BaseNPC::ParseScriptedNPCInteractions(void)
 						else if (!Q_strncmp(szName, "their_", 6))
 						{
 							const char *szTheirName = szName + 6;
-							sInteraction.bHasSeparateSequenceNames = true;
 
 							if (!Q_strncmp(szTheirName, "entry_sequence", 14))
+							{
+								sInteraction.bHasSeparateSequenceNames = true;
 								sInteraction.sTheirPhases[SNPCINT_ENTRY].iszSequence = AllocPooledString(szValue);
+							}
 							else if (!Q_strncmp(szTheirName, "entry_activity", 14))
+							{
+								sInteraction.bHasSeparateSequenceNames = true;
 								sInteraction.sTheirPhases[SNPCINT_ENTRY].iActivity = GetOrRegisterActivity(szValue);
+							}
 
 							else if (!Q_strncmp(szTheirName, "sequence", 8))
+							{
+								sInteraction.bHasSeparateSequenceNames = true;
 								sInteraction.sTheirPhases[SNPCINT_SEQUENCE].iszSequence = AllocPooledString(szValue);
+							}
 							else if (!Q_strncmp(szTheirName, "activity", 8))
+							{
+								sInteraction.bHasSeparateSequenceNames = true;
 								sInteraction.sTheirPhases[SNPCINT_SEQUENCE].iActivity = GetOrRegisterActivity(szValue);
+							}
 
 							else if (!Q_strncmp(szTheirName, "exit_sequence", 13))
+							{
+								sInteraction.bHasSeparateSequenceNames = true;
 								sInteraction.sTheirPhases[SNPCINT_EXIT].iszSequence = AllocPooledString(szValue);
+							}
 							else if (!Q_strncmp(szTheirName, "exit_activity", 13))
+							{
+								sInteraction.bHasSeparateSequenceNames = true;
 								sInteraction.sTheirPhases[SNPCINT_EXIT].iActivity = GetOrRegisterActivity(szValue);
+							}
 
 							// Add anything else to our miscellaneous criteria
 							else


### PR DESCRIPTION
The latest update added support for interaction partners to use separate sequence names. This involves a new boolean value which is enabled if any separate sequence name keyvalues are parsed. However, there was an oversight in which this boolean value was enabled when any keyvalue starting with `their_` is parsed, such as `their_healthfrac`. This PR fixes that and only enables the boolean value when the activity or sequence keyvalues are used.

This issue mainly causes problems for interactions which use activities instead of sequence names, as the activities will select different sequences between the two interaction participants.

---

<!-- Replace [ ] with [x] for each item your PR satisfies -->
#### PR Checklist
- [x] **My PR follows all guidelines in the CONTRIBUTING.md file**
- [x] My PR targets a `develop` branch OR targets another branch with a specific goal in mind
