### PR TITLE
Change workflow to use .sln and consolidate artifact tasks

### DIFF
--- a/.github/workflows/mapbase_build-base.yml
+++ b/.github/workflows/mapbase_build-base.yml
@@ -54,7 +54,7 @@ jobs:
     - uses: actions/checkout@v4
 
     - name: Add MSBuild to PATH
-      uses: microsoft/setup-msbuild@v1.1
+      uses: compnerd/gha-setup-vsdevenv@v6
 
     - name: Enable VS2022
       working-directory: '${{inputs.branch}}/src/vpc_scripts'
@@ -77,108 +77,40 @@ jobs:
 
       # --------------------------------------------------------------------
 
-      # "I'm invoking msbuild for each project individually, which looks a bit odd considering there is a solution file which should be able to invoke the builds in their proper order automatically, but passing the solution to msbuild doesn't seem to work."
-      # https://github.com/mapbase-source/source-sdk-2013/pull/162
-
-    - name: Build mathlib
+    - name: Build
       #if: steps.filter.outputs.game == 'true'
       working-directory: '${{inputs.branch}}/src'
       shell: cmd
       run: |
-        msbuild -m -p:Configuration=${{inputs.configuration}} mathlib\mathlib.vcxproj || exit /b
-
-    - name: Build Base Libraries
-      if: inputs.project-group == 'all' || inputs.project-group == 'game' || inputs.project-group == 'maptools'
-      working-directory: '${{inputs.branch}}/src'
-      shell: cmd
-      run: |
-        msbuild -m -p:Configuration=${{inputs.configuration}} raytrace\raytrace.vcxproj || exit /b
-        msbuild -m -p:Configuration=${{inputs.configuration}} tier1\tier1.vcxproj || exit /b
-        msbuild -m -p:Configuration=${{inputs.configuration}} vscript\vscript.vcxproj || exit /b
-
-    - name: Build Map Tools
-      if: inputs.project-group == 'all' || inputs.project-group == 'maptools'
-      working-directory: '${{inputs.branch}}/src'
-      shell: cmd
-      run: |
-        msbuild -m -p:Configuration=${{inputs.configuration}} fgdlib\fgdlib.vcxproj || exit /b
-        msbuild -m -p:Configuration=${{inputs.configuration}} utils\vbsp\vbsp.vcxproj || exit /b
-        msbuild -m -p:Configuration=${{inputs.configuration}} utils\vvis\vvis_dll.vcxproj || exit /b
-        msbuild -m -p:Configuration=${{inputs.configuration}} utils\vvis_launcher\vvis_launcher.vcxproj || exit /b
-        msbuild -m -p:Configuration=${{inputs.configuration}} utils\vrad\vrad_dll.vcxproj || exit /b
-        msbuild -m -p:Configuration=${{inputs.configuration}} utils\vrad_launcher\vrad_launcher.vcxproj || exit /b
-
-    - name: Build Shaders
-      if: inputs.project-group == 'shaders'
-      working-directory: '${{inputs.branch}}/src'
-      shell: cmd
-      run: |
-        msbuild -m -p:Configuration=${{inputs.configuration}} materialsystem\stdshaders\game_shader_dx9_${{inputs.game}}.vcxproj || exit /b
-
-    - name: Build Game
-      if: inputs.project-group == 'game'
-      working-directory: '${{inputs.branch}}/src'
-      shell: cmd
-      run: |
-        msbuild -m -p:Configuration=${{inputs.configuration}} vgui2\vgui_controls\vgui_controls.vcxproj || exit /b
-        msbuild -m -p:Configuration=${{inputs.configuration}} responserules\runtime\responserules.vcxproj || exit /b
-        msbuild -m -p:Configuration=${{inputs.configuration}} game\client\client_${{inputs.game}}.vcxproj || exit /b
-        msbuild -m -p:Configuration=${{inputs.configuration}} game\server\server_${{inputs.game}}.vcxproj || exit /b
-
-    # TODO: Hook to game naming?
-    - name: Build everything
-      if: inputs.project-group == 'all'
-      working-directory: '${{inputs.branch}}/src'
-      shell: cmd
-      run: |
-        msbuild -m -p:Configuration=${{inputs.configuration}} vgui2\vgui_controls\vgui_controls.vcxproj || exit /b
-        msbuild -m -p:Configuration=${{inputs.configuration}} responserules\runtime\responserules.vcxproj || exit /b
-        msbuild -m -p:Configuration=${{inputs.configuration}} materialsystem\stdshaders\game_shader_dx9_episodic.vcxproj || exit /b
-        msbuild -m -p:Configuration=${{inputs.configuration}} materialsystem\stdshaders\game_shader_dx9_hl2.vcxproj || exit /b
-        msbuild -m -p:Configuration=${{inputs.configuration}} game\client\client_episodic.vcxproj || exit /b
-        msbuild -m -p:Configuration=${{inputs.configuration}} game\client\client_hl2.vcxproj || exit /b
-        msbuild -m -p:Configuration=${{inputs.configuration}} game\server\server_episodic.vcxproj || exit /b
-        msbuild -m -p:Configuration=${{inputs.configuration}} game\server\server_hl2.vcxproj || exit /b
+        devenv ${{inputs.solution-name}}.sln /upgrade
+        msbuild -m -t:Rebuild -p:Configuration=${{inputs.configuration}};Platform=x86 ${{inputs.solution-name}}.sln
 
       # --------------------------------------------------------------------
 
