### PR TITLE
Fix vgui_screen crashing existing saves (until Mapbase v8.0)

### DIFF
--- a/sp/src/game/server/vguiscreen.cpp
+++ b/sp/src/game/server/vguiscreen.cpp
@@ -184,6 +184,11 @@ CVGuiScreen::~CVGuiScreen()
 
 int CVGuiScreen::Save(ISave& save)
 {
+#if MAPBASE_VER_INT < 8000
+	// HACKHACK: Until v8.0, mark this screen as using the new save system to prevent existing saves with vgui_screen from crashing
+	AddContext( "uses_new_save", "1" );
+#endif
+
 	int status = BaseClass::Save(save);
 	if (!status)
 		return 0;
@@ -208,6 +213,12 @@ int CVGuiScreen::Restore(IRestore& restore)
 	int status = BaseClass::Restore(restore);
 	if (!status)
 		return 0;
+
+#if MAPBASE_VER_INT < 8000
+	// HACKHACK: Until v8.0, mark this screen as using the new save system to prevent existing saves with vgui_screen from crashing
+	if (!HasContext( "uses_new_save", "1" ))
+		return status;
+#endif
 
 	const int iCount = restore.ReadInt();
 	m_PanelOutputs.EnsureCapacity(iCount);


### PR DESCRIPTION
This fixes existing saves with `vgui_screen`s crashing on load. This was caused by https://github.com/mapbase-source/source-sdk-2013/pull/264, which has unique handling for saving and restoring outputs.

This code will be automatically disabled when the version is incremented to v8.0, the next save-breaking update.

---

<!-- Replace [ ] with [x] for each item your PR satisfies -->
#### PR Checklist
- [x] **My PR follows all guidelines in the CONTRIBUTING.md file**
- [x] My PR targets a `develop` branch OR targets another branch with a specific goal in mind
