### PR TITLE
Fix OOB access

### DIFF
--- a/sp/src/game/server/ai_basenpc.cpp
+++ b/sp/src/game/server/ai_basenpc.cpp
@@ -8045,10 +8045,13 @@ int CAI_BaseNPC::UnholsterWeapon( void )
 	if (i == -1)
 	{
 		// Set i to the first weapon you can find
-		for (i = 0; i < WeaponCount(); i++)
+		for (i = 0;;)
 		{
 			if (GetWeapon(i))
 				break;
+
+			if (++i >= WeaponCount())
+				return -1;
 		}
 	}
 #else


### PR DESCRIPTION
When the loop fails its `i < 48` condition, it will access out of array bounds on `GetWeapon` right after. This was mostly benign because `CHandle m_hMyWeapons[48]` is followed by `CHandle m_hActiveWeapon` in memory, so `m_hMyWeapons[48]` would access `m_hActiveWeapon`, which would always be null because the entity can't have an active weapon with no weapons.

---

#### PR Checklist
- [x] **My PR follows all guidelines in the CONTRIBUTING.md file**
- [x] My PR targets a `develop` branch OR targets another branch with a specific goal in mind
