### PR TITLE
[FIX] Undefined behaviour on comparison of NaN and float at particlemgr.cpp

### DIFF
--- a/mp/src/game/client/particlemgr.cpp
+++ b/mp/src/game/client/particlemgr.cpp
@@ -146,7 +146,7 @@ CParticleEffectBinding::CParticleEffectBinding()
 	m_LastMin = m_Min;
 	m_LastMax = m_Max;
 
-	m_flParticleCullRadius = 0.0f
+	m_flParticleCullRadius = 0.0f;
 
 	SetParticleCullRadius( 0.0f );
 	m_nActiveParticles = 0;

--- a/mp/src/game/client/particlemgr.cpp
+++ b/mp/src/game/client/particlemgr.cpp
@@ -146,6 +146,8 @@ CParticleEffectBinding::CParticleEffectBinding()
 	m_LastMin = m_Min;
 	m_LastMax = m_Max;
 
+	m_flParticleCullRadius = 0.0f
+
 	SetParticleCullRadius( 0.0f );
 	m_nActiveParticles = 0;
 

--- a/sp/src/game/client/particlemgr.cpp
+++ b/sp/src/game/client/particlemgr.cpp
@@ -146,7 +146,7 @@ CParticleEffectBinding::CParticleEffectBinding()
 	m_LastMin = m_Min;
 	m_LastMax = m_Max;
 
-	m_flParticleCullRadius = 0.0f
+	m_flParticleCullRadius = 0.0f;
 
 	SetParticleCullRadius( 0.0f );
 	m_nActiveParticles = 0;

--- a/sp/src/game/client/particlemgr.cpp
+++ b/sp/src/game/client/particlemgr.cpp
@@ -146,6 +146,8 @@ CParticleEffectBinding::CParticleEffectBinding()
 	m_LastMin = m_Min;
 	m_LastMax = m_Max;
 
+	m_flParticleCullRadius = 0.0f
+
 	SetParticleCullRadius( 0.0f );
 	m_nActiveParticles = 0;
 


### PR DESCRIPTION
At particlemgr.cpp in class `CParticleEffectBinding` there is a variable named `float m_flParticleCullRadius` that (as i think valve expected to happen) are 0.0f -ed in constructor by calling `SetParticleCullRadius(0.0f)`, but looks like they didnt know that `if ( m_flParticleCullRadius != flMaxParticleRadius )` that happens in `SetParticleCullRadius` working with float NaN, which is Undefined Behaviour, and results of this thing are declared by individual compilers realization.

As the result of the problem some particles like explosions, sparks, smoke and dust may not appear at all. There even where no drawcall at this conditions.

Its not a problem when you use same compiler version, on same system version, on same computer configuration. But it is if its a multiplatform open-source project.

Hopefully it can be fixed easely, by manually 0.0f -ing `m_flParticleCullRadius` in constructor.