### PR TITLE
Fixes and expansions for Lost/FoundEnemySound on NPCs

### DIFF
--- a/sp/src/game/server/ai_basenpc.cpp
+++ b/sp/src/game/server/ai_basenpc.cpp
@@ -6110,7 +6110,11 @@ bool CAI_BaseNPC::UpdateEnemyMemory( CBaseEntity *pEnemy, const Vector &position
 		// If the was eluding me and allow the NPC to play a sound
 		if (GetEnemies()->HasEludedMe(pEnemy))
 		{
+#ifdef MAPBASE
+			FoundEnemySound( pEnemy );
+#else
 			FoundEnemySound();
+#endif
 		}
 		float reactionDelay = ( !pInformer || pInformer == this ) ? GetReactionDelay( pEnemy ) : 0.0;
 		bool result = GetEnemies()->UpdateMemory(GetNavigator()->GetNetwork(), pEnemy, position, reactionDelay, firstHand);
@@ -11731,7 +11735,11 @@ bool CAI_BaseNPC::ChooseEnemy( void )
 			if ( fEnemyEluded )
 			{
 				SetCondition( COND_LOST_ENEMY );
+#ifdef MAPBASE
+				LostEnemySound( pInitialEnemy );
+#else
 				LostEnemySound();
+#endif
 			}
 
 			if ( fEnemyWasPlayer )

--- a/sp/src/game/server/ai_basenpc.h
+++ b/sp/src/game/server/ai_basenpc.h
@@ -1401,6 +1401,11 @@ public:
 	virtual void		FearSound( void )				 			{ return; };
 	virtual void		LostEnemySound( void ) 						{ return; };
 	virtual void		FoundEnemySound( void ) 					{ return; };
+#ifdef MAPBASE
+	// New versions of the above functions which pass the enemy in question as a parameter. Chains to the original by default
+	virtual void		LostEnemySound( CBaseEntity *pEnemy )		{ LostEnemySound(); };
+	virtual void		FoundEnemySound( CBaseEntity *pEnemy )		{ FoundEnemySound(); };
+#endif
 	virtual void		BarnacleDeathSound( void )					{ CTakeDamageInfo info;	PainSound( info ); }
 
 	virtual void		SpeakSentence( int sentenceType ) 			{ return; };

--- a/sp/src/game/server/ai_playerally.cpp
+++ b/sp/src/game/server/ai_playerally.cpp
@@ -14,6 +14,7 @@
 #include "gameinterface.h"
 #ifdef MAPBASE
 #include "mapbase/matchers.h"
+#include "ai_memory.h"
 #endif
 
 // memdbgon must be the last include file in a .cpp file!!!
@@ -133,6 +134,8 @@ ConceptInfo_t g_ConceptInfos[] =
 	{ 	TLK_TAKING_FIRE,		SPEECH_IMPORTANT,-1,	-1,		-1,		-1,		 -1,	-1,		AICF_DEFAULT,	},
 	{ 	TLK_NEW_ENEMY,			SPEECH_IMPORTANT,-1,	-1,		-1,		-1,		 -1,	-1,		AICF_DEFAULT,	},
 	{ 	TLK_COMBAT_IDLE,		SPEECH_IMPORTANT,-1,	-1,		-1,		-1,		 -1,	-1,		AICF_DEFAULT,	},
+	{ 	TLK_LOSTENEMY,			SPEECH_IMPORTANT,-1,	-1,		-1,		-1,		 -1,	-1,		AICF_DEFAULT,	},
+	{ 	TLK_REFINDENEMY,		SPEECH_IMPORTANT,-1,	-1,		-1,		-1,		 -1,	-1,		AICF_DEFAULT,	},
 #endif
 };
 
@@ -1425,6 +1428,28 @@ void CAI_PlayerAlly::PainSound( const CTakeDamageInfo &info )
 {
 	SpeakIfAllowed( TLK_WOUND );
 }
+
+#ifdef MAPBASE
+//-----------------------------------------------------------------------------
+void CAI_PlayerAlly::LostEnemySound( CBaseEntity *pEnemy )
+{
+	AI_CriteriaSet modifiers;
+	ModifyOrAppendEnemyCriteria( modifiers, pEnemy );
+
+	modifiers.AppendCriteria( "lastseenenemy", gpGlobals->curtime - GetEnemies()->LastTimeSeen( pEnemy ) );
+
+	SpeakIfAllowed( TLK_LOSTENEMY, modifiers );
+}
+
+//-----------------------------------------------------------------------------
+void CAI_PlayerAlly::FoundEnemySound( CBaseEntity *pEnemy )
+{
+	AI_CriteriaSet modifiers;
+	ModifyOrAppendEnemyCriteria( modifiers, pEnemy );
+
+	SpeakIfAllowed( TLK_REFINDENEMY, modifiers );
+}
+#endif
 
 //-----------------------------------------------------------------------------
 // Purpose: Implemented to look at talk target