-    - name: Publish Windows game DLLs
-      if: inputs.project-group == 'game'
-      uses: actions/upload-artifact@v3
+    - name: Publish game binaries
+      if: inputs.project-group == 'game' || inputs.project-group == 'shaders'
+      uses: actions/upload-artifact@v4
       with:
-        name: 'Windows Game DLLs (server & client.dll) [${{ inputs.configuration }}]'
+        name: '${{inputs.project-group}}_${{inputs.game}}_win32_${{ inputs.configuration }}'
         path: |
-          ${{inputs.branch}}/game/mod_${{inputs.game}}/bin/client.dll
-          ${{inputs.branch}}/game/mod_${{inputs.game}}/bin/server.dll
+          ${{inputs.branch}}/game/mod_${{inputs.game}}/bin/*.dll
         if-no-files-found: error
 
-    - name: Publish Windows shader DLL
-      if: inputs.project-group == 'shaders'
-      uses: actions/upload-artifact@v3
-      with:
-        name: 'Windows Shader DLL (game_shader_dx9.dll) [${{ inputs.configuration }}]'
-        path: |
-          ${{inputs.branch}}/game/mod_${{inputs.game}}/bin/game_shader_dx9.dll
-        if-no-files-found: error
-
-    - name: Publish Windows map tools
+    - name: Publish map tools
       if: inputs.project-group == 'maptools'
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
-        name: 'Windows Map Tools [${{ inputs.configuration }}]'
+        name: '${{inputs.project-group}}_win32_${{ inputs.configuration }}'
         path: |
-          ${{inputs.branch}}/game/bin/vbsp.exe
-          ${{inputs.branch}}/game/bin/vvis.exe
-          ${{inputs.branch}}/game/bin/vvis_dll.dll
-          ${{inputs.branch}}/game/bin/vrad.exe
-          ${{inputs.branch}}/game/bin/vrad_dll.dll
+          ${{inputs.branch}}/game/bin/*.exe
+          ${{inputs.branch}}/game/bin/*.dll
         if-no-files-found: error
 
-    - name: Publish everything (Windows)
+    - name: Publish everything
       if: inputs.project-group == 'all'
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
-        name: 'Everything (Windows) [${{ inputs.configuration }}]'
+        name: 'everything_win32_${{ inputs.configuration }}'
         path: |
           ${{inputs.branch}}/game/bin
           ${{inputs.branch}}/game/mod_*/bin
@@ -225,30 +157,21 @@ jobs:
 
       # --------------------------------------------------------------------
 
-    - name: Publish Linux game SOs
-      if: inputs.project-group == 'game'
-      uses: actions/upload-artifact@v3
+    - name: Publish game binaries
+      if: inputs.project-group == 'game' || inputs.project-group == 'shaders'
+      uses: actions/upload-artifact@v4
       with:
-        name: 'Linux Game SOs (server & client.so) [${{ inputs.configuration }}]'
+        name: '${{inputs.project-group}}_${{inputs.game}}_linux32_${{ inputs.configuration }}'
         path: |
