### PR TITLE
Add capability to +USE serverside ragdolls and toggle cleanup of individual ragdolls

### DIFF
--- a/sp/src/game/server/physics_prop_ragdoll.h
+++ b/sp/src/game/server/physics_prop_ragdoll.h
@@ -42,6 +42,10 @@ public:
 
 	int ObjectCaps();
 
+#ifdef MAPBASE
+	void Use( CBaseEntity *pActivator, CBaseEntity *pCaller, USE_TYPE useType, float value );
+#endif
+
 	DECLARE_SERVERCLASS();
 	// Don't treat as a live target
 	virtual bool IsAlive( void ) { return false; }
@@ -113,6 +117,8 @@ public:
 #ifdef MAPBASE
 	void			InputWake( inputdata_t &inputdata );
 	void			InputSleep( inputdata_t &inputdata );
+	void			InputAddToLRU( inputdata_t &inputdata );
+	void			InputRemoveFromLRU( inputdata_t &inputdata );
 #endif
 	void			InputTurnOn( inputdata_t &inputdata );
 	void			InputTurnOff( inputdata_t &inputdata );
@@ -157,6 +163,10 @@ private:
 
 	string_t			m_strSourceClassName;
 	bool				m_bHasBeenPhysgunned;
+
+#ifdef MAPBASE
+	COutputEvent		m_OnPlayerUse;
+#endif
 
 	// If not 1, then allow underlying sequence to blend in with simulated bone positions
 	CNetworkVar( float, m_flBlendWeight );

--- a/sp/src/game/shared/ragdoll_shared.cpp
+++ b/sp/src/game/shared/ragdoll_shared.cpp
@@ -1178,6 +1178,32 @@ void CRagdollLRURetirement::MoveToTopOfLRU( CBaseAnimating *pRagdoll, bool bImpo
 #endif
 }
 
+#ifdef MAPBASE
+//-----------------------------------------------------------------------------
+// Remove it from the LRU
+//-----------------------------------------------------------------------------
+void CRagdollLRURetirement::RemoveFromLRU( CBaseAnimating *pRagdoll )
+{
+	for (int i = 0; i < m_LRU.Count(); i++)
+	{
+		if (m_LRU[i].Get() == pRagdoll)
+		{
+			m_LRU.Remove( i );
+			return;
+		}
+	}
+	
+	for (int i = 0; i < m_LRUImportantRagdolls.Count(); i++)
+	{
+		if (m_LRUImportantRagdolls[i].Get() == pRagdoll)
+		{
+			m_LRUImportantRagdolls.Remove( i );
+			return;
+		}
+	}
+}
+#endif
+
 
 //EFFECT/ENTITY TRANSFERS
 

--- a/sp/src/game/shared/ragdoll_shared.h
+++ b/sp/src/game/shared/ragdoll_shared.h
@@ -114,8 +114,9 @@ public:
 	virtual void FrameUpdatePostEntityThink( void );
 
 	// Move it to the top of the LRU
-#ifdef MAPBASE // From Alien Swarm SDK
-	void MoveToTopOfLRU( CBaseAnimating *pRagdoll, bool bImportant = false, float flForcedRetireTime = 0.0f );
+#ifdef MAPBASE
+	void MoveToTopOfLRU( CBaseAnimating *pRagdoll, bool bImportant = false, float flForcedRetireTime = 0.0f ); // From Alien Swarm SDK
+	void RemoveFromLRU( CBaseAnimating *pRagdoll );
 #else
 	void MoveToTopOfLRU( CBaseAnimating *pRagdoll, bool bImportant = false );
 #endif


### PR DESCRIPTION
This PR adds two new spawnflags to `prop_ragdoll` to enable +USE and prevent pickup, respectively. When a ragdoll has +USE enabled, the player will be able to grab a limb and drag it around. This uses the same framework as the mega physcannon, although pickup forces will only use the strength of the carried limb, rather than the strength of the entire bone hierarchy. The other spawnflag disables picking up the ragdoll even when +USE is enabled, and is intended for situations where a ragdoll should be useable but should not be picked up. An `OnPlayerUse` output is also included, and it fires every time the ragdoll is +USE'd regardless of whether it is picked up. A new cvar, `ragdoll_always_allow_use`, allows all ragdolls to be +USE'd regardless of the spawnflag, which may be useful if you're making a game or mod centered around this mechanic. This cvar is disabled by default.

This PR also includes two new inputs: `AddToLRU` and `RemoveFromLRU`. "LRU" stands for "Least Recently Used", and in this case it's referring to Source's ragdoll cleanup system, which automatically removes ragdolls which haven't been used. Serverside ragdolls spawned by NPCs are automatically added to this system, while `prop_ragdoll`s spawned by the map are not. You can use the `AddToLRU` input to add any ragdoll to this system, or the `RemoveFromLRU` input to remove a ragdoll from this system. This is useful when you want a ragdoll created by a NPC to linger, or if you want a ragdoll created by the map to be treated as a regular NPC ragdoll.

---

<!-- Replace [ ] with [x] for each item your PR satisfies -->
#### PR Checklist
- [x] **My PR follows all guidelines in the CONTRIBUTING.md file**
- [x] My PR targets a `develop` branch OR targets another branch with a specific goal in mind