--- a/sp/src/game/server/ai_playerally.h
+++ b/sp/src/game/server/ai_playerally.h
@@ -137,6 +137,8 @@
 #define TLK_TAKING_FIRE	"TLK_TAKING_FIRE"	// Someone fired at me (regardless of whether I was hit)
 #define TLK_NEW_ENEMY	"TLK_NEW_ENEMY"		// A new enemy appeared while combat was already in progress
 #define TLK_COMBAT_IDLE	"TLK_COMBAT_IDLE"	// Similar to TLK_ATTACKING, but specifically for when *not* currently attacking (e.g. when in cover or reloading)
+#define TLK_LOSTENEMY	"TLK_LOSTENEMY"		// Current enemy has eluded squad
+#define TLK_REFINDENEMY	"TLK_REFINDENEMY"	// Found a previously eluded enemy
 #endif
 
 //-----------------------------------------------------------------------------
@@ -338,6 +340,11 @@ public:
 	//---------------------------------
 
 	virtual void PainSound( const CTakeDamageInfo &info );
+
+#ifdef MAPBASE
+	virtual void		LostEnemySound( CBaseEntity *pEnemy );
+	virtual void		FoundEnemySound( CBaseEntity *pEnemy );
+#endif
 
 	//---------------------------------
 	// Speech & Acting

--- a/sp/src/game/server/hl2/npc_combine.cpp
+++ b/sp/src/game/server/hl2/npc_combine.cpp
@@ -3145,13 +3145,22 @@ void CNPC_Combine::PainSound ( void )
 // Input  :
 // Output :
 //-----------------------------------------------------------------------------
+#ifdef MAPBASE
+void CNPC_Combine::LostEnemySound( CBaseEntity *pEnemy )
+#else
 void CNPC_Combine::LostEnemySound( void)
