### PR TITLE
Fix forced interaction partners being made to face each other even when interaction doesn't require it

### DIFF
--- a/sp/src/game/server/ai_basenpc_schedule.cpp
+++ b/sp/src/game/server/ai_basenpc_schedule.cpp
@@ -3506,6 +3506,12 @@ void CAI_BaseNPC::RunTask( const Task_t *pTask )
 			// as this should only run with the NPC "receiving" the interaction
 			ScriptedNPCInteraction_t *pInteraction = m_hForcedInteractionPartner->GetRunningDynamicInteraction();
 
+			if ( !(pInteraction->iFlags & SCNPC_FLAG_TEST_OTHER_ANGLES) )
+			{
+				TaskComplete();
+				return;
+			}
+
 			// Get our target's origin
 			Vector vecTarget = m_hForcedInteractionPartner->GetAbsOrigin();
 


### PR DESCRIPTION
This fixes forced interaction partners being made to face an undefined relative angle when an unrelative angle is not needed. This is a minor issue since the undefined relative angle is usually just `0 0 0`, but it does prevent any other angle from being used by forced interactions.

---

<!-- Replace [ ] with [x] for each item your PR satisfies -->
#### PR Checklist
- [x] **My PR follows all guidelines in the CONTRIBUTING.md file**
- [x] My PR targets a `develop` branch OR targets another branch with a specific goal in mind
