### PR TITLE
Integrate registry key fix for using VPC without Visual Studio 2013

### DIFF
--- a/sp/src/vpc_scripts/newer_vs_toolsets.vpc
+++ b/sp/src/vpc_scripts/newer_vs_toolsets.vpc
@@ -13,6 +13,10 @@ $Conditional VS2019	"0" // Toggles Visual Studio 2019 (v142) toolset
 $Conditional VS2022	"0" // Toggles Visual Studio 2022 (v143) toolset
 
 // 
+// WARNING: If you do not have Visual Studio 2013 installed and try to use VPC, it may produce an error about a missing RegKey.
+// You can fix this without installing VS2013 by running newer_vs_toolsets_regkey_fix.reg, which is in the same directory as this file.
+// This .reg file adds a registry key which is normally created by installing VS2013. You will only have to do this once per machine.
+// 
 // VPC may still say "Generating for Visual Studio 2013" even when using one of the above toolsets. This message is irrelevant and can be ignored.
 // 
 // The following projects currently do not compile with any of the above toolsets and are not included in their solutions:

--- a/sp/src/vpc_scripts/newer_vs_toolsets_regkey_fix.reg
+++ b/sp/src/vpc_scripts/newer_vs_toolsets_regkey_fix.reg
@@ -1,0 +1,7 @@
+Windows Registry Editor Version 5.00
+
+; https://github.com/ValveSoftware/source-sdk-2013/issues/72#issuecomment-326633328
+; If you are running a 32-bit system, you may need to remove WOW6432Node from the path.
+
+[HKEY_LOCAL_MACHINE\SOFTWARE\WOW6432Node\Microsoft\VisualStudio\10.0\Projects\{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}]
+"DefaultProjectExtension"="vcproj"


### PR DESCRIPTION
If VPC is used without having Visual Studio 2013 installed, VPC may produce an error about a missing registry key. This is an issue if you want to use newer VS toolsets without having to install VS2013, but it can be fixed by adding the registry key manually. This PR adds a registry file which applies the fix and adds instructions on how to use it for newer VS toolsets.

---

<!-- Replace [ ] with [x] for each item your PR satisfies -->
#### PR Checklist
- [x] **My PR follows all guidelines in the CONTRIBUTING.md file**
- [x] My PR targets a `develop` branch OR targets another branch with a specific goal in mind
