### PR TITLE
Fixed BlurFilterY uses width instead of height

### DIFF
--- a/sp/src/materialsystem/stdshaders/BlurFilterY.cpp
+++ b/sp/src/materialsystem/stdshaders/BlurFilterY.cpp
@@ -85,7 +85,7 @@ BEGIN_VS_SHADER_FLAGS( BlurFilterY, "Help for BlurFilterY", SHADER_NOT_EDITABLE 
 
 			// The temp buffer is 1/4 back buffer size
 			ITexture *src_texture = params[BASETEXTURE]->GetTextureValue();
-			int height = src_texture->GetActualWidth();
+			int height = src_texture->GetActualHeight();
 			float dY = 1.0f / height;
 //			dY *= 0.4;
 			float v[4];


### PR DESCRIPTION
Now height variable uses GetActualHeight() instead of GetActualWidth() on line 88 in BlurFilterY.cpp.

---

#### Does this PR close any issues?
Yes, it fixed #265 

<!-- Replace [ ] with [x] for each item your PR satisfies -->
#### PR Checklist
- [x] **My PR follows all guidelines in the CONTRIBUTING.md file**
- [x] My PR targets a `develop` branch OR targets another branch with a specific goal in mind
