### PR TITLE
Fixed "color_correction_volume" crash caused by dangling pointers inside of ccmngr

### DIFF
--- a/sp/src/game/client/colorcorrectionmgr.cpp
+++ b/sp/src/game/client/colorcorrectionmgr.cpp
@@ -157,6 +157,22 @@ void CColorCorrectionMgr::CommitColorCorrectionWeights()
 	}
 	m_colorCorrectionWeights.RemoveAll();
 }
+
+void CColorCorrectionMgr::LevelShutdownPreEntity()
+{
+	//Clean up the vectors when shuting down a level
+	//will keep dangling pointers inside of the vector causing a nullptr crash
+	if (g_ColorCorrectionVolumeList.Base())
+	{
+		g_ColorCorrectionVolumeList.Purge();
+	}
+
+	if (g_ColorCorrectionList.Base())
+	{
+		g_ColorCorrectionList.Purge();
+	}
+}
+
 #else
 void CColorCorrectionMgr::SetColorCorrectionWeight( ClientCCHandle_t h, float flWeight )
 {

--- a/sp/src/game/client/colorcorrectionmgr.h
+++ b/sp/src/game/client/colorcorrectionmgr.h
@@ -76,6 +76,8 @@ private:
 	CUtlVector< SetWeightParams_t > m_colorCorrectionWeights;
 
 	void CommitColorCorrectionWeights();
+
+	void LevelShutdownPreEntity();
 #endif
 };
 


### PR DESCRIPTION
Inside the colorcorrectionmgr there are 2 vectors that are not cleaned up after a level restart

This causes the vector to have dangling pointers in them causing the game to crash when we want to update the color correction in-game

---

#### Does this PR close any issues?
* fixes #380 

<!-- Replace [ ] with [x] for each item your PR satisfies -->
#### PR Checklist
- [x] **My PR follows all guidelines in the CONTRIBUTING.md file**
- [x] My PR targets a `develop` branch OR targets another branch with a specific goal in mind
