### PR TITLE
Expose CBaseCombatCharacter glow funcs to VScript + add color functionality

### DIFF
--- a/sp/src/game/client/c_basecombatcharacter.cpp
+++ b/sp/src/game/client/c_basecombatcharacter.cpp
@@ -34,6 +34,10 @@ C_BaseCombatCharacter::C_BaseCombatCharacter()
 	m_pGlowEffect = NULL;
 	m_bGlowEnabled = false;
 	m_bOldGlowEnabled = false;
+	m_GlowColor.Init( 0.76f, 0.76f, 0.76f );
+	m_OldGlowColor = m_GlowColor;
+	m_GlowAlpha = 1.0f;
+	m_OldGlowAlpha = 1.0f;
 #endif // GLOWS_ENABLE
 }
 
@@ -66,6 +70,8 @@ void C_BaseCombatCharacter::OnPreDataChanged( DataUpdateType_t updateType )
 
 #ifdef GLOWS_ENABLE
 	m_bOldGlowEnabled = m_bGlowEnabled;
+	m_OldGlowColor = m_GlowColor;
+	m_OldGlowAlpha = m_GlowAlpha;
 #endif // GLOWS_ENABLE
 }
 
@@ -77,7 +83,7 @@ void C_BaseCombatCharacter::OnDataChanged( DataUpdateType_t updateType )
 	BaseClass::OnDataChanged( updateType );
 
 #ifdef GLOWS_ENABLE
-	if ( m_bOldGlowEnabled != m_bGlowEnabled )
+	if ( m_bOldGlowEnabled != m_bGlowEnabled || m_OldGlowColor != m_GlowColor || m_OldGlowAlpha != m_GlowAlpha )
 	{
 		UpdateGlowEffect();
 	}
@@ -106,11 +112,13 @@ void C_BaseCombatCharacter::DoMuzzleFlash()
 //-----------------------------------------------------------------------------
 // Purpose: 
 //-----------------------------------------------------------------------------
-void C_BaseCombatCharacter::GetGlowEffectColor( float *r, float *g, float *b )
+void C_BaseCombatCharacter::GetGlowEffectColor( float *r, float *g, float *b, float *a )
 {
-	*r = 0.76f;
-	*g = 0.76f;
-	*b = 0.76f;
+	*r = m_GlowColor.x;
+	*g = m_GlowColor.y;
+	*b = m_GlowColor.z;
+	if (a)
+		*a = m_GlowAlpha;
 }
 
 //-----------------------------------------------------------------------------
@@ -127,10 +135,10 @@ void C_BaseCombatCharacter::UpdateGlowEffect( void )
 	// create a new effect
 	if ( m_bGlowEnabled )
 	{
-		float r, g, b;
-		GetGlowEffectColor( &r, &g, &b );
+		float r, g, b, a;
+		GetGlowEffectColor( &r, &g, &b, &a );
 
-		m_pGlowEffect = new CGlowObject( this, Vector( r, g, b ), 1.0, true );
+		m_pGlowEffect = new CGlowObject( this, Vector( r, g, b ), a, true );
 	}
 }
 
@@ -161,6 +169,8 @@ BEGIN_RECV_TABLE(C_BaseCombatCharacter, DT_BaseCombatCharacter)
 	RecvPropArray3( RECVINFO_ARRAY(m_hMyWeapons), RecvPropEHandle( RECVINFO( m_hMyWeapons[0] ) ) ),
 #ifdef GLOWS_ENABLE
 	RecvPropBool( RECVINFO( m_bGlowEnabled ) ),
+	RecvPropVector( RECVINFO( m_GlowColor ) ),
+	RecvPropFloat( RECVINFO( m_GlowAlpha ) ),
 #endif // GLOWS_ENABLE
 
 #ifdef INVASION_CLIENT_DLL

--- a/sp/src/game/client/c_basecombatcharacter.h
+++ b/sp/src/game/client/c_basecombatcharacter.h
@@ -99,7 +99,7 @@ public:
 
 #ifdef GLOWS_ENABLE
 	CGlowObject			*GetGlowObject( void ){ return m_pGlowEffect; }
-	virtual void		GetGlowEffectColor( float *r, float *g, float *b );
+	virtual void		GetGlowEffectColor( float *r, float *g, float *b, float *a = NULL );
 #endif // GLOWS_ENABLE
 
 #ifdef MAPBASE_VSCRIPT
