### PR TITLE
Don't network info_null/func_null

### DIFF
--- a/mp/src/game/server/subs.cpp
+++ b/mp/src/game/server/subs.cpp
@@ -22,10 +22,10 @@ void CPointEntity::Spawn( void )
 }
 
 
-class CNullEntity : public CBaseEntity
+class CNullEntity : public CServerOnlyEntity
 {
 public:
-	DECLARE_CLASS( CNullEntity, CBaseEntity );
+	DECLARE_CLASS( CNullEntity, CServerOnlyEntity );
 
 	void Spawn( void );
 };

--- a/sp/src/game/server/subs.cpp
+++ b/sp/src/game/server/subs.cpp
@@ -22,10 +22,10 @@ void CPointEntity::Spawn( void )
 }
 
 
-class CNullEntity : public CBaseEntity
+class CNullEntity : public CServerOnlyEntity
 {
 public:
-	DECLARE_CLASS( CNullEntity, CBaseEntity );
+	DECLARE_CLASS( CNullEntity, CServerOnlyEntity );
 
 	void Spawn( void );
 };


### PR DESCRIPTION
Inheriting CServerOnlyEntity instead of CBaseEntity reduces potential for entity limit crashes, as CNullEntity still exists for the first tick. 

---

#### Does this PR close any issues?
* No.

<!-- Replace [ ] with [x] for each item your PR satisfies -->
#### PR Checklist
- [x] **My PR follows all guidelines in the CONTRIBUTING.md file**
- [ ] My PR targets a `develop` branch OR targets another branch with a specific goal in mind
