### PR TITLE
Expose VPhysicsInitNormal and VPhysicsDestroyObject to VScript

### DIFF
--- a/sp/src/game/client/c_baseentity.cpp
+++ b/sp/src/game/client/c_baseentity.cpp
@@ -485,6 +485,8 @@ BEGIN_ENT_SCRIPTDESC_ROOT( C_BaseEntity, "Root class of all client-side entities
 	DEFINE_SCRIPTFUNC_NAMED( ScriptEntityToWorldTransform, "EntityToWorldTransform", "Get the entity's transform" )
 
 	DEFINE_SCRIPTFUNC_NAMED( ScriptGetPhysicsObject, "GetPhysicsObject", "Get the entity's physics object if it has one" )
+	DEFINE_SCRIPTFUNC_NAMED( ScriptPhysicsInitNormal, "PhysicsInitNormal", "Initializes the entity's physics object with the specified solid type, solid flags, and whether to start asleep" )
+	DEFINE_SCRIPTFUNC_NAMED( ScriptPhysicsDestroyObject, "PhysicsDestroyObject", "Destroys the entity's physics object" )
 
 	DEFINE_SCRIPTFUNC( GetWaterLevel, "Get current level of water submergence" )
 

--- a/sp/src/game/client/c_baseentity.h
+++ b/sp/src/game/client/c_baseentity.h
@@ -1206,6 +1206,8 @@ public:
 	HSCRIPT ScriptEntityToWorldTransform( void );
 
 	HSCRIPT ScriptGetPhysicsObject( void );
+	void ScriptPhysicsInitNormal( int nSolidType, int nSolidFlags, bool createAsleep );
+	void ScriptPhysicsDestroyObject() { VPhysicsDestroyObject(); }
 
 	void ScriptSetParent( HSCRIPT hParent, const char *szAttachment );
 	HSCRIPT ScriptGetMoveParent( void );

--- a/sp/src/game/server/baseentity.cpp
+++ b/sp/src/game/server/baseentity.cpp
@@ -2312,6 +2312,8 @@ BEGIN_ENT_SCRIPTDESC_ROOT( CBaseEntity, "Root class of all server-side entities"
 	DEFINE_SCRIPTFUNC_NAMED( ScriptEntityToWorldTransform, "EntityToWorldTransform", "Get the entity's transform" )
 
 	DEFINE_SCRIPTFUNC_NAMED( ScriptGetPhysicsObject, "GetPhysicsObject", "Get the entity's physics object if it has one" )
+	DEFINE_SCRIPTFUNC_NAMED( ScriptPhysicsInitNormal, "PhysicsInitNormal", "Initializes the entity's physics object with the specified solid type, solid flags, and whether to start asleep" )
+	DEFINE_SCRIPTFUNC_NAMED( ScriptPhysicsDestroyObject, "PhysicsDestroyObject", "Destroys the entity's physics object" )
 
 	DEFINE_SCRIPTFUNC( ApplyAbsVelocityImpulse, "" )
 	DEFINE_SCRIPTFUNC( ApplyLocalAngularVelocityImpulse, "" )

--- a/sp/src/game/server/baseentity.h
+++ b/sp/src/game/server/baseentity.h
@@ -2097,6 +2097,8 @@ public:
 	HSCRIPT ScriptEntityToWorldTransform( void );
 
 	HSCRIPT ScriptGetPhysicsObject( void );
+	void ScriptPhysicsInitNormal( int nSolidType, int nSolidFlags, bool createAsleep );
+	void ScriptPhysicsDestroyObject() { VPhysicsDestroyObject(); }
 
 	void ScriptSetParent(HSCRIPT hParent, const char *szAttachment);
 #endif

--- a/sp/src/game/shared/baseentity_shared.cpp
+++ b/sp/src/game/shared/baseentity_shared.cpp
@@ -2811,6 +2811,14 @@ HSCRIPT CBaseEntity::ScriptGetPhysicsObject( void )
 		return NULL;
 }
 
+//-----------------------------------------------------------------------------
+// Vscript: Gets the entity's physics object if it has one
+//-----------------------------------------------------------------------------
+void CBaseEntity::ScriptPhysicsInitNormal( int nSolidType, int nSolidFlags, bool createAsleep )
+{
+	VPhysicsInitNormal( (SolidType_t)nSolidType, nSolidFlags, createAsleep );
+}
+
 
 #ifdef GAME_DLL
 #define SCRIPT_NEVER_THINK TICK_NEVER_THINK

--- a/sp/src/game/shared/mapbase/vscript_consts_shared.cpp
+++ b/sp/src/game/shared/mapbase/vscript_consts_shared.cpp
@@ -291,6 +291,17 @@ void RegisterSharedScriptConstants()
 	ScriptRegisterConstant( g_pScriptVM, EF_PARENT_ANIMATES, "Effect flag used in GetEffects(), etc." );
 
 	// 
+	// Solid Types
+	// 
+	ScriptRegisterConstant( g_pScriptVM, SOLID_NONE, "Solid type used by VPhysics" );
+	ScriptRegisterConstant( g_pScriptVM, SOLID_BSP, "Solid type used by VPhysics" );
+	ScriptRegisterConstant( g_pScriptVM, SOLID_BBOX, "Solid type used by VPhysics" );
+	ScriptRegisterConstant( g_pScriptVM, SOLID_OBB, "Solid type used by VPhysics" );
+	ScriptRegisterConstant( g_pScriptVM, SOLID_OBB_YAW, "Solid type used by VPhysics" );
+	ScriptRegisterConstant( g_pScriptVM, SOLID_CUSTOM, "Solid type used by VPhysics" );
+	ScriptRegisterConstant( g_pScriptVM, SOLID_VPHYSICS, "Solid type used by VPhysics" );
+
+	// 
 	// Solid Flags
 	// 
 	ScriptRegisterConstant( g_pScriptVM, FSOLID_CUSTOMRAYTEST, "Solid flag used in GetSolidFlags(), etc." );


### PR DESCRIPTION
This pull request exposes `VPhysicsInitNormal`, `VPhysicsDestroyObject`, and the `SOLID_` enum to VScript. This gives VScript direct control over the creation and destruction of VPhysics objects on entities.

---

<!-- Replace [ ] with [x] for each item your PR satisfies -->
#### PR Checklist
- [x] **My PR follows all guidelines in the CONTRIBUTING.md file**
- [x] My PR targets a `develop` branch OR targets another branch with a specific goal in mind