+#endif
 {
 	if ( gpGlobals->curtime <= m_flNextLostSoundTime )
 		return;
 
 #ifdef COMBINE_SOLDIER_USES_RESPONSE_SYSTEM
-	if (SpeakIfAllowed( TLK_CMB_LOSTENEMY, UTIL_VarArgs("lastseenenemy:%d", GetEnemyLastTimeSeen()) ))
+	AI_CriteriaSet modifiers;
+	ModifyOrAppendEnemyCriteria( modifiers, pEnemy );
+
+	modifiers.AppendCriteria( "lastseenenemy", gpGlobals->curtime - GetEnemies()->LastTimeSeen( pEnemy ) );
+
+	if (SpeakIfAllowed( TLK_CMB_LOSTENEMY, modifiers ))
 	{
 		m_flNextLostSoundTime = gpGlobals->curtime + random->RandomFloat(5.0,15.0);
 	}
@@ -3179,10 +3188,17 @@ void CNPC_Combine::LostEnemySound( void)
 // Input  :
 // Output :
 //-----------------------------------------------------------------------------
+#ifdef MAPBASE
+void CNPC_Combine::FoundEnemySound( CBaseEntity *pEnemy )
+#else
 void CNPC_Combine::FoundEnemySound( void)
+#endif
 {
 #ifdef COMBINE_SOLDIER_USES_RESPONSE_SYSTEM
-	SpeakIfAllowed( TLK_CMB_REFINDENEMY, SENTENCE_PRIORITY_HIGH );
+	AI_CriteriaSet modifiers;
+	ModifyOrAppendEnemyCriteria( modifiers, pEnemy );
+
+	SpeakIfAllowed( TLK_CMB_REFINDENEMY, modifiers, SENTENCE_PRIORITY_HIGH );
 #else
 	m_Sentences.Speak( "COMBINE_REFIND_ENEMY", SENTENCE_PRIORITY_HIGH );
 #endif

--- a/sp/src/game/server/hl2/npc_combine.h
+++ b/sp/src/game/server/hl2/npc_combine.h
@@ -181,8 +181,13 @@ public:
 #endif
 	void			IdleSound( void );
 	void			AlertSound( void );
+#ifdef MAPBASE
+	void			LostEnemySound( CBaseEntity *pEnemy );
+	void			FoundEnemySound( CBaseEntity *pEnemy );
+#else
 	void			LostEnemySound( void );
 	void			FoundEnemySound( void );
+#endif
 	void			AnnounceAssault( void );
 	void			AnnounceEnemyType( CBaseEntity *pEnemy );
 	void			AnnounceEnemyKill( CBaseEntity *pEnemy );

--- a/sp/src/game/server/hl2/npc_metropolice.cpp
+++ b/sp/src/game/server/hl2/npc_metropolice.cpp
@@ -2938,7 +2938,11 @@ void CNPC_MetroPolice::DeathSound( const CTakeDamageInfo &info )
 // Input  :
 // Output :
 //-----------------------------------------------------------------------------
+#ifdef MAPBASE
+void CNPC_MetroPolice::LostEnemySound( CBaseEntity *pEnemy )
+#else
 void CNPC_MetroPolice::LostEnemySound( void)
+#endif
 {
 	// Don't announce enemies when the player isn't a criminal
 	if ( !PlayerIsCriminal() )
@@ -2948,7 +2952,12 @@ void CNPC_MetroPolice::LostEnemySound( void)
 		return;
 
 #ifdef METROPOLICE_USES_RESPONSE_SYSTEM
-	if (SpeakIfAllowed(TLK_COP_LOSTENEMY))
+	AI_CriteriaSet modifiers;
+	ModifyOrAppendEnemyCriteria( modifiers, pEnemy );
+
+	modifiers.AppendCriteria( "lastseenenemy", gpGlobals->curtime - GetEnemies()->LastTimeSeen( pEnemy ) );
+
+	if (SpeakIfAllowed(TLK_COP_LOSTENEMY, modifiers ))
 	{
 		m_flNextLostSoundTime = gpGlobals->curtime + random->RandomFloat(5.0,15.0);
 	}
@@ -2977,14 +2986,21 @@ void CNPC_MetroPolice::LostEnemySound( void)
 // Input  :
 // Output :
 //-----------------------------------------------------------------------------
+#ifdef MAPBASE
+void CNPC_MetroPolice::FoundEnemySound( CBaseEntity *pEnemy )
+#else
 void CNPC_MetroPolice::FoundEnemySound( void)
+#endif
 {
 	// Don't announce enemies when I'm in arrest behavior
 	if ( HasSpawnFlags( SF_METROPOLICE_ARREST_ENEMY ) )
 		return;
 
 #ifdef METROPOLICE_USES_RESPONSE_SYSTEM
-	SpeakIfAllowed( TLK_COP_REFINDENEMY, SENTENCE_PRIORITY_HIGH );
+	AI_CriteriaSet modifiers;
+	ModifyOrAppendEnemyCriteria( modifiers, pEnemy );
+
+	SpeakIfAllowed( TLK_COP_REFINDENEMY, modifiers, SENTENCE_PRIORITY_HIGH );
 #else
 	m_Sentences.Speak( "METROPOLICE_REFIND_ENEMY", SENTENCE_PRIORITY_HIGH );
 #endif

--- a/sp/src/game/server/hl2/npc_metropolice.h
+++ b/sp/src/game/server/hl2/npc_metropolice.h
@@ -170,8 +170,13 @@ private:
 	void		SpeakAssaultSentence( int nSentenceType );
 	void		SpeakStandoffSentence( int nSentenceType );
 
+#ifdef MAPBASE
+	virtual void	LostEnemySound( CBaseEntity *pEnemy );
+	virtual void	FoundEnemySound( CBaseEntity *pEnemy );
+#else
 	virtual void	LostEnemySound( void );
 	virtual void	FoundEnemySound( void );
+#endif
 	virtual void	AlertSound( void );
 	virtual void	PainSound( const CTakeDamageInfo &info );
 	virtual void	DeathSound( const CTakeDamageInfo &info );


### PR DESCRIPTION
This pull request adds new versions of `LostEnemySound` and `FoundEnemySound` which pass the enemy the respective functions refer to, and it changes `npc_combine_s` and `npc_metropolice` to utilize the new functions. It also adds `TLK_REFINDENEMY` and `TLK_LOSTENEMY` to `CAI_PlayerAlly`, which encompasses citizens and other allied NPCs.

In vanilla HL2, Combine soldiers and metrocops did not use the correct enemy when evaluating the last time they saw one, causing their "lost short" sentences to go unused. This pull request fixes that, although these sentences are still rarely used due to the difficulty of enemies being marked as eluded under default soldier/metrocop AI.

The new concepts on `CAI_PlayerAlly` do nothing by default because no ally NPC in vanilla HL2 has responses for eluding or refinding enemies, but they can be used for custom responses and/or for when an ally-based NPC is using Combine soldier or metrocop responses.

---

<!-- Replace [ ] with [x] for each item your PR satisfies -->
#### PR Checklist
- [x] **My PR follows all guidelines in the CONTRIBUTING.md file**
- [x] My PR targets a `develop` branch OR targets another branch with a specific goal in mind
