### PR TITLE
fixed breakable props taking damage when picked up and let go after physgun punt

### DIFF
--- a/sp/src/game/server/props.cpp
+++ b/sp/src/game/server/props.cpp
@@ -3378,6 +3378,15 @@ void CPhysicsProp::OnPhysGunPickup( CBasePlayer *pPhysGunUser, PhysGunPickup_t r
 		}
 	}
 
+#ifdef MAPBASE
+	//Make Sure to reset this because if we throw a prop in the air
+	//and pick it up again and gently put it down it will make it take damage
+	//with this we curcimvent this issue
+	//-Nbc66
+	m_bFirstCollisionAfterLaunch = false;
+#endif // MAPBASE
+
+
 	m_OnPhysGunPickup.FireOutput( pPhysGunUser, this );
 
 	if( reason == PICKED_UP_BY_CANNON )


### PR DESCRIPTION
(Describe your PR here and then fill out the checklist at the bottom)

Breakable props take damage after the first contact of anything when they are punted
but if you pick it up and let go the prop still takes damage even if you gently let it down with the physgun

with this change we make sure to reset the bool to NOT take damage after picking up the prop and letting it go mid-air

---

#### Does this PR close any issues?
* Fixes #306

<!-- Replace [ ] with [x] for each item your PR satisfies -->
#### PR Checklist
- [x] **My PR follows all guidelines in the CONTRIBUTING.md file**
- [x] My PR targets a `develop` branch OR targets another branch with a specific goal in mind
