### PR TITLE
Fix func_conveyor "SetSpeed" not properly reading float input

### DIFF
--- a/sp/src/game/server/bmodels.cpp
+++ b/sp/src/game/server/bmodels.cpp
@@ -285,9 +285,10 @@ LINK_ENTITY_TO_CLASS( func_conveyor, CFuncConveyor );
 BEGIN_DATADESC( CFuncConveyor )
 
 	DEFINE_INPUTFUNC( FIELD_VOID, "ToggleDirection", InputToggleDirection ),
-	DEFINE_INPUTFUNC( FIELD_VOID, "SetSpeed", InputSetSpeed ),
+	DEFINE_INPUTFUNC( FIELD_FLOAT, "SetSpeed", InputSetSpeed ),
 
 	DEFINE_KEYFIELD( m_vecMoveDir, FIELD_VECTOR, "movedir" ),
+	DEFINE_KEYFIELD( m_flSpeed, FIELD_FLOAT, "speed" ),
 	DEFINE_FIELD( m_flConveyorSpeed, FIELD_FLOAT ),
 
 END_DATADESC()


### PR DESCRIPTION
code credit goes to Verttox from the momentum mod repo 

https://togithub.com/momentum-mod/game/pull/346/commits/c4cdba18480de6e6665ef46f3bb535a1c6e15b43 (togithub.com redirect cause crosslink bumps are cringe)

Anyway heres a video of it working in my custom edit of mapbase: https://github.com/meatspace/storage/raw/refs/heads/main/setspeed.mp4

Im not a programmer so ymmv. I don't THINK it breaks anything. I specifically did not include the other half of the commit that changes m_flSpeed to 0 which I believe **would** break existing maps. _(idk how to make that code optional, perhaps you can do that)_ 


---

#### Does this PR close any issues?
no

<!-- Replace [ ] with [x] for each item your PR satisfies -->
#### PR Checklist
- [x] **My PR follows all guidelines in the CONTRIBUTING.md file**
- [x] My PR targets a `develop` branch OR targets another branch with a specific goal in mind
