### PR TITLE
Primitive chromatic aberration effect for env_screeneffect

### DIFF
--- a/sp/src/game/client/c_env_screenoverlay.cpp
+++ b/sp/src/game/client/c_env_screenoverlay.cpp
@@ -219,6 +219,11 @@ enum
 	SCREENEFFECT_EP2_ADVISOR_STUN,
 	SCREENEFFECT_EP1_INTRO,
 	SCREENEFFECT_EP2_GROGGY,
+
+#ifdef MAPBASE
+	SCREENEFFECT_MAPBASE_CHROMATIC_BLUR = 100,			// Overlays 3 different frames of red, green, and blue tints respectively with different offsets
+	SCREENEFFECT_MAPBASE_CHROMATIC_ABERRATION,			// Similar to above, except it stretches frames in addition to offsetting them
+#endif
 };
 
 // ============================================================================
@@ -303,6 +308,21 @@ void C_EnvScreenEffect::ReceiveMessage( int classID, bf_read &msg )
 					g_pScreenSpaceEffects->SetScreenSpaceEffectParams( "ep2_groggy", pKeys );
 					g_pScreenSpaceEffects->EnableScreenSpaceEffect( "ep2_groggy" );
 				}
+#ifdef MAPBASE
+				else if ( m_nType == SCREENEFFECT_MAPBASE_CHROMATIC_BLUR || m_nType == SCREENEFFECT_MAPBASE_CHROMATIC_ABERRATION )
+				{
+					if( g_pMaterialSystemHardwareConfig->GetDXSupportLevel() < 80 )
+						return;
+
+					// Set our keys
+					pKeys->SetFloat( "duration", m_flDuration );
+					pKeys->SetInt( "fadeout", 0 );
+					pKeys->SetInt( "stretch", m_nType == SCREENEFFECT_MAPBASE_CHROMATIC_ABERRATION );
+
+					g_pScreenSpaceEffects->SetScreenSpaceEffectParams( "mapbase_chromatic_aberration", pKeys );
+					g_pScreenSpaceEffects->EnableScreenSpaceEffect( "mapbase_chromatic_aberration" );
+				}
+#endif
                 
 				pKeys->deleteThis();
 			}
@@ -349,6 +369,25 @@ void C_EnvScreenEffect::ReceiveMessage( int classID, bf_read &msg )
 
 				g_pScreenSpaceEffects->SetScreenSpaceEffectParams( "ep2_groggy", pKeys );
 			}
+#ifdef MAPBASE
+			else if ( m_nType == SCREENEFFECT_MAPBASE_CHROMATIC_BLUR || m_nType == SCREENEFFECT_MAPBASE_CHROMATIC_ABERRATION )
+			{
+				if( g_pMaterialSystemHardwareConfig->GetDXSupportLevel() < 80 )
+					return;
+
+				// Create a keyvalue block to set these params
+				KeyValues *pKeys = new KeyValues( "keys" );
+				if ( pKeys == NULL )
+					return;
+
+				// Set our keys
+				pKeys->SetFloat( "duration", m_flDuration );
+				pKeys->SetInt( "fadeout", 1 );
+				pKeys->SetInt( "stretch", m_nType == SCREENEFFECT_MAPBASE_CHROMATIC_ABERRATION );
+
+				g_pScreenSpaceEffects->SetScreenSpaceEffectParams( "mapbase_chromatic_aberration", pKeys );
+			}
+#endif
 
 			break;
 	}

--- a/sp/src/game/client/episodic/episodic_screenspaceeffects.h
+++ b/sp/src/game/client/episodic/episodic_screenspaceeffects.h
@@ -116,4 +116,38 @@ private:
 
 ADD_SCREENSPACE_EFFECT( CEP2StunEffect, ep2_groggy );
 
+#ifdef MAPBASE
+class CChromaticAberrationEffect : public IScreenSpaceEffect
+{
+public:
+	CChromaticAberrationEffect( void ) :
+		m_flDuration( 0.0f ), 
+		m_flFinishTime( 0.0f ), 
+		m_bUpdateView( true ),
+		m_bEnabled( false ),
+		m_bFadeOut( false ) {}
+
+	virtual void Init( void );
+	virtual void Shutdown( void );
+	virtual void SetParameters( KeyValues *params );
+	virtual void Enable( bool bEnable ) { m_bEnabled = bEnable; };
+	virtual bool IsEnabled( ) { return m_bEnabled; }
+
+	virtual void RenderColorFrame( CMatRenderContextPtr &pRenderContext, float flEffectPerc, int nColorMode, int x, int y, int w, int h );
+	virtual void Render( int x, int y, int w, int h );
+
+private:
+	CTextureReference m_StunTexture;
+	CMaterialReference m_EffectMaterial;
+	float		m_flDuration;
+	float		m_flFinishTime;
+	bool		m_bUpdateView;
+	bool		m_bStretch;
+	bool		m_bFadeOut;
+	bool		m_bEnabled;
+};
+
+ADD_SCREENSPACE_EFFECT( CChromaticAberrationEffect, mapbase_chromatic_aberration );
+#endif
+
 #endif // EPISODIC_SCREENSPACEEFFECTS_H


### PR DESCRIPTION
This PR adds two new effect types: **Chromatic Blur** and **Chromatic Aberration**. The former overlays 3 different frames of red, green, and blue tints respectively with different offsets. The latter does the same thing, but stretches the frames to distort colors based on how far away they are from the middle of the screen. Parameters like the offset or tint of each frame can be modified via cvars prefixed by `r_chromatic_aberration`. The effects themselves are controlled by `env_screeneffect`, and they start at `100` to avoid conflicts with any potential mod effects.

Note that I am not experienced with post-processing elements and there are likely better ways of programming these effects. I originally developed these for an Entropy : Zero-related project, but I decided to try bringing them to Mapbase because a generic chromatic aberration effect could come in handy for other designers.

---

### No effect active:
![mapbase_demo010000](https://github.com/mapbase-source/source-sdk-2013/assets/19228257/014ed935-7836-4040-8b9e-40c863ba5772)

### Chromatic Blur:
![mapbase_demo010001](https://github.com/mapbase-source/source-sdk-2013/assets/19228257/7ff0537e-8777-4712-87a0-96e7fc2ee899)

### Chromatic Aberration:
![mapbase_demo010002](https://github.com/mapbase-source/source-sdk-2013/assets/19228257/b5e5633e-236c-4f2f-a8d4-ce69a290cf67)


---

<!-- Replace [ ] with [x] for each item your PR satisfies -->
#### PR Checklist
- [x] **My PR follows all guidelines in the CONTRIBUTING.md file**
- [x] My PR targets a `develop` branch OR targets another branch with a specific goal in mind
