### PR TITLE
Prevent return of dangling Vector/QAngle to VScript

### DIFF
--- a/sp/src/game/server/BaseAnimatingOverlay.cpp
+++ b/sp/src/game/server/BaseAnimatingOverlay.cpp
@@ -16,6 +16,10 @@
 #include "saverestore_utlvector.h"
 #include "dt_utlvector_send.h"
 
+#ifdef MAPBASE_VSCRIPT
+#include "mapbase/vscript_funcs_shared.h"
+#endif
+
 // memdbgon must be the last include file in a .cpp file!!!
 #include "tier0/memdbgon.h"
 
@@ -471,7 +475,8 @@ void CAnimationLayer::DispatchAnimEvents( CBaseAnimating *eventHandler, CBaseAni
 		}
 
 #ifdef MAPBASE_VSCRIPT
-		if (eventHandler->m_ScriptScope.IsInitialized() && eventHandler->ScriptHookHandleAnimEvent( &event ) == false)
+		scriptanimevent_t wrapper( event );
+		if (eventHandler->m_ScriptScope.IsInitialized() && !eventHandler->ScriptHookHandleAnimEvent( wrapper ))
 			continue;
 #endif
 

--- a/sp/src/game/server/baseanimating.cpp
+++ b/sp/src/game/server/baseanimating.cpp
@@ -1261,7 +1261,8 @@ void CBaseAnimating::DispatchAnimEvents ( CBaseAnimating *eventHandler )
 		}
 
 #ifdef MAPBASE_VSCRIPT
-		if (eventHandler->ScriptHookHandleAnimEvent( &event ) == false)
+		scriptanimevent_t wrapper( event );
+		if (!eventHandler->ScriptHookHandleAnimEvent( wrapper ))
 			continue;
 #endif
 
@@ -1299,11 +1300,11 @@ void CBaseAnimating::DispatchAnimEvents ( CBaseAnimating *eventHandler )
 //-----------------------------------------------------------------------------
 // Purpose: 
 //-----------------------------------------------------------------------------
