### PR TITLE
Fix SetRelationship input not using !activator

### DIFF
--- a/sp/src/game/server/basecombatcharacter.cpp
+++ b/sp/src/game/server/basecombatcharacter.cpp
@@ -3482,13 +3482,13 @@ void CBaseCombatCharacter::AddRelationship( const char *pszRelationship, CBaseEn
 		bool bFoundEntity = false;
 
 		// Try to get pointer to an entity of this name
-		CBaseEntity *entity = gEntList.FindEntityByName( NULL, entityString );
+		CBaseEntity *entity = gEntList.FindEntityByName( NULL, entityString, this, pActivator );
 		while( entity )
 		{
 			// make sure you catch all entities of this name.
 			bFoundEntity = true;
 			AddEntityRelationship(entity, disposition, priority );
-			entity = gEntList.FindEntityByName( entity, entityString );
+			entity = gEntList.FindEntityByName( entity, entityString, this, pActivator );
 		}
 
 		if( !bFoundEntity )


### PR DESCRIPTION
This PR fixes the `SetRelationship` input not respecting `!activator`. This may also allow it to access procedurals that require `!self`.

---

<!-- Replace [ ] with [x] for each item your PR satisfies -->
#### PR Checklist
- [x] **My PR follows all guidelines in the CONTRIBUTING.md file**
- [x] My PR targets a `develop` branch OR targets another branch with a specific goal in mind
