### PR TITLE
Fix autocubemap crashing when not in a level

### DIFF
--- a/sp/src/game/client/mapbase/mapbase_autocubemap.cpp
+++ b/sp/src/game/client/mapbase/mapbase_autocubemap.cpp
@@ -125,6 +125,12 @@ public:
 			//Msg("No maps to cubemap with!\n");
 			//return;
 
+			if (C_BasePlayer::GetLocalPlayer() == NULL)
+			{
+				Msg( "Must be in a level (or have a loaded map list) to begin autocubemap\n" );
+				return;
+			}
+
 			// Just do this map
 			m_AutoCubemapMaps.AddToTail( strdup( g_MapName ) );
 		}


### PR DESCRIPTION
This fixes a bug in which running `autocubemap_start` would crash the game if there is no map or map list loaded.

---

#### Does this PR close any issues?
* https://github.com/mapbase-source/source-sdk-2013/issues/296

<!-- Replace [ ] with [x] for each item your PR satisfies -->
#### PR Checklist
- [x] **My PR follows all guidelines in the CONTRIBUTING.md file**
- [x] My PR targets a `develop` branch OR targets another branch with a specific goal in mind