@@ -133,6 +133,10 @@ private:
 	bool				m_bGlowEnabled;
 	bool				m_bOldGlowEnabled;
 	CGlowObject			*m_pGlowEffect;
+	Vector				m_GlowColor;
+	Vector				m_OldGlowColor;
+	float				m_GlowAlpha;
+	int					m_OldGlowAlpha;
 #endif // GLOWS_ENABLE
 
 private:

--- a/sp/src/game/server/basecombatcharacter.cpp
+++ b/sp/src/game/server/basecombatcharacter.cpp
@@ -195,6 +195,13 @@ BEGIN_ENT_SCRIPTDESC( CBaseCombatCharacter, CBaseFlex, "The base class shared by
 
 	DEFINE_SCRIPTFUNC( LastHitGroup, "Get the last hitgroup." )
 
+#ifdef GLOWS_ENABLE
+	DEFINE_SCRIPTFUNC( AddGlowEffect, "" )
+	DEFINE_SCRIPTFUNC( RemoveGlowEffect, "" )
+	DEFINE_SCRIPTFUNC( IsGlowEffectActive, "" )
+	DEFINE_SCRIPTFUNC( SetGlowColor, "" )
+#endif
+
 	// 
 	// Hooks
 	// 
@@ -293,6 +300,8 @@ END_SEND_TABLE();
 IMPLEMENT_SERVERCLASS_ST(CBaseCombatCharacter, DT_BaseCombatCharacter)
 #ifdef GLOWS_ENABLE
 	SendPropBool( SENDINFO( m_bGlowEnabled ) ),
+	SendPropVector( SENDINFO( m_GlowColor ), 8, 0, 0, 1 ),
+	SendPropFloat( SENDINFO( m_GlowAlpha ) ),
 #endif // GLOWS_ENABLE
 	// Data that only gets sent to the local player.
 	SendPropDataTable( "bcc_localdata", 0, &REFERENCE_SEND_TABLE(DT_BCCLocalPlayerExclusive), SendProxy_SendBaseCombatCharacterLocalDataTable ),
@@ -878,6 +887,8 @@ CBaseCombatCharacter::CBaseCombatCharacter( void )
 
 #ifdef GLOWS_ENABLE
 	m_bGlowEnabled.Set( false );
+	m_GlowColor.GetForModify().Init( 0.76f, 0.76f, 0.76f );
+	m_GlowAlpha.Set(1.0f);
 #endif // GLOWS_ENABLE
 }
 
@@ -4097,6 +4108,12 @@ void CBaseCombatCharacter::RemoveGlowEffect( void )
 bool CBaseCombatCharacter::IsGlowEffectActive( void )
 {
 	return m_bGlowEnabled;
+}
+
+void CBaseCombatCharacter::SetGlowColor( float red, float green, float blue, float alpha )
+{
+	m_GlowColor.GetForModify().Init( red, green, blue );
+	m_GlowAlpha.Set( alpha );
 }
 #endif // GLOWS_ENABLE
 

--- a/sp/src/game/server/basecombatcharacter.h
+++ b/sp/src/game/server/basecombatcharacter.h
@@ -532,6 +532,7 @@ public:
 	void				AddGlowEffect( void );
 	void				RemoveGlowEffect( void );
 	bool				IsGlowEffectActive( void );
+	void				SetGlowColor( float red, float green, float blue, float alpha );
 #endif // GLOWS_ENABLE
 
 #ifdef INVASION_DLL
@@ -576,6 +577,8 @@ public:
 #ifdef GLOWS_ENABLE
 protected:
 	CNetworkVar( bool, m_bGlowEnabled );
+	CNetworkVector( m_GlowColor );
+	CNetworkVar( float, m_GlowAlpha );
 #endif // GLOWS_ENABLE
 
 private:


### PR DESCRIPTION
This pull request exposes `CBaseCombatCharacter`'s innate glow functions to VScript. It also adds functionality for custom colors, which comes from [this commit](https://github.com/entropy-zero/source-sdk-2013/commit/ba214dbfbe1bfba1dc8fb84767ae9570ca4e177c) by @1upD to Entropy : Zero 2.

---

#### Does this PR close any issues?
* (Optional) Insert issue number(s) and any related info here

<!-- Replace [ ] with [x] for each item your PR satisfies -->
#### PR Checklist
- [x] **My PR follows all guidelines in the CONTRIBUTING.md file**
- [x] My PR targets a `develop` branch OR targets another branch with a specific goal in mind