### PR TITLE
Fix vertex blend swapping in Hammer for SDK_LightmappedGeneric

### DIFF
--- a/sp/src/materialsystem/stdshaders/lightmappedgeneric_dx9_helper.cpp
+++ b/sp/src/materialsystem/stdshaders/lightmappedgeneric_dx9_helper.cpp
@@ -1537,7 +1537,7 @@ void DrawLightmappedGeneric_DX9_Internal(CBaseVSShader *pShader, IMaterialVar** 
 				float envMapOrigin[4] = {0,0,0,0};
 				params[info.m_nEnvmapOrigin]->GetVecValue( envMapOrigin, 3 );
 #ifdef MAPBASE
-				envMapOrigin[4] = bEditorBlend ? 1.0f : 0.0f;
+				envMapOrigin[3] = bEditorBlend ? 1.0f : 0.0f;
 #endif
 				pContextData->m_SemiStaticCmdsOut.SetPixelShaderConstant( 21, envMapOrigin );
 


### PR DESCRIPTION
Out of bounds array index corrupting the stack

(Describe your PR here and then fill out the checklist at the bottom)

---

#### Does this PR close any issues?
* (Optional) Insert issue number(s) and any related info here

<!-- Replace [ ] with [x] for each item your PR satisfies -->
#### PR Checklist
- [X] **My PR follows all guidelines in the CONTRIBUTING.md file**
- [X] My PR targets a `develop` branch OR targets another branch with a specific goal in mind
