### PR TITLE
Fix suit power HUD checking for actual sprint instead of sprint device

### DIFF
--- a/sp/src/game/client/hl2/hud_suitpower.cpp
+++ b/sp/src/game/client/hl2/hud_suitpower.cpp
@@ -100,7 +100,11 @@ void CHudSuitPower::OnThink( void )
 	}
 
 	bool flashlightActive = pPlayer->IsFlashlightActive();
+#ifdef MAPBASE
+	bool sprintActive = pPlayer->IsSprintActive();
+#else
 	bool sprintActive = pPlayer->IsSprinting();
+#endif
 	bool breatherActive = pPlayer->IsBreatherActive();
 	int activeDevices = (int)flashlightActive + (int)sprintActive + (int)breatherActive;
 
@@ -250,7 +254,11 @@ void CHudSuitPower::Paint()
 			ypos += text2_gap;
 		}
 
+#ifdef MAPBASE
+		if (pPlayer->IsSprintActive())
+#else
 		if (pPlayer->IsSprinting())
+#endif
 		{
 			tempString = g_pVGuiLocalize->Find("#Valve_Hud_SPRINT");
 


### PR DESCRIPTION
This PR fixes the HL2 aux power HUD directly checking for if the player is sprinting with `IsSprinting()`, rather than whether or not the sprinting device is active with `IsSprintActive()` like with the other suit devices. This is an issue in cases where the sprint device isn't active, but the player is still sprinting (e.g. some alternate infinite sprint methods in mods).

Otherwise, this PR does not change anything functionally. `IsSprinting()` and `IsSprintActive()` will normally return the same value in practice.

---

<!-- Replace [ ] with [x] for each item your PR satisfies -->
#### PR Checklist
- [x] **My PR follows all guidelines in the CONTRIBUTING.md file**
- [x] My PR targets a `develop` branch OR targets another branch with a specific goal in mind
