### PR TITLE
Fix detail scale in SDK_VertexLitGeneric not working with phong and bumpmap

### DIFF
--- a/sp/src/materialsystem/stdshaders/skin_dx9_helper.cpp
+++ b/sp/src/materialsystem/stdshaders/skin_dx9_helper.cpp
@@ -767,16 +767,7 @@ void DrawSkin_DX9_Internal( CBaseVSShader *pShader, IMaterialVar** params, IShad
 
 		pShader->SetVertexShaderTextureTransform( VERTEX_SHADER_SHADER_SPECIFIC_CONST_0, info.m_nBaseTextureTransform );
 
-#ifdef MAPBASE
-		// The original code makes it seem like we have the opportunity to support both $bumptransform and $detail at the same time,
-		// and that may or may not have been Valve's intention, but we'd need to add another texcoord for this and it's already
-		// a limitation with the non-skin shader anyway.
-		if ( bHasBump )
-		{
-			pShader->SetVertexShaderTextureTransform( VERTEX_SHADER_SHADER_SPECIFIC_CONST_4, info.m_nBumpTransform );
-		}
-		else
-#else
+#ifndef MAPBASE // See below
 		if( bHasBump )
 		{
 			pShader->SetVertexShaderTextureTransform( VERTEX_SHADER_SHADER_SPECIFIC_CONST_2, info.m_nBumpTransform );
@@ -794,6 +785,15 @@ void DrawSkin_DX9_Internal( CBaseVSShader *pShader, IMaterialVar** params, IShad
 																info.m_nBaseTextureTransform, 
 																info.m_nDetailScale );
 		}
+#ifdef MAPBASE
+		// The original code makes it seem like we have the opportunity to support both $bumptransform and $detail at the same time,
+		// and that may or may not have been Valve's intention, but we'd need to add another texcoord for this and it's already
+		// a limitation with the non-skin shader anyway.
+		else if ( bHasBump )
+		{
+			pShader->SetVertexShaderTextureTransform( VERTEX_SHADER_SHADER_SPECIFIC_CONST_4, info.m_nBumpTransform );
+		}
+#endif
 
 		pShader->SetModulationPixelShaderDynamicState_LinearColorSpace( 1 );
 		pShader->SetPixelShaderConstant_W( PSREG_SELFILLUMTINT, info.m_nSelfIllumTint, fBlendFactor );


### PR DESCRIPTION
This PR fixes `$detailscale` not working in `SDK_VertexLitGeneric` materials when combined with `$bumpmap` and `$phong`. The issue was that a restoration of `$bumptransform` which is incompatible with `$detail` by design was accidentally causing `$bumpmap` to override `$detail` in this particular shader path.

---

<!-- Replace [ ] with [x] for each item your PR satisfies -->
#### PR Checklist
- [x] **My PR follows all guidelines in the CONTRIBUTING.md file**
- [x] My PR targets a `develop` branch OR targets another branch with a specific goal in mind
