### PR TITLE
Fix citizen SelectModel VScript hook having issues in save/restore

### DIFF
--- a/sp/src/game/server/hl2/npc_citizen17.cpp
+++ b/sp/src/game/server/hl2/npc_citizen17.cpp
@@ -839,6 +839,9 @@ void CNPC_Citizen::SelectModel()
 					}
 				}
 
+				// Models selected this way must be unique to avoid conflicts in save/restore
+				m_Type = CT_UNIQUE;
+
 				// Just set the model right here
 				SetModelName( AllocPooledString( returnValue.m_pszString ) );
 				return;


### PR DESCRIPTION
This PR fixes citizens which selected a model via `SelectModel` switching back to default citizen models after loading a save.

After using the `SelectModel` hook, citizens will now have their type set to `CT_UNIQUE`, which bypasses the model selection code and prevents a new one from being selected by accident later.

---

<!-- Replace [ ] with [x] for each item your PR satisfies -->
#### PR Checklist
- [x] **My PR follows all guidelines in the CONTRIBUTING.md file**
- [x] My PR targets a `develop` branch OR targets another branch with a specific goal in mind
