### PR TITLE
Append followup dispatcher contexts to response followup target

### DIFF
--- a/sp/src/game/server/ai_expresserfollowup.cpp
+++ b/sp/src/game/server/ai_expresserfollowup.cpp
@@ -78,6 +78,7 @@ static void DispatchComeback( CAI_ExpresserWithFollowup *pExpress, CBaseEntity *
 	// See DispatchFollowupThroughQueue()
 	criteria.AppendCriteria( "From_idx", CNumStr( pSpeaker->entindex() ) );
 	criteria.AppendCriteria( "From_class", pSpeaker->GetClassname() );
+	pSpeaker->AppendContextToCriteria( criteria, "From_" );
 #endif
 	// if a SUBJECT criteria is missing, put it back in.
 	if ( criteria.FindCriterionIndex( "Subject" ) == -1 )


### PR DESCRIPTION
This PR allows response followup targets to use contexts from the entity that dispatched the followup.

---

<!-- Replace [ ] with [x] for each item your PR satisfies -->
#### PR Checklist
- [x] **My PR follows all guidelines in the CONTRIBUTING.md file**
- [x] My PR targets a `develop` branch OR targets another branch with a specific goal in mind
