### PR TITLE
Fix crash when objects are pulled with the gravity gun

### DIFF
--- a/sp/src/game/server/hl2/weapon_physcannon.cpp
+++ b/sp/src/game/server/hl2/weapon_physcannon.cpp
@@ -2758,7 +2758,7 @@ CWeaponPhysCannon::FindObjectResult_t CWeaponPhysCannon::FindObject( void )
 		pullDir *= (mass + 0.5) * (1/50.0f);
 	}
 
-	CPhysicsProp* pProp = dynamic_cast<CPhysicsProp*>(pObj);
+	CPhysicsProp* pProp = dynamic_cast<CPhysicsProp*>(pEntity);
 	if (pProp) {
 		pProp->OnPhysGunPull( pOwner );
 	}


### PR DESCRIPTION
This PR fixes a crash introduced with the latest update. Upon pulling an object with the gravity gun, the game would crash.

The issue was introduced with https://github.com/mapbase-source/source-sdk-2013/pull/266 and was due to the `dynamic_cast` seen [here](https://github.com/mapbase-source/source-sdk-2013/commit/02e232babf80b12ba7db102b39a659c584658b66#diff-e094bf11a8a45398dcba684f01e4be33055c759f249b26ad1227d0805042e858R2726-R2730). The problem with this `dynamic_cast` was that it casted to `pObj` instead of `pEntity`. `pObj` refers to `pEntity`'s physics object, rather than the entity itself. With this PR, I confirmed that the crash is resolved and the new output functions properly.

This resolves https://github.com/mapbase-source/source-sdk-2013/issues/358.

---

As a hotfix branch, this will be rebased directly into `master`. Please do not pull from this branch independently.