### PR TITLE
OnStartTipped output for npc_turret_floor

### DIFF
--- a/sp/src/game/server/hl2/npc_turret_floor.cpp
+++ b/sp/src/game/server/hl2/npc_turret_floor.cpp
@@ -152,6 +152,9 @@ BEGIN_DATADESC( CNPC_FloorTurret )
 	DEFINE_OUTPUT( m_OnTipped, "OnTipped" ),
 	DEFINE_OUTPUT( m_OnPhysGunPickup, "OnPhysGunPickup" ),
 	DEFINE_OUTPUT( m_OnPhysGunDrop, "OnPhysGunDrop" ),
+#ifdef MAPBASE
+	DEFINE_OUTPUT( m_OnStartTipped, "OnStartTipped" ),
+#endif
 
 	DEFINE_BASENPCINTERACTABLE_DATADESC(),
 
@@ -1525,6 +1528,10 @@ bool CNPC_FloorTurret::PreThink( turretState_e state )
 				SetThink( &CNPC_FloorTurret::InactiveThink );
 				SetEyeState( TURRET_EYE_DEAD );
 			}
+
+#ifdef MAPBASE
+			m_OnStartTipped.FireOutput( this, this );
+#endif
 
 			//Stop being targetted
 			SetState( NPC_STATE_DEAD );

--- a/sp/src/game/server/hl2/npc_turret_floor.h
+++ b/sp/src/game/server/hl2/npc_turret_floor.h
@@ -265,6 +265,9 @@ protected:
 	COutputEvent m_OnTipped;
 	COutputEvent m_OnPhysGunPickup;
 	COutputEvent m_OnPhysGunDrop;
+#ifdef MAPBASE
+	COutputEvent m_OnStartTipped;
+#endif
 
 	bool	m_bHackedByAlyx;
 	HSOUNDSCRIPTHANDLE			m_ShotSounds;


### PR DESCRIPTION
This PR adds a new `OnStartTipped` output for `npc_turret_floor`. This output will fire the moment a turret is tipped over and begins thrashing, as opposed to `OnTipped`, which only fires after the turret has finished thrashing and goes inactive.

This output will also fire when a turret without ammo is tipped over and goes inactive.

---

<!-- Replace [ ] with [x] for each item your PR satisfies -->
#### PR Checklist
- [x] **My PR follows all guidelines in the CONTRIBUTING.md file**
- [x] My PR targets a `develop` branch OR targets another branch with a specific goal in mind
