### PR TITLE
Spotlight "Ignore solid" keyvalue from MP branch

### DIFF
--- a/sp/src/game/server/point_spotlight.cpp
+++ b/sp/src/game/server/point_spotlight.cpp
@@ -62,6 +62,7 @@ private:
 private:
 	bool	m_bSpotlightOn;
 	bool	m_bEfficientSpotlight;
+	bool	m_bIgnoreSolid;
 	Vector	m_vSpotlightTargetPos;
 	Vector	m_vSpotlightCurrentPos;
 	Vector	m_vSpotlightDir;
@@ -100,6 +101,7 @@ BEGIN_DATADESC( CPointSpotlight )
 	DEFINE_FIELD( m_vSpotlightDir,			FIELD_VECTOR ),
 	DEFINE_FIELD( m_nHaloSprite,			FIELD_INTEGER ),
 
+	DEFINE_KEYFIELD( m_bIgnoreSolid, FIELD_BOOLEAN, "IgnoreSolid" ),
 	DEFINE_KEYFIELD( m_flSpotlightMaxLength,FIELD_FLOAT, "SpotlightLength"),
 	DEFINE_KEYFIELD( m_flSpotlightGoalWidth,FIELD_FLOAT, "SpotlightWidth"),
 	DEFINE_KEYFIELD( m_flHDRColorScale, FIELD_FLOAT, "HDRColorScale" ),
@@ -138,6 +140,7 @@ CPointSpotlight::CPointSpotlight()
 #endif
 	m_flHDRColorScale = 1.0f;
 	m_nMinDXLevel = 0;
+	m_bIgnoreSolid = false;
 #ifdef MAPBASE
 	m_flHaloScale = 60.0f;
 #endif
@@ -380,12 +383,21 @@ void CPointSpotlight::SpotlightCreate(void)
 
 	AngleVectors( GetAbsAngles(), &m_vSpotlightDir );
 
-	trace_t tr;
-	UTIL_TraceLine( GetAbsOrigin(), GetAbsOrigin() + m_vSpotlightDir * m_flSpotlightMaxLength, MASK_SOLID_BRUSHONLY, this, COLLISION_GROUP_NONE, &tr);
+	Vector vTargetPos;
+	if ( m_bIgnoreSolid )
+	{
+		vTargetPos = GetAbsOrigin() + m_vSpotlightDir * m_flSpotlightMaxLength;
+	}
+	else
+	{
+		trace_t tr;
+		UTIL_TraceLine( GetAbsOrigin(), GetAbsOrigin() + m_vSpotlightDir * m_flSpotlightMaxLength, MASK_SOLID_BRUSHONLY, this, COLLISION_GROUP_NONE, &tr );
+		vTargetPos = tr.endpos;
+	}
 
 	m_hSpotlightTarget = (CSpotlightEnd*)CreateEntityByName( "spotlight_end" );
 	m_hSpotlightTarget->Spawn();
-	m_hSpotlightTarget->SetAbsOrigin( tr.endpos );
+	m_hSpotlightTarget->SetAbsOrigin( vTargetPos );
 	m_hSpotlightTarget->SetOwnerEntity( this );
 	m_hSpotlightTarget->m_clrRender = m_clrRender;
 	m_hSpotlightTarget->m_Radius = m_flSpotlightMaxLength;
@@ -437,9 +449,17 @@ Vector CPointSpotlight::SpotlightCurrentPos(void)
 	AngleVectors( GetAbsAngles(), &m_vSpotlightDir );
 
 	//	Get beam end point.  Only collide with solid objects, not npcs
-	trace_t tr;
-	UTIL_TraceLine( GetAbsOrigin(), GetAbsOrigin() + (m_vSpotlightDir * 2 * m_flSpotlightMaxLength), MASK_SOLID_BRUSHONLY, this, COLLISION_GROUP_NONE, &tr );
-	return tr.endpos;
+	Vector vEndPos = GetAbsOrigin() + ( m_vSpotlightDir * 2 * m_flSpotlightMaxLength );
+	if ( m_bIgnoreSolid )
+	{
+		return vEndPos;
+	}
+	else
+	{
+		trace_t tr;
+		UTIL_TraceLine( GetAbsOrigin(), vEndPos, MASK_SOLID_BRUSHONLY, this, COLLISION_GROUP_NONE, &tr );
+		return tr.endpos;
+	}
 }
 
 //------------------------------------------------------------------------------


### PR DESCRIPTION
This PR adds the "Ignore solid" keyvalue on `point_spotlight`, ported directly from the MP branch. This keyvalue allows a spotlight to trace through the ground.

---

<!-- Replace [ ] with [x] for each item your PR satisfies -->
#### PR Checklist
- [x] **My PR follows all guidelines in the CONTRIBUTING.md file**
- [x] My PR targets a `develop` branch OR targets another branch with a specific goal in mind
