### PR TITLE
Improvements to gunship and helicopter crash points

### DIFF
--- a/sp/src/game/server/hl2/npc_combinegunship.cpp
+++ b/sp/src/game/server/hl2/npc_combinegunship.cpp
@@ -187,15 +187,29 @@ public:
 	{
 		return m_bDisabled;
 	}
+#ifdef MAPBASE
+	void	GunshipCrashedOnTarget( CBaseHelicopter *pGunship )
+	{
+		m_OnCrashed.FireOutput( pGunship, this );
+	}
+	void	GunshipAcquiredCrashTarget( CBaseHelicopter *pGunship )
+	{
+		m_OnBeginCrash.FireOutput( pGunship, this );
+	}
+#else
 	void	GunshipCrashedOnTarget( void )
 	{
 		m_OnCrashed.FireOutput( this, this );
 	}
+#endif
 
 private:
 	bool			m_bDisabled;
 
 	COutputEvent	m_OnCrashed;
+#ifdef MAPBASE
+	COutputEvent	m_OnBeginCrash;
+#endif
 };
 
 LINK_ENTITY_TO_CLASS( info_target_gunshipcrash, CTargetGunshipCrash );
@@ -209,6 +223,9 @@ BEGIN_DATADESC( CTargetGunshipCrash )
 
 	// Outputs
 	DEFINE_OUTPUT( m_OnCrashed,			"OnCrashed" ),
+#ifdef MAPBASE
+	DEFINE_OUTPUT( m_OnBeginCrash,			"OnBeginCrash" ),
+#endif
 END_DATADESC()
 
 
@@ -1564,7 +1581,11 @@ void CNPC_CombineGunship::PrescheduleThink( void )
 				{
 					BeginDestruct();
 					m_OnCrashed.FireOutput( this, this );
+#ifdef MAPBASE
+					m_hCrashTarget->GunshipCrashedOnTarget( this );
+#else
 					m_hCrashTarget->GunshipCrashedOnTarget();
+#endif
 					return;
 				}
 			}
@@ -1975,6 +1996,10 @@ bool CNPC_CombineGunship::FindNearestGunshipCrash( void )
   	m_hCrashTarget = pNearest;
 	m_flNextGunshipCrashFind = gpGlobals->curtime + 0.5;
 	m_flEndDestructTime = 0;
+
+#ifdef MAPBASE
+	m_hCrashTarget->GunshipAcquiredCrashTarget( this );
+#endif
 
 	if ( g_debug_gunship.GetInt() )
 	{


### PR DESCRIPTION
This PR makes several changes to `info_target_gunshipcrash` and `info_target_helicopter_crash`, the entities used by `npc_combinegunship` and `npc_helicopter` respectively when looking for a destination to crash at.

Both crash point entities now have an `OnBeginCrash` output for when an aircraft begins flying over to crash on the point. `info_target_gunshipcrash`'s `OnCrashed` output will now provide the crashed gunship as the activator. `info_target_helicopter_crash` now has the `OnCrashed` output as well, with the same type of activator.

`npc_helicopter` will now use a similar search method to `npc_combinegunship`, searching for and crashing at the nearest crash point instead of the first found. The original behavior can be toggled with `g_helicopter_crashpoint_nearest` if needed.

`npc_helicopter` will also now have an optional cvar called `g_helicopter_phys_follow_while_crashing` which allows the bone followers to continue to follow the helicopter while it is navigating to a crash point. This is technically a bug, as the bone followers would normally stay at the previous location and can still collide with anything at that location. However, this is in a cvar that's disabled by default to prevent any potential differences or issues.

---

<!-- Replace [ ] with [x] for each item your PR satisfies -->
#### PR Checklist
- [x] **My PR follows all guidelines in the CONTRIBUTING.md file**
- [x] My PR targets a `develop` branch OR targets another branch with a specific goal in mind