-bool CBaseAnimating::ScriptHookHandleAnimEvent( animevent_t *pEvent )
+bool CBaseAnimating::ScriptHookHandleAnimEvent( scriptanimevent_t &event )
 {
 	if (m_ScriptScope.IsInitialized() && g_Hook_HandleAnimEvent.CanRunInScope(m_ScriptScope))
 	{
-		HSCRIPT hEvent = g_pScriptVM->RegisterInstance( reinterpret_cast<scriptanimevent_t*>(pEvent) );
+		HSCRIPT hEvent = g_pScriptVM->RegisterInstance( &event );
 
 		// event
 		ScriptVariant_t args[] = { hEvent };

--- a/sp/src/game/server/baseanimating.h
+++ b/sp/src/game/server/baseanimating.h
@@ -16,6 +16,9 @@
 #include "datacache/idatacache.h"
 #include "tier0/threadtools.h"
 
+#ifdef MAPBASE_VSCRIPT
+struct scriptanimevent_t;
+#endif
 
 struct animevent_t;
 struct matrix3x4_t;
@@ -146,7 +149,7 @@ public:
 	virtual	void DispatchAnimEvents ( CBaseAnimating *eventHandler ); // Handle events that have happend since last time called up until X seconds into the future
 	virtual void HandleAnimEvent( animevent_t *pEvent );
 #ifdef MAPBASE_VSCRIPT
-	bool ScriptHookHandleAnimEvent( animevent_t *pEvent );
+	bool ScriptHookHandleAnimEvent( scriptanimevent_t &event );
 #endif
 
 	int		LookupPoseParameter( CStudioHdr *pStudioHdr, const char *szName );

--- a/sp/src/game/server/hl2/proto_sniper.cpp
+++ b/sp/src/game/server/hl2/proto_sniper.cpp
@@ -2645,16 +2645,19 @@ Vector CProtoSniper::DesiredBodyTarget( CBaseEntity *pTarget )
 {
 	// By default, aim for the center
 	Vector vecTarget = pTarget->WorldSpaceCenter();
+	const Vector vecBulletOrigin = GetBulletOrigin();
 
 #ifdef MAPBASE_VSCRIPT
-	if (m_ScriptScope.IsInitialized() && g_Hook_GetActualShootPosition.CanRunInScope(m_ScriptScope))
+	if ( m_ScriptScope.IsInitialized() && g_Hook_GetActualShootPosition.CanRunInScope( m_ScriptScope ) )
 	{
 		ScriptVariant_t functionReturn;
-		ScriptVariant_t args[] = { GetBulletOrigin(), ToHScript( pTarget ) };
-		if (g_Hook_GetActualShootPosition.Call( m_ScriptScope, &functionReturn, args ))
+		ScriptVariant_t args[] = { vecBulletOrigin, ToHScript( pTarget ) };
+		if ( g_Hook_GetActualShootPosition.Call( m_ScriptScope, &functionReturn, args ) )
 		{
-			if (functionReturn.m_type == FIELD_VECTOR && functionReturn.m_pVector->LengthSqr() != 0.0f)
+			if ( functionReturn.m_type == FIELD_VECTOR && functionReturn.m_pVector->LengthSqr() != 0.0f )
+			{
 				return *functionReturn.m_pVector;
+			}
 		}
 	}
 #endif
@@ -2682,12 +2685,12 @@ Vector CProtoSniper::DesiredBodyTarget( CBaseEntity *pTarget )
 		{
 			if( flTimeSinceLastMiss > 0.0f && flTimeSinceLastMiss < 4.0f && hl2_episodic.GetBool() )
 			{
-				vecTarget = pTarget->BodyTarget( GetBulletOrigin(), false );
+				vecTarget = pTarget->BodyTarget( vecBulletOrigin, false );
 			}
 			else
 			{
 				// Shoot zombies in the headcrab
-				vecTarget = pTarget->HeadTarget( GetBulletOrigin() );
+				vecTarget = pTarget->HeadTarget( vecBulletOrigin );
 			}
 		}
 		else if( pTarget->Classify() == CLASS_ANTLION )

--- a/sp/src/game/shared/mapbase/vscript_consts_shared.cpp
+++ b/sp/src/game/shared/mapbase/vscript_consts_shared.cpp
@@ -346,7 +346,8 @@ void RegisterSharedScriptConstants()
 	ScriptRegisterConstant( g_pScriptVM, ROPE_NO_GRAVITY, "Disable gravity on this rope. (for use in rope flags)" );
 	ScriptRegisterConstant( g_pScriptVM, ROPE_NUMFLAGS, "The number of rope flags recognized by the game." );
 
-	ScriptRegisterConstantNamed( g_pScriptVM, Vector( ROPE_GRAVITY ), "ROPE_GRAVITY", "Default rope gravity vector." );
+	static Vector vecRopeGravity( ROPE_GRAVITY );
+	ScriptRegisterConstantNamed( g_pScriptVM, vecRopeGravity, "ROPE_GRAVITY", "Default rope gravity vector." );
 
 	// 
 	// Sounds

--- a/sp/src/game/shared/mapbase/vscript_funcs_shared.cpp
+++ b/sp/src/game/shared/mapbase/vscript_funcs_shared.cpp
@@ -560,16 +560,18 @@ bool CAnimEventTInstanceHelper::Set( void *p, const char *pszKey, ScriptVariant_
 
 	animevent_t *ani = ((animevent_t *)p);
 	if (FStrEq( pszKey, "event" ))
-		ani->event = variant;
+		return variant.AssignTo( &ani->event );
 	else if (FStrEq( pszKey, "options" ))
-		ani->options = variant;
+		// broken: return variant.AssignTo( &ani->options );
+		//         variant memory is freed afterwards
+		return false;
 	else if (FStrEq( pszKey, "cycle" ))
-		ani->cycle = variant;
+		return variant.AssignTo( &ani->cycle );
 	else if (FStrEq( pszKey, "eventtime" ))
-		ani->eventtime = variant;
+		return variant.AssignTo( &ani->eventtime );
 	else if (FStrEq( pszKey, "type" ))
-		ani->type = variant;
-	else if (FStrEq( pszKey, "source" ))
+		return variant.AssignTo( &ani->type );
+	else if (FStrEq( pszKey, "source" ) && variant.m_type == FIELD_HSCRIPT)
 	{
 		CBaseEntity *pEnt = ToEnt( variant.m_hScript );
 		if (pEnt)

--- a/sp/src/game/shared/mapbase/vscript_funcs_shared.cpp
+++ b/sp/src/game/shared/mapbase/vscript_funcs_shared.cpp
@@ -535,7 +535,7 @@ bool CAnimEventTInstanceHelper::Get( void *p, const char *pszKey, ScriptVariant_
 {
 	DevWarning( "VScript animevent_t.%s: animevent_t metamethod members are deprecated! Use 'script_help animevent_t' to see the correct functions.\n", pszKey );
 
-	animevent_t *ani = ((animevent_t *)p);
+	animevent_t *ani = &((scriptanimevent_t *)p)->event;
 	if (FStrEq( pszKey, "event" ))
 		variant = ani->event;
 	else if (FStrEq( pszKey, "options" ))
@@ -558,13 +558,21 @@ bool CAnimEventTInstanceHelper::Set( void *p, const char *pszKey, ScriptVariant_
 {
 	DevWarning( "VScript animevent_t.%s: animevent_t metamethod members are deprecated! Use 'script_help animevent_t' to see the correct functions.\n", pszKey );
 
-	animevent_t *ani = ((animevent_t *)p);
+	scriptanimevent_t *script_ani = ((scriptanimevent_t *)p);
+	animevent_t *ani = &script_ani->event;
 	if (FStrEq( pszKey, "event" ))
+	{
 		return variant.AssignTo( &ani->event );
+	}
 	else if (FStrEq( pszKey, "options" ))
-		// broken: return variant.AssignTo( &ani->options );
-		//         variant memory is freed afterwards
-		return false;
+	{
+		char *szOptions;
+		if (!variant.AssignTo( &szOptions ))
+		{
+			return false;
+		}
+		script_ani->SetOptions( szOptions );
+	}
 	else if (FStrEq( pszKey, "cycle" ))
 		return variant.AssignTo( &ani->cycle );
 	else if (FStrEq( pszKey, "eventtime" ))

--- a/sp/src/game/shared/mapbase/vscript_funcs_shared.h
+++ b/sp/src/game/shared/mapbase/vscript_funcs_shared.h
@@ -172,30 +172,47 @@ private:
 //-----------------------------------------------------------------------------
 // Exposes animevent_t to VScript
 //-----------------------------------------------------------------------------
-struct scriptanimevent_t : public animevent_t
+struct scriptanimevent_t
 {
-	int GetEvent() { return event; }
-	void SetEvent( int nEvent ) { event = nEvent; }
+	friend class CAnimEventTInstanceHelper;
 
-	const char *GetOptions() { return options; }
-	void SetOptions( const char *pOptions ) { options = pOptions; }
+public:
+	scriptanimevent_t( animevent_t &event ) : event( event ), options( NULL ) { }
+	~scriptanimevent_t( ) { delete[] options; }
 
-	float GetCycle() { return cycle; }
-	void SetCycle( float flCycle ) { cycle = flCycle; }
+	int GetEvent() { return event.event; }
+	void SetEvent( int nEvent ) { event.event = nEvent; }
 
-	float GetEventTime() { return eventtime; }
-	void SetEventTime( float flEventTime ) { eventtime = flEventTime; }
+	const char *GetOptions() { return event.options; }
+	void SetOptions( const char *pOptions )
+	{
+		size_t len = strlen( pOptions );
+		delete[] options;
+		event.options = options = new char[len + 1];
+		memcpy( options, pOptions, len + 1 );
+	}
 
-	int GetType() { return type; }
-	void SetType( int nType ) { eventtime = type; }
+	float GetCycle() { return event.cycle; }
+	void SetCycle( float flCycle ) { event.cycle = flCycle; }
 
-	HSCRIPT GetSource() { return ToHScript( pSource ); }
+	float GetEventTime() { return event.eventtime; }
+	void SetEventTime( float flEventTime ) { event.eventtime = flEventTime; }
+
+	int GetType() { return event.type; }
+	void SetType( int nType ) { event.type = nType; }
+
+	HSCRIPT GetSource() { return ToHScript( event.pSource ); }
 	void SetSource( HSCRIPT hSource )
 	{
 		CBaseEntity *pEnt = ToEnt( hSource );
 		if (pEnt)
-			pSource = pEnt->GetBaseAnimating();
+			event.pSource = pEnt->GetBaseAnimating();
 	}
+
+private:
+	animevent_t &event;
+	// storage for ScriptVariant_t string, which may be temporary
+	char *options;
 };
 
 class CAnimEventTInstanceHelper : public IScriptInstanceHelper

--- a/sp/src/public/vscript/ivscript.h
+++ b/sp/src/public/vscript/ivscript.h
@@ -300,7 +300,8 @@ enum ScriptFuncBindingFlags_t
 	SF_MEMBER_FUNC	= 0x01,
 };
 
-typedef bool (*ScriptBindingFunc_t)( void *pFunction, void *pContext, ScriptVariant_t *pArguments, int nArguments, ScriptVariant_t *pReturn );
+union ScriptVariantTemporaryStorage_t;
+typedef bool (*ScriptBindingFunc_t)( void *pFunction, void *pContext, ScriptVariant_t *pArguments, int nArguments, ScriptVariant_t *pReturn, ScriptVariantTemporaryStorage_t &temporaryReturnStorage );
 
 struct ScriptFunctionBinding_t
 {
@@ -389,52 +390,17 @@ struct ScriptVariant_t
 	ScriptVariant_t( bool val ) :			m_flags( 0 ), m_type( FIELD_BOOLEAN )	{ m_bool = val; }
 	ScriptVariant_t( HSCRIPT val ) :		m_flags( 0 ), m_type( FIELD_HSCRIPT )	{ m_hScript = val; }
 
-	ScriptVariant_t( const Vector &val, bool bCopy = false ) : m_flags( 0 ), m_type( FIELD_VECTOR )
-	{
-		if ( !bCopy )
-		{
-			m_pVector = &val;
-		}
-		else
-		{
-			m_pVector = (Vector*)malloc( sizeof( Vector ) );
-			new ( (Vector*)m_pVector ) Vector( val );
-			m_flags |= SV_FREE;
-		}
-	}
-	ScriptVariant_t( const Vector *val, bool bCopy = false ) : ScriptVariant_t( *val ) { }
+	ScriptVariant_t( const Vector &val ) : m_flags( 0 ), m_type( FIELD_VECTOR ) { m_pVector = &val; }
+	ScriptVariant_t( const Vector *val ) : ScriptVariant_t( *val ) { }
 
-	ScriptVariant_t( const char *val , bool bCopy = false ) : m_flags( 0 ), m_type( FIELD_CSTRING )
-	{
-		if ( !bCopy )
-		{
-			m_pszString = val;
-		}
-		else
-		{
-			m_pszString = strdup( val );
-			m_flags |= SV_FREE;
-		}
-	}
+	ScriptVariant_t( const char *val ) : m_flags( 0 ), m_type( FIELD_CSTRING ) { m_pszString = val; }
 
 #ifdef MAPBASE_VSCRIPT
-	ScriptVariant_t( const QAngle &val, bool bCopy = false ) : m_flags( 0 ), m_type( FIELD_VECTOR )
-	{
-		if ( !bCopy )
-		{
-			m_pAngle = &val;
-		}
-		else
-		{
-			m_pAngle = (QAngle*)malloc( sizeof( QAngle ) );
-			new ( (QAngle*)m_pAngle ) QAngle( val );
-			m_flags |= SV_FREE;
-		}
-	}
-	ScriptVariant_t( const QAngle *val, bool bCopy = false ) : ScriptVariant_t( *val ) { }
+	ScriptVariant_t( const QAngle &val ) : m_flags( 0 ), m_type( FIELD_VECTOR ) { m_pAngle = &val; }
+	ScriptVariant_t( const QAngle *val ) : ScriptVariant_t( *val ) { }
 
-	ScriptVariant_t( Vector &&val ) : ScriptVariant_t( val, true ) { }
-	ScriptVariant_t( QAngle &&val ) : ScriptVariant_t( val, true ) { }
+	ScriptVariant_t( Vector &&val ) = delete;
+	ScriptVariant_t( QAngle &&val ) = delete;
 #endif
 
 	bool IsNull() const						{ return (m_type == FIELD_VOID ); }
@@ -442,42 +408,29 @@ struct ScriptVariant_t
 	operator int() const					{ Assert( m_type == FIELD_INTEGER );	return m_int; }
 	operator float() const					{ Assert( m_type == FIELD_FLOAT );		return m_float; }
 	operator const char *() const			{ Assert( m_type == FIELD_CSTRING );	return ( m_pszString ) ? m_pszString : ""; }
-	operator const Vector &() const			{ Assert( m_type == FIELD_VECTOR );		static Vector vecNull(0, 0, 0); return (m_pVector) ? *m_pVector : vecNull; }
+	operator const Vector &() const			{ Assert( m_type == FIELD_VECTOR );		return (m_pVector) ? *m_pVector : vec3_origin; }
 	operator char() const					{ Assert( m_type == FIELD_CHARACTER );	return m_char; }
 	operator bool() const					{ Assert( m_type == FIELD_BOOLEAN );	return m_bool; }
 	operator HSCRIPT() const				{ Assert( m_type == FIELD_HSCRIPT );	return m_hScript; }
 #ifdef MAPBASE_VSCRIPT
-	operator const QAngle &() const			{ Assert( m_type == FIELD_VECTOR );		static QAngle vecNull(0, 0, 0); return (m_pAngle) ? *m_pAngle : vecNull; }
+	operator const QAngle &() const			{ Assert( m_type == FIELD_VECTOR );		return (m_pAngle) ? *m_pAngle : vec3_angle; }
 #endif
 
-	void operator=( int i ) 				{ m_type = FIELD_INTEGER; m_int = i; }
-	void operator=( float f ) 				{ m_type = FIELD_FLOAT; m_float = f; }
-	void operator=( double f ) 				{ m_type = FIELD_FLOAT; m_float = (float)f; }
-	void operator=( const Vector &vec )		{ m_type = FIELD_VECTOR; m_pVector = &vec; }
-	void operator=( const Vector *vec )		{ m_type = FIELD_VECTOR; m_pVector = vec; }
-	void operator=( const char *psz )		{ m_type = FIELD_CSTRING; m_pszString = psz; }
-	void operator=( char c )				{ m_type = FIELD_CHARACTER; m_char = c; }
-	void operator=( bool b ) 				{ m_type = FIELD_BOOLEAN; m_bool = b; }
-	void operator=( HSCRIPT h ) 			{ m_type = FIELD_HSCRIPT; m_hScript = h; }
+	void operator=( int i ) 				{ m_type = FIELD_INTEGER; m_flags = 0; m_int = i; }
+	void operator=( float f ) 				{ m_type = FIELD_FLOAT; m_flags = 0; m_float = f; }
+	void operator=( double f ) 				{ m_type = FIELD_FLOAT; m_flags = 0; m_float = (float)f; }
+	void operator=( const Vector &vec )		{ m_type = FIELD_VECTOR; m_flags = 0; m_pVector = &vec; }
+	void operator=( const Vector *vec )		{ m_type = FIELD_VECTOR; m_flags = 0; m_pVector = vec; }
+	void operator=( const char *psz )		{ m_type = FIELD_CSTRING; m_flags = 0; m_pszString = psz; }
+	void operator=( char c )				{ m_type = FIELD_CHARACTER; m_flags = 0; m_char = c; }
+	void operator=( bool b ) 				{ m_type = FIELD_BOOLEAN; m_flags = 0; m_bool = b; }
+	void operator=( HSCRIPT h ) 			{ m_type = FIELD_HSCRIPT; m_flags = 0; m_hScript = h; }
 #ifdef MAPBASE_VSCRIPT
-	void operator=( const QAngle &vec )		{ m_type = FIELD_VECTOR; m_pAngle = &vec; }
-	void operator=( const QAngle *vec )		{ m_type = FIELD_VECTOR; m_pAngle = vec; }
+	void operator=( const QAngle &ang )		{ m_type = FIELD_VECTOR; m_flags = 0; m_pAngle = &ang; }
+	void operator=( const QAngle *ang )		{ m_type = FIELD_VECTOR; m_flags = 0; m_pAngle = ang; }
 
-	void operator=( Vector &&vec )
-	{
-		m_type = FIELD_VECTOR;
-		m_pVector = (Vector*)malloc( sizeof( Vector ) );
-		new ( (Vector*)m_pVector ) Vector( vec );
-		m_flags |= SV_FREE;
-	}
-
-	void operator=( QAngle &&ang )
-	{
-		m_type = FIELD_VECTOR;
-		m_pAngle = (QAngle*)malloc( sizeof( QAngle ) );
-		new ( (QAngle*)m_pAngle ) QAngle( ang );
-		m_flags |= SV_FREE;
-	}
+	void operator=( Vector &&vec ) = delete;
+	void operator=( QAngle &&ang ) = delete;
 #endif
 
 	void Free()
@@ -651,6 +604,16 @@ inline void ScriptVariant_t::EmplaceAllocedVector( const Vector &vec )
 
 #define SCRIPT_VARIANT_NULL ScriptVariant_t()
 
+union ScriptVariantTemporaryStorage_t
+{
+	// members must be initialized via placement-new
+	ScriptVariantTemporaryStorage_t() { }
+
+	// members must have trivial destructor, since no destructor will be invoked
+	Vector m_vec;
+	QAngle m_ang;
+};
+
 #ifdef MAPBASE_VSCRIPT
 //---------------------------------------------------------
 struct ScriptConstantBinding_t
@@ -743,7 +706,7 @@ static inline int ToConstantVariant(int value)
 // This is used for registering variants (particularly vectors) not tied to existing variables.
 // The principal difference is that m_data is initted with bCopy set to true.
 #define ScriptRegisterConstantFromTemp( pVM, constant, description )									ScriptRegisterConstantFromTempNamed( pVM, constant, #constant, description )
-#define ScriptRegisterConstantFromTempNamed( pVM, constant, scriptName, description )					do { static ScriptConstantBinding_t binding; binding.m_pszScriptName = scriptName; binding.m_pszDescription = description; binding.m_data = ScriptVariant_t( constant, true ); pVM->RegisterConstant( &binding ); } while (0)
+#define ScriptRegisterConstantFromTempNamed( pVM, constant, scriptName, description )					do { static const auto constantStorage = constant; static ScriptConstantBinding_t binding; binding.m_pszScriptName = scriptName; binding.m_pszDescription = description; binding.m_data = ScriptVariant_t( constantStorage ); pVM->RegisterConstant( &binding ); } while (0)
 
 //-----------------------------------------------------------------------------
 // 

--- a/sp/src/public/vscript/ivscript.h
+++ b/sp/src/public/vscript/ivscript.h
@@ -322,11 +322,6 @@ public:
 #ifdef MAPBASE_VSCRIPT
 	virtual bool Get( void *p, const char *pszKey, ScriptVariant_t &variant )		{ return false; }
 	virtual bool Set( void *p, const char *pszKey, ScriptVariant_t &variant )		{ return false; }
-
-	virtual ScriptVariant_t *Add( void *p, ScriptVariant_t &variant )				{ return NULL; }
-	virtual ScriptVariant_t *Subtract( void *p, ScriptVariant_t &variant )			{ return NULL; }
-	virtual ScriptVariant_t *Multiply( void *p, ScriptVariant_t &variant )			{ return NULL; }
-	virtual ScriptVariant_t *Divide( void *p, ScriptVariant_t &variant )			{ return NULL; }
 #endif
 };
 

--- a/sp/src/public/vscript/ivscript.h
+++ b/sp/src/public/vscript/ivscript.h
@@ -497,6 +497,7 @@ struct ScriptVariant_t
 
 	bool AssignTo( ScriptVariant_t *pDest )
 	{
+		pDest->Free();
 		pDest->m_type = m_type;
 		if ( m_flags & SV_FREE )
 		{

--- a/sp/src/public/vscript/ivscript.h
+++ b/sp/src/public/vscript/ivscript.h
@@ -445,52 +445,6 @@ struct ScriptVariant_t
 		free( (void*)m_pszString );
 	}
 
-	template <typename T>
-	T Get()
-	{
-		T value;
-		AssignTo( &value );
-		return value;
-	}
-
-	template <typename T>
-	bool AssignTo( T *pDest )
-	{
-		ScriptDataType_t destType = ScriptDeduceType( T );
-		if ( destType == FIELD_TYPEUNKNOWN )
-		{
-			DevWarning( "Unable to convert script variant to unknown type\n" );
-		}
-		if ( destType == m_type )
-		{
-			*pDest = *this;
-			return true;
-		}
-
-		if ( m_type != FIELD_VECTOR && m_type != FIELD_CSTRING && destType != FIELD_VECTOR && destType != FIELD_CSTRING )
-		{
-			switch ( m_type )
-			{
-			case FIELD_VOID:		*pDest = 0; break;
-			case FIELD_INTEGER:		*pDest = m_int; return true;
-			case FIELD_FLOAT:		*pDest = m_float; return true;
-			case FIELD_CHARACTER:	*pDest = m_char; return true;
-			case FIELD_BOOLEAN:		*pDest = m_bool; return true;
-			case FIELD_HSCRIPT:		*pDest = m_hScript; return true;
-			}
-		}
-		else
-		{
-			DevWarning( "No free conversion of %s script variant to %s right now\n",
-				ScriptFieldTypeName( m_type ), ScriptFieldTypeName<T>() );
-			if ( destType != FIELD_VECTOR )
-			{
-				*pDest = 0;
-			}
-		}
-		return false;
-	}
-
 	bool AssignTo( float *pDest )
 	{
 		switch( m_type )

--- a/sp/src/public/vscript/ivscript.h
+++ b/sp/src/public/vscript/ivscript.h
@@ -396,6 +396,9 @@ struct ScriptVariant_t
 #ifdef MAPBASE_VSCRIPT
 	ScriptVariant_t( const QAngle &val, bool bCopy = false ) :	m_flags( 0 ), m_type( FIELD_VECTOR )	{ if ( !bCopy ) { m_pAngle = &val; } else { m_pAngle = new QAngle( val ); m_flags |= SV_FREE; } }
 	ScriptVariant_t( const QAngle *val, bool bCopy = false ) :	m_flags( 0 ), m_type( FIELD_VECTOR )	{ if ( !bCopy ) { m_pAngle = val; } else { m_pAngle = new QAngle( *val ); m_flags |= SV_FREE; } }
+
+	ScriptVariant_t( Vector &&val ) : ScriptVariant_t( val, true ) { }
+	ScriptVariant_t( QAngle &&val ) : ScriptVariant_t( val, true ) { }
 #endif
 
 	bool IsNull() const						{ return (m_type == FIELD_VOID ); }
@@ -423,6 +426,9 @@ struct ScriptVariant_t
 #ifdef MAPBASE_VSCRIPT
 	void operator=( const QAngle &vec )		{ m_type = FIELD_VECTOR; m_pAngle = &vec; }
 	void operator=( const QAngle *vec )		{ m_type = FIELD_VECTOR; m_pAngle = vec; }
+
+	void operator=( Vector &&vec )		{ m_type = FIELD_VECTOR; m_pVector = new Vector( vec ); m_flags |= SV_FREE; }
+	void operator=( QAngle &&vec )		{ m_type = FIELD_VECTOR; m_pAngle = new QAngle( vec ); m_flags |= SV_FREE; }
 #endif
 
 	void Free()								{ if ( ( m_flags & SV_FREE ) && ( m_type == FIELD_HSCRIPT || m_type == FIELD_VECTOR || m_type == FIELD_CSTRING ) ) delete m_pszString; } // Generally only needed for return results

--- a/sp/src/public/vscript/vscript_templates.h
+++ b/sp/src/public/vscript/vscript_templates.h
@@ -337,8 +337,6 @@ inline FUNCPTR_TYPE ScriptConvertFuncPtrFromVoid( void *p )
 				return false; \
 			} \
 			*pReturn = ((FUNC_TYPE)pFunction)( SCRIPT_BINDING_ARGS_##N ); \
-			if ( pReturn->m_type == FIELD_VECTOR ) \
-				pReturn->m_pVector = new Vector(*pReturn->m_pVector); \
  			return true; \
  		} \
 	}; \
@@ -377,8 +375,6 @@ inline FUNCPTR_TYPE ScriptConvertFuncPtrFromVoid( void *p )
 				return false; \
 			} \
 			*pReturn = (((OBJECT_TYPE_PTR)(pContext))->*ScriptConvertFuncPtrFromVoid<FUNC_TYPE>(pFunction))( SCRIPT_BINDING_ARGS_##N ); \
-			if ( pReturn->m_type == FIELD_VECTOR ) \
-				pReturn->m_pVector = new Vector(*pReturn->m_pVector); \
  			return true; \
  		} \
 	}; \

--- a/sp/src/public/vscript/vscript_templates.h
+++ b/sp/src/public/vscript/vscript_templates.h
@@ -326,8 +326,8 @@ inline FUNCPTR_TYPE ScriptConvertFuncPtrFromVoid( void *p )
 	class CNonMemberScriptBinding##N \
 	{ \
 	public: \
- 		static bool Call( void *pFunction, void *pContext, ScriptVariant_t *pArguments, int nArguments, ScriptVariant_t *pReturn ) \
- 		{ \
+		static bool Call( void *pFunction, void *pContext, ScriptVariant_t *pArguments, int nArguments, ScriptVariant_t *pReturn, ScriptVariantTemporaryStorage_t &temporaryReturnStorage ) \
+		{ \
 			Assert( nArguments == N ); \
 			Assert( pReturn ); \
 			Assert( !pContext ); \
@@ -337,15 +337,15 @@ inline FUNCPTR_TYPE ScriptConvertFuncPtrFromVoid( void *p )
 				return false; \
 			} \
 			*pReturn = ((FUNC_TYPE)pFunction)( SCRIPT_BINDING_ARGS_##N ); \
- 			return true; \
- 		} \
+			return true; \
+		} \
 	}; \
 	\
 	template <typename FUNC_TYPE FUNC_TEMPLATE_FUNC_PARAMS_##N> \
 	class CNonMemberScriptBinding##N<FUNC_TYPE, void FUNC_BASE_TEMPLATE_FUNC_PARAMS_PASSTHRU_##N> \
 	{ \
 	public: \
-		static bool Call( void *pFunction, void *pContext, ScriptVariant_t *pArguments, int nArguments, ScriptVariant_t *pReturn ) \
+		static bool Call( void *pFunction, void *pContext, ScriptVariant_t *pArguments, int nArguments, ScriptVariant_t *pReturn, ScriptVariantTemporaryStorage_t &temporaryReturnStorage ) \
 		{ \
 			Assert( nArguments == N ); \
 			Assert( !pReturn ); \
@@ -360,12 +360,52 @@ inline FUNCPTR_TYPE ScriptConvertFuncPtrFromVoid( void *p )
 		} \
 	}; \
 	\
+	template <typename FUNC_TYPE FUNC_TEMPLATE_FUNC_PARAMS_##N> \
+	class CNonMemberScriptBinding##N<FUNC_TYPE, Vector FUNC_BASE_TEMPLATE_FUNC_PARAMS_PASSTHRU_##N> \
+	{ \
+	public: \
+		static bool Call( void *pFunction, void *pContext, ScriptVariant_t *pArguments, int nArguments, ScriptVariant_t *pReturn, ScriptVariantTemporaryStorage_t &temporaryReturnStorage ) \
+		{ \
+			Assert( nArguments == N ); \
+			Assert( pReturn ); \
+			Assert( !pContext ); \
+			\
+			if ( nArguments != N || !pReturn || pContext ) \
+			{ \
+				return false; \
+			} \
+			new ( &temporaryReturnStorage.m_vec ) Vector( ((FUNC_TYPE)pFunction)( SCRIPT_BINDING_ARGS_##N ) ); \
+			*pReturn = temporaryReturnStorage.m_vec; \
+			return true; \
+		} \
+	}; \
+	\
+	template <typename FUNC_TYPE FUNC_TEMPLATE_FUNC_PARAMS_##N> \
+	class CNonMemberScriptBinding##N<FUNC_TYPE, QAngle FUNC_BASE_TEMPLATE_FUNC_PARAMS_PASSTHRU_##N> \
+	{ \
+	public: \
+		static bool Call( void *pFunction, void *pContext, ScriptVariant_t *pArguments, int nArguments, ScriptVariant_t *pReturn, ScriptVariantTemporaryStorage_t &temporaryReturnStorage ) \
+		{ \
+			Assert( nArguments == N ); \
+			Assert( pReturn ); \
+			Assert( !pContext ); \
+			\
+			if ( nArguments != N || !pReturn || pContext ) \
+			{ \
+				return false; \
+			} \
+			new ( &temporaryReturnStorage.m_ang ) QAngle( ((FUNC_TYPE)pFunction)( SCRIPT_BINDING_ARGS_##N ) ); \
+			*pReturn = temporaryReturnStorage.m_ang; \
+			return true; \
+		} \
+	}; \
+	\
 	template <class OBJECT_TYPE_PTR, typename FUNC_TYPE, typename FUNCTION_RETTYPE FUNC_TEMPLATE_FUNC_PARAMS_##N> \
 	class CMemberScriptBinding##N \
 	{ \
 	public: \
- 		static bool Call( void *pFunction, void *pContext, ScriptVariant_t *pArguments, int nArguments, ScriptVariant_t *pReturn ) \
- 		{ \
+		static bool Call( void *pFunction, void *pContext, ScriptVariant_t *pArguments, int nArguments, ScriptVariant_t *pReturn, ScriptVariantTemporaryStorage_t &temporaryReturnStorage ) \
+		{ \
 			Assert( nArguments == N ); \
 			Assert( pReturn ); \
 			Assert( pContext ); \
@@ -375,15 +415,15 @@ inline FUNCPTR_TYPE ScriptConvertFuncPtrFromVoid( void *p )
 				return false; \
 			} \
 			*pReturn = (((OBJECT_TYPE_PTR)(pContext))->*ScriptConvertFuncPtrFromVoid<FUNC_TYPE>(pFunction))( SCRIPT_BINDING_ARGS_##N ); \
- 			return true; \
- 		} \
+			return true; \
+		} \
 	}; \
 	\
 	template <class OBJECT_TYPE_PTR, typename FUNC_TYPE FUNC_TEMPLATE_FUNC_PARAMS_##N> \
 	class CMemberScriptBinding##N<OBJECT_TYPE_PTR, FUNC_TYPE, void FUNC_BASE_TEMPLATE_FUNC_PARAMS_PASSTHRU_##N> \
 	{ \
 	public: \
-		static bool Call( void *pFunction, void *pContext, ScriptVariant_t *pArguments, int nArguments, ScriptVariant_t *pReturn ) \
+		static bool Call( void *pFunction, void *pContext, ScriptVariant_t *pArguments, int nArguments, ScriptVariant_t *pReturn, ScriptVariantTemporaryStorage_t &temporaryReturnStorage ) \
 		{ \
 			Assert( nArguments == N ); \
 			Assert( !pReturn ); \
@@ -394,6 +434,46 @@ inline FUNCPTR_TYPE ScriptConvertFuncPtrFromVoid( void *p )
 				return false; \
 			} \
 			(((OBJECT_TYPE_PTR)(pContext))->*ScriptConvertFuncPtrFromVoid<FUNC_TYPE>(pFunction))( SCRIPT_BINDING_ARGS_##N ); \
+			return true; \
+		} \
+	}; \
+	\
+	template <class OBJECT_TYPE_PTR, typename FUNC_TYPE FUNC_TEMPLATE_FUNC_PARAMS_##N> \
+	class CMemberScriptBinding##N<OBJECT_TYPE_PTR, FUNC_TYPE, Vector FUNC_BASE_TEMPLATE_FUNC_PARAMS_PASSTHRU_##N> \
+	{ \
+	public: \
+		static bool Call( void *pFunction, void *pContext, ScriptVariant_t *pArguments, int nArguments, ScriptVariant_t *pReturn, ScriptVariantTemporaryStorage_t &temporaryReturnStorage ) \
+		{ \
+			Assert( nArguments == N ); \
+			Assert( pReturn ); \
+			Assert( pContext ); \
+			\
+			if ( nArguments != N || !pReturn || !pContext ) \
+			{ \
+				return false; \
+			} \
+			new ( &temporaryReturnStorage.m_vec ) Vector( (((OBJECT_TYPE_PTR)(pContext))->*ScriptConvertFuncPtrFromVoid<FUNC_TYPE>(pFunction))( SCRIPT_BINDING_ARGS_##N ) ); \
+			*pReturn = temporaryReturnStorage.m_vec; \
+			return true; \
+		} \
+	}; \
+	\
+	template <class OBJECT_TYPE_PTR, typename FUNC_TYPE FUNC_TEMPLATE_FUNC_PARAMS_##N> \
+	class CMemberScriptBinding##N<OBJECT_TYPE_PTR, FUNC_TYPE, QAngle FUNC_BASE_TEMPLATE_FUNC_PARAMS_PASSTHRU_##N> \
+	{ \
+	public: \
+		static bool Call( void *pFunction, void *pContext, ScriptVariant_t *pArguments, int nArguments, ScriptVariant_t *pReturn, ScriptVariantTemporaryStorage_t &temporaryReturnStorage ) \
+		{ \
+			Assert( nArguments == N ); \
+			Assert( pReturn ); \
+			Assert( pContext ); \
+			\
+			if ( nArguments != N || !pReturn || !pContext ) \
+			{ \
+				return false; \
+			} \
+			new ( &temporaryReturnStorage.m_ang ) QAngle( (((OBJECT_TYPE_PTR)(pContext))->*ScriptConvertFuncPtrFromVoid<FUNC_TYPE>(pFunction))( SCRIPT_BINDING_ARGS_##N ) ); \
+			*pReturn = temporaryReturnStorage.m_ang; \
 			return true; \
 		} \
 	}; \
@@ -419,7 +499,11 @@ inline FUNCPTR_TYPE ScriptConvertFuncPtrFromVoid( void *p )
 		return &CMemberScriptBinding##N<OBJECT_TYPE_PTR, Func_t, FUNCTION_RETTYPE FUNC_BASE_TEMPLATE_FUNC_PARAMS_PASSTHRU_##N>::Call; \
 	}
 
+//note: no memory is actually allocated in the functions that get defined,
+//      it merely uses placement-new for which we need to disable this
+#include "tier0/memdbgoff.h"
 FUNC_GENERATE_ALL( DEFINE_SCRIPT_BINDINGS );
+#include "tier0/memdbgon.h"
 
 //-----------------------------------------------------------------------------
 // 

--- a/sp/src/vscript/vscript_bindings_base.cpp
+++ b/sp/src/vscript/vscript_bindings_base.cpp
@@ -440,13 +440,11 @@ bool CScriptColorInstanceHelper::Get( void *p, const char *pszKey, ScriptVariant
 bool CScriptColorInstanceHelper::Set( void *p, const char *pszKey, ScriptVariant_t &variant )
 {
 	Color *pClr = ((Color *)p);
-	if ( strlen(pszKey) == 1 )
+	int iVal;
+	if ( strlen(pszKey) == 1 && variant.AssignTo( &iVal ) )
 	{
-		int iVal;
-		variant.AssignTo( &iVal );
 		switch (pszKey[0])
 		{
-			// variant.AssignTo( &(*pClr)[0] );
 			case 'r':
 				(*pClr)[0] = iVal;
 				return true;

--- a/sp/src/vscript/vscript_bindings_math.cpp
+++ b/sp/src/vscript/vscript_bindings_math.cpp
@@ -259,17 +259,13 @@ bool CScriptQuaternionInstanceHelper::Set( void *p, const char *pszKey, ScriptVa
 		switch (pszKey[0])
 		{
 			case 'x':
-				variant.AssignTo( &pQuat->x );
-				return true;
+				return variant.AssignTo( &pQuat->x );
 			case 'y':
-				variant.AssignTo( &pQuat->y );
-				return true;
+				return variant.AssignTo( &pQuat->y );
 			case 'z':
-				variant.AssignTo( &pQuat->z );
-				return true;
+				return variant.AssignTo( &pQuat->z );
 			case 'w':
-				variant.AssignTo( &pQuat->w );
-				return true;
+				return variant.AssignTo( &pQuat->w );
 		}
 	}
 	return false;

--- a/sp/src/vscript/vscript_bindings_math.cpp
+++ b/sp/src/vscript/vscript_bindings_math.cpp
@@ -275,23 +275,6 @@ bool CScriptQuaternionInstanceHelper::Set( void *p, const char *pszKey, ScriptVa
 	return false;
 }
 
-ScriptVariant_t *CScriptQuaternionInstanceHelper::Add( void *p, ScriptVariant_t &variant )
-{
-	Quaternion *pQuat = ((Quaternion *)p);
-
-	float flAdd;
-	variant.AssignTo( &flAdd );
-
-	(*pQuat)[0] += flAdd;
-	(*pQuat)[1] += flAdd;
-	(*pQuat)[2] += flAdd;
-	(*pQuat)[3] += flAdd;
-
-	static ScriptVariant_t result;
-	result = (HSCRIPT)p;
-	return &result;
-}
-
 //-----------------------------------------------------------------------------
 //-----------------------------------------------------------------------------
 

--- a/sp/src/vscript/vscript_bindings_math.h
+++ b/sp/src/vscript/vscript_bindings_math.h
@@ -40,11 +40,6 @@ class CScriptQuaternionInstanceHelper : public IScriptInstanceHelper
 
 	bool Get( void *p, const char *pszKey, ScriptVariant_t &variant );
 	bool Set( void *p, const char *pszKey, ScriptVariant_t &variant );
-
-	ScriptVariant_t *Add( void *p, ScriptVariant_t &variant );
-	//ScriptVariant_t *Subtract( void *p, ScriptVariant_t &variant );
-	//ScriptVariant_t *Multiply( void *p, ScriptVariant_t &variant );
-	//ScriptVariant_t *Divide( void *p, ScriptVariant_t &variant );
 };
 
 inline Quaternion *ToQuaternion( HSCRIPT hQuat ) { return HScriptToClass<Quaternion>( hQuat ); }

--- a/sp/src/vscript/vscript_squirrel.cpp
+++ b/sp/src/vscript/vscript_squirrel.cpp
@@ -1578,106 +1578,6 @@ SQInteger set_stub(HSQUIRRELVM vm)
 	return 0;
 }
 
-SQInteger add_stub(HSQUIRRELVM vm)
-{
-	ClassInstanceData* classInstanceData = nullptr;
-	sq_getinstanceup(vm, 1, (SQUserPointer*)&classInstanceData, 0);
-
-	ScriptVariant_t var;
-	getVariant( vm, 1, var );
-
-	if (classInstanceData &&
-		classInstanceData->instance &&
-		classInstanceData->desc->pHelper)
-	{
-		ScriptVariant_t *result = classInstanceData->desc->pHelper->Add( classInstanceData->instance, var );
-		if (result != nullptr)
-		{
-			PushVariant( vm, *result );
-			sq_pop(vm, 1);
-			return 1;
-		}
-	}
-
-	sq_pop(vm, 1);
-	return sqstd_throwerrorf(vm, "invalid arith op +");
-}
-
-SQInteger sub_stub(HSQUIRRELVM vm)
-{
-	ClassInstanceData* classInstanceData = nullptr;
-	sq_getinstanceup(vm, 1, (SQUserPointer*)&classInstanceData, 0);
-
-	ScriptVariant_t var;
-	getVariant( vm, 1, var );
-
-	if (classInstanceData &&
-		classInstanceData->instance &&
-		classInstanceData->desc->pHelper)
-	{
-		ScriptVariant_t *result = classInstanceData->desc->pHelper->Subtract( classInstanceData->instance, var );
-		if (result != nullptr)
-		{
-			PushVariant( vm, *result );
-			sq_pop(vm, 1);
-			return 1;
-		}
-	}
-
-	sq_pop(vm, 1);
-	return sqstd_throwerrorf(vm, "invalid arith op -");
-}
-
-SQInteger mul_stub(HSQUIRRELVM vm)
-{
-	ClassInstanceData* classInstanceData = nullptr;
-	sq_getinstanceup(vm, 1, (SQUserPointer*)&classInstanceData, 0);
-
-	ScriptVariant_t var;
-	getVariant( vm, 1, var );
-
-	if (classInstanceData &&
-		classInstanceData->instance &&
-		classInstanceData->desc->pHelper )
-	{
-		ScriptVariant_t *result = classInstanceData->desc->pHelper->Add( classInstanceData->instance, var );
-		if (result != nullptr)
-		{
-			PushVariant( vm, *result );
-			sq_pop(vm, 1);
-			return 1;
-		}
-	}
-
-	sq_pop(vm, 1);
-	return sqstd_throwerrorf(vm, "invalid arith op *");
-}
-
-SQInteger div_stub(HSQUIRRELVM vm)
-{
-	ClassInstanceData* classInstanceData = nullptr;
-	sq_getinstanceup(vm, 1, (SQUserPointer*)&classInstanceData, 0);
-
-	ScriptVariant_t var;
-	getVariant( vm, 1, var );
-
-	if (classInstanceData &&
-		classInstanceData->instance &&
-		classInstanceData->desc->pHelper )
-	{
-		ScriptVariant_t *result = classInstanceData->desc->pHelper->Add( classInstanceData->instance, var );
-		if (result != nullptr)
-		{
-			PushVariant( vm, *result );
-			sq_pop(vm, 1);
-			return 1;
-		}
-	}
-
-	sq_pop(vm, 1);
-	return sqstd_throwerrorf(vm, "invalid arith op /");
-}
-
 SQInteger IsValid_stub(HSQUIRRELVM vm)
 {
 	ClassInstanceData* classInstanceData = nullptr;
@@ -2509,22 +2409,6 @@ bool SquirrelVM::RegisterClass(ScriptClassDesc_t* pClassDesc)
 
 	sq_pushstring(vm_, "_set", -1);
 	sq_newclosure(vm_, set_stub, 0);
-	sq_newslot(vm_, -3, SQFalse);
-
-	sq_pushstring(vm_, "_add", -1);
-	sq_newclosure(vm_, add_stub, 0);
-	sq_newslot(vm_, -3, SQFalse);
-
-	sq_pushstring(vm_, "_sub", -1);
-	sq_newclosure(vm_, sub_stub, 0);
-	sq_newslot(vm_, -3, SQFalse);
-
-	sq_pushstring(vm_, "_mul", -1);
-	sq_newclosure(vm_, mul_stub, 0);
-	sq_newslot(vm_, -3, SQFalse);
-
-	sq_pushstring(vm_, "_div", -1);
-	sq_newclosure(vm_, div_stub, 0);
 	sq_newslot(vm_, -3, SQFalse);
 
 	sq_pushstring(vm_, "IsValid", -1);

--- a/sp/src/vscript/vscript_squirrel.cpp
+++ b/sp/src/vscript/vscript_squirrel.cpp
@@ -1247,7 +1247,7 @@ bool getVariant(HSQUIRRELVM vm, SQInteger idx, ScriptVariant_t& variant)
 		{
 			return false;
 		}
-		char* buffer = new char[size + 1];
+		char* buffer = (char*)malloc(size + 1);
 		V_memcpy(buffer, val, size);
 		buffer[size] = 0;
 		variant = buffer;
@@ -1262,7 +1262,8 @@ bool getVariant(HSQUIRRELVM vm, SQInteger idx, ScriptVariant_t& variant)
 			tag == TYPETAG_VECTOR &&
 			SQ_SUCCEEDED(sq_getinstanceup(vm, idx, (SQUserPointer*)&v, TYPETAG_VECTOR)))
 		{
-			variant = new Vector(*v);
+			variant = (Vector*)malloc(sizeof(Vector));
+			variant.EmplaceAllocedVector(*v);
 			variant.m_flags |= SV_FREE;
 			return true;
 		}

--- a/sp/src/vscript/vscript_squirrel.cpp
+++ b/sp/src/vscript/vscript_squirrel.cpp
@@ -1399,6 +1399,7 @@ SQInteger function_stub(HSQUIRRELVM vm)
 	}
 
 	ScriptVariant_t retval;
+	ScriptVariantTemporaryStorage_t retval_storage;
 
 	SquirrelVM* pSquirrelVM = (SquirrelVM*)sq_getforeignptr(vm);
 	assert(pSquirrelVM);
@@ -1406,7 +1407,7 @@ SQInteger function_stub(HSQUIRRELVM vm)
 	sq_resetobject(&pSquirrelVM->lastError_);
 
 	(*pFunc->m_pfnBinding)(pFunc->m_pFunction, instance, params.Base(), nargs,
-		pFunc->m_desc.m_ReturnType == FIELD_VOID ? nullptr : &retval);
+		pFunc->m_desc.m_ReturnType == FIELD_VOID ? nullptr : &retval, retval_storage);
 
 	if (!sq_isnull(pSquirrelVM->lastError_))
 	{
@@ -1417,7 +1418,9 @@ SQInteger function_stub(HSQUIRRELVM vm)
 
 	PushVariant(vm, retval);
 
-	retval.Free();
+	// strings never get copied here, Vector and QAngle are stored in script_retval_storage
+	// everything else is stored inline, so there should be no memory to free
+	Assert(!(retval.m_flags & SV_FREE));
 
 	return pFunc->m_desc.m_ReturnType != FIELD_VOID;
 }

--- a/sp/src/vscript/vscript_squirrel.cpp
+++ b/sp/src/vscript/vscript_squirrel.cpp
@@ -1205,6 +1205,7 @@ bool getVariant(HSQUIRRELVM vm, SQInteger idx, ScriptVariant_t& variant)
 	{
 	case OT_NULL:
 	{
+		variant.Free();
 		variant.m_flags = 0;
 		// TODO: Should this be (HSCRIPT)nullptr
 		variant.m_type = FIELD_VOID;
@@ -1217,6 +1218,7 @@ bool getVariant(HSQUIRRELVM vm, SQInteger idx, ScriptVariant_t& variant)
 		{
 			return false;
 		}
+		variant.Free();
 		variant = (int)val;
 		return true;
 	}
@@ -1227,6 +1229,7 @@ bool getVariant(HSQUIRRELVM vm, SQInteger idx, ScriptVariant_t& variant)
 		{
 			return false;
 		}
+		variant.Free();
 		variant = (float)val;
 		return true;
 	}
@@ -1237,6 +1240,7 @@ bool getVariant(HSQUIRRELVM vm, SQInteger idx, ScriptVariant_t& variant)
 		{
 			return false;
 		}
+		variant.Free();
 		variant = val ? true : false;
 		return true;
 	}
@@ -1248,6 +1252,7 @@ bool getVariant(HSQUIRRELVM vm, SQInteger idx, ScriptVariant_t& variant)
 		{
 			return false;
 		}
+		variant.Free();
 		char* buffer = (char*)malloc(size + 1);
 		V_memcpy(buffer, val, size);
 		buffer[size] = 0;
@@ -1263,6 +1268,7 @@ bool getVariant(HSQUIRRELVM vm, SQInteger idx, ScriptVariant_t& variant)
 			tag == TYPETAG_VECTOR &&
 			SQ_SUCCEEDED(sq_getinstanceup(vm, idx, (SQUserPointer*)&v, TYPETAG_VECTOR)))
 		{
+			variant.Free();
 			variant = (Vector*)malloc(sizeof(Vector));
 			variant.EmplaceAllocedVector(*v);
 			variant.m_flags |= SV_FREE;
@@ -1272,6 +1278,7 @@ bool getVariant(HSQUIRRELVM vm, SQInteger idx, ScriptVariant_t& variant)
 	}
 	default:
 	{
+		variant.Free();
 		HSQOBJECT* obj = new HSQOBJECT;
 		sq_resetobject(obj);
 		sq_getstackobj(vm, idx, obj);

--- a/sp/src/vscript/vscript_squirrel.cpp
+++ b/sp/src/vscript/vscript_squirrel.cpp
@@ -1415,8 +1415,7 @@ SQInteger function_stub(HSQUIRRELVM vm)
 
 	PushVariant(vm, retval);
 
-	if (retval.m_type == FIELD_VECTOR)
-		delete retval.m_pVector;
+	retval.Free();
 
 	return pFunc->m_desc.m_ReturnType != FIELD_VOID;
 }

--- a/sp/src/vscript/vscript_squirrel.cpp
+++ b/sp/src/vscript/vscript_squirrel.cpp
@@ -1205,6 +1205,7 @@ bool getVariant(HSQUIRRELVM vm, SQInteger idx, ScriptVariant_t& variant)
 	{
 	case OT_NULL:
 	{
+		variant.m_flags = 0;
 		// TODO: Should this be (HSCRIPT)nullptr
 		variant.m_type = FIELD_VOID;
 		return true;
@@ -3074,6 +3075,7 @@ void SquirrelVM::ReleaseValue(ScriptVariant_t& value)
 
 	// Let's prevent this being called again and giving some UB
 	value.m_type = FIELD_VOID;
+	value.m_flags = 0;
 }
 
 bool SquirrelVM::ClearValue(HSCRIPT hScope, const char* pszKey)

--- a/sp/src/vscript/vscript_squirrel.cpp
+++ b/sp/src/vscript/vscript_squirrel.cpp
@@ -1429,8 +1429,15 @@ SQInteger function_stub(HSQUIRRELVM vm)
 	{
 		Assert(script_retval.m_type == pFunc->m_desc.m_ReturnType);
 
-		PushVariant(vm, script_retval);
-		sq_retval = 1;
+		if (pFunc->m_desc.m_ReturnType != FIELD_VOID)
+		{
+			PushVariant(vm, script_retval);
+			sq_retval = 1;
+		}
+		else
+		{
+			sq_retval = 0;
+		}
 	}
 
 	// strings never get copied here, Vector and QAngle are stored in script_retval_storage


### PR DESCRIPTION
When a Vector or QAngle rvalue reference is returned from a VScript function, the constructed ScriptVariant_t must not store the pointer to it since it is, per convention, a temporary reference. Only do that for lvalue-references, but do a copy when constructing from or assigning a rvalue reference.

---

I'm not sure `ScriptVairant_t` really needs to try and prevent copies of `Vector` and `QAngle`. They're pretty small and trivial classes, so are cheap to copy. When a copy must be made it surely beats a dynamic allocation & deallocation.
`Free()` refers to `FIELD_HSCRIPT`, although it will never set `SV_FREE`. Perhaps this is just outdated?
Strings will need to be copied (`strdup()`ed) due to their dynamic length, but it could try to do a small-string optimization.

The types of `new` and `delete` are misaligned, since `Free()` only ever does `delete m_pszString`. Since `HSCRIPT`, `Vector` and `QAngle` are all trivial to destruct this shouldn't have any ill effects.
At most I'm worried about `strdup()` being paired with `delete` instead of `free()`.

Anyway, I wanted to hear your thoughts on this before I change more stuff. This change alone sufficiently fixes issues I've observed in return-values playing a Mapbase-based mod that uses VScripts (https://www.moddb.com/mods/sourceworld).

---

#### Does this PR close any issues?
* Maybe relates to #104? I do not observe memory usage rising when executing the loop 100-fold several times.

<!-- Replace [ ] with [x] for each item your PR satisfies -->
#### PR Checklist
- [x] **My PR follows all guidelines in the CONTRIBUTING.md file**
- [x] My PR targets a `develop` branch OR targets another branch with a specific goal in mind
