### PR TITLE
Move npc_metropolice enemy kill concept to Event_KilledOther()

### DIFF
--- a/sp/src/game/server/hl2/npc_metropolice.cpp
+++ b/sp/src/game/server/hl2/npc_metropolice.cpp
@@ -534,10 +534,12 @@ void CNPC_MetroPolice::OnScheduleChange()
 {
 	BaseClass::OnScheduleChange();
 
+#ifndef MAPBASE // Moved to Event_KilledOther()
 	if ( GetEnemy() && HasCondition( COND_ENEMY_DEAD ) )
 	{
 		AnnounceEnemyKill( GetEnemy() );
 	}
+#endif
 }
 
 
@@ -3704,6 +3706,21 @@ void CNPC_MetroPolice::Event_Killed( const CTakeDamageInfo &info )
 	}
 
 	BaseClass::Event_Killed( info );
+}
+
+//-----------------------------------------------------------------------------
+// 
+//-----------------------------------------------------------------------------
+void CNPC_MetroPolice::Event_KilledOther( CBaseEntity *pVictim, const CTakeDamageInfo &info )
+{
+	BaseClass::Event_KilledOther( pVictim, info );
+
+#ifdef MAPBASE // Moved from OnScheduleChange()
+	if ( pVictim && (pVictim->IsPlayer() || pVictim->IsNPC()) )
+	{
+		AnnounceEnemyKill( pVictim );
+	}
+#endif
 }
 
 //-----------------------------------------------------------------------------

--- a/sp/src/game/server/hl2/npc_metropolice.h
+++ b/sp/src/game/server/hl2/npc_metropolice.h
@@ -79,6 +79,8 @@ public:
 
 	virtual void Event_Killed( const CTakeDamageInfo &info );
 
+	virtual void Event_KilledOther( CBaseEntity *pVictim, const CTakeDamageInfo &info );
+
 	virtual void OnScheduleChange();
 
 	float		GetIdealAccel( void ) const;


### PR DESCRIPTION
This PR moves the call to `AnnounceEnemyKill` from `OnScheduleChange` to `Event_KilledOther`. By using the direct victim (rather than just the current enemy), this fixes `npc_metropolice` not referring to the correct enemy.

---

<!-- Replace [ ] with [x] for each item your PR satisfies -->
#### PR Checklist
- [x] **My PR follows all guidelines in the CONTRIBUTING.md file**
- [x] My PR targets a `develop` branch OR targets another branch with a specific goal in mind