-          ${{inputs.branch}}/game/mod_${{inputs.game}}/bin/client.so
-          ${{inputs.branch}}/game/mod_${{inputs.game}}/bin/server.so
+          ${{inputs.branch}}/game/mod_${{inputs.game}}/bin/*.so
+          !${{inputs.branch}}/game/mod_${{inputs.game}}/bin/*_srv.so
         if-no-files-found: error
 
-    - name: Publish Linux shader SO
-      if: inputs.project-group == 'shaders'
-      uses: actions/upload-artifact@v3
-      with:
-        name: 'Linux Shader SO (game_shader_dx9.so) [${{ inputs.configuration }}]'
-        path: |
-          ${{inputs.branch}}/game/mod_${{inputs.game}}/bin/game_shader_dx9.so
-        if-no-files-found: error
-
-    #- name: Publish Linux map tools
+    #- name: Publish map tools
     #  if: inputs.project-group == 'maptools'
-    #  uses: actions/upload-artifact@v3
+    #  uses: actions/upload-artifact@v4
     #  with:
-    #    name: 'Linux Map Tools [${{ inputs.configuration }}]'
+    #    name: '${{inputs.project-group}}_linux32_${{ inputs.configuration }}'
     #    path: |
     #      ${{inputs.branch}}/game/bin/vbsp
     #      ${{inputs.branch}}/game/bin/vvis
@@ -259,11 +182,11 @@ jobs:
 
     # For now, don't publish the .dbg files even though we publish .pdb files on Windows
     # (they're too big)
-    - name: Publish everything (Linux)
+    - name: Publish everything
       if: inputs.project-group == 'all'
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
-        name: 'Everything (Linux) [${{ inputs.configuration }}]'
+        name: 'everything_linux32_${{ inputs.configuration }}'
         path: |
           ${{inputs.branch}}/game/bin/*.so
           !${{inputs.branch}}/game/bin/*_srv.so


### PR DESCRIPTION
This PR changes the GitHub Actions build workflow to use the solution file instead of the individual projects. It also updates the artifact tasks to `v4`, standardizes their archive names, and consolidates them.

---

### Moving to .sln

Previously, building using the solution file didn't work for unknown reasons. After further investigation, it turned out to be because the solution file generated by VPC as-is apparently lacks data that MSBuild needs. I'm not sure if this is due to VPC still using a VS2013-based format or if it's because VPC assumes the solution would be opened by Visual Studio first, but Visual Studio automatically modifies/upgrades the solution upon opening it while MSBuild does not. Since the GitHub workflow directly invoked MSBuild and didn't use Visual Studio, the solution file could not be read properly.

In order to fix this, I first switched from `setup-msbuild` to a more general action called `gha-setup-vsdevenv` which also adds `devenv` to PATH. This is specifically [a more up-to-date fork](https://github.com/compnerd/gha-setup-vsdevenv) of [an action on the marketplace](https://github.com/marketplace/actions/setup-vs-dev-environment) that no longer appears to be maintained. This allows me to invoke `devenv /upgrade`, which upgrades the target solution in the same way that Visual Studio does.

Now, the solution is able to be built directly by MSBuild. With that in mind. I consolidated all of the build tasks into a single one, as is already the case with the Linux build.

#### Pros and cons against direct projects

From my testing, this method seems to generally take a few minutes longer to compile than when projects are used directly. I'm not sure if this is because of the solution being upgraded or if it's from compiling the solution itself, but this generally isn't noticeable because the Linux compile already (generally) takes much longer, so there isn't much fluctuation in when the job as a whole actually completes.

Other than that, building the solution file directly nullifies several workarounds and hacks which were needed when building direct projects. For example, the workflows were previously separated into several shared build tasks, some of which were found to be in the wrong place or required other explicit commands to make sure they failed the job if they failed to compile. Building everything also required the games to be explicitly defined within the workflow, as opposed to just being an anonymous input option.

Building with the solution dodges all of this and only requires a single compile step with no conditionals, with conditional behavior instead being handled by VPC and making the workflow one-to-one with how a regular user would compile the projects.

---

### Artifact tasks

The artifact tasks were updated to `v4` to remove a deprecation notice, although I also made some changes to try to standardize them better. These are not as important as the solution fix, but they make the artifact tasks similarly extendable.

Previously, the artifact tasks were separated based on explicit file names, while building everything provided the full folders. For example, building for the game explicitly uploaded `server.dll` and `client.dll`, while building for the shaders explicitly uploaded `game_shader_dx9.dll`. I've united both of those tasks into publishing all DLLs in the relevant game's `bin` folder. Similarly, the compile tools were previously uploaded via explicit `.exe` and `.dll` names for the compile tools. I've changed this to upload all `.exe` and `.dll` files in the root `bin` folder used by the tools. This not only simplifies the steps involved, but it also allows any additional binaries to be uploaded in case a mod defines new projects within an existing solution.

#### Artifact names

I also changed the convention of the archive file names. Previously, the file names used long explicit titles with spaces and casing, such as "Windows Game DLLs (server & client.dll) [Release]" or "Everything (Linux) [Debug]". I don't think this is as readable or user-friendly as I thought it would be, or at least in my personal experience.

I've implemented a new naming convention which uses the standard of `{project group}_{game}_{platform} [{Configuration}]` instead. Here's some examples of artifacts using this convention:

| Old Name | New Name |
| -------- | ------- |
| Windows Game DLLs (server & client.dll) [Release] | game_episodic_win32 [Release] |
| Linux Shader SO (game_shader_dx9.so) [Release] | shaders_hl2_linux32 [Release] |
| Everything (Linux) [Debug] | everything_linux32 [Debug] |
| Windows Map Tools [Debug] | maptools_win32 [Debug] |

*(Note: The selected game was not mentioned in the old naming system)*

I am open to feedback on this in case the old naming system is widely preferred.

---

<!-- Replace [ ] with [x] for each item your PR satisfies -->
#### PR Checklist
- [x] **My PR follows all guidelines in the CONTRIBUTING.md file**
- [x] My PR targets a `develop` branch OR targets another branch with a specific goal in mind
