### PR TITLE
Fix maps with multiple sky_cameras not using the correct sky_camera after loading a save

### DIFF
--- a/sp/src/game/server/SkyCamera.cpp
+++ b/sp/src/game/server/SkyCamera.cpp
@@ -211,6 +211,11 @@ void CSkyCamera::Activate( )
 		}
 	}
 #endif
+
+#ifdef MAPBASE
+	if (HasSpawnFlags( SF_SKY_MASTER ))
+		g_hActiveSkybox = this;
+#endif
 }
 
 #ifdef MAPBASE
@@ -368,9 +373,11 @@ void CSkyCamera::InputActivateSkybox( inputdata_t &inputdata )
 		// Deactivate that skybox
 		pActiveSky->SetThink( NULL );
 		pActiveSky->SetNextThink( TICK_NEVER_THINK );
+		pActiveSky->RemoveSpawnFlags( SF_SKY_MASTER );
 	}
 
 	g_hActiveSkybox = this;
+	AddSpawnFlags( SF_SKY_MASTER );
 
 	if (HasSpawnFlags( SF_SKY_START_UPDATING ))
 		InputStartUpdating( inputdata );
@@ -384,6 +391,7 @@ void CSkyCamera::InputDeactivateSkybox( inputdata_t &inputdata )
 	if (GetCurrentSkyCamera() == this)
 	{
 		g_hActiveSkybox = NULL;
+		RemoveSpawnFlags( SF_SKY_MASTER );
 
 		// ClientData doesn't catch this immediately
 		CBasePlayer *pPlayer = NULL;


### PR DESCRIPTION
This PR fixes maps not using the correct `sky_camera` after loading a save. This issue occurred because the active `sky_camera` is currently based on a static handle variable, which doesn't save with the game. This PR fixes this by always associating the active `sky_camera` with the "Master" spawnflag, which does restore after loading a save. Then, when a save is loaded, the `sky_camera` with the "Master" spawnflag is assigned as the active skybox.

---

<!-- Replace [ ] with [x] for each item your PR satisfies -->
#### PR Checklist
- [x] **My PR follows all guidelines in the CONTRIBUTING.md file**
- [x] My PR targets a `develop` branch OR targets another branch with a specific goal in mind
