### PR TITLE
Allow NPCs to face targets while parented

### DIFF
--- a/sp/src/game/server/ai_basenpc.cpp
+++ b/sp/src/game/server/ai_basenpc.cpp
@@ -2847,7 +2847,7 @@ void CAI_BaseNPC::SetHeadDirection( const Vector &vTargetPos, float flInterval)
 	//--------------------------------------
 	// Set head yaw
 	//--------------------------------------
-	float flDesiredYaw = VecToYaw(vTargetPos - GetLocalOrigin()) - GetLocalAngles().y;
+	float flDesiredYaw = VecToYaw(vTargetPos - GetAbsOrigin()) - GetAbsAngles().y;
 	if (flDesiredYaw > 180)
 		flDesiredYaw -= 360;
 	if (flDesiredYaw < -180)
@@ -7791,7 +7791,7 @@ void CAI_BaseNPC::NPCInit ( void )
 
 	SetGravity(1.0);	// Don't change
 	m_takedamage		= DAMAGE_YES;
-	GetMotor()->SetIdealYaw( GetLocalAngles().y );
+	GetMotor()->SetIdealYaw( GetAbsAngles().y );
 	m_iMaxHealth		= m_iHealth;
 	m_lifeState			= LIFE_ALIVE;
 	SetIdealState( NPC_STATE_IDLE );// Assume npc will be idle, until proven otherwise
@@ -9404,14 +9404,14 @@ float CAI_BaseNPC::CalcIdealYaw( const Vector &vecTarget )
 		vecProjection.x = -vecTarget.y;
 		vecProjection.y = vecTarget.x;
 
-		return UTIL_VecToYaw( vecProjection - GetLocalOrigin() );
+		return UTIL_VecToYaw( vecProjection - GetAbsOrigin() );
 	}
 	else if ( GetNavigator()->GetMovementActivity() == ACT_STRAFE_RIGHT )
 	{
 		vecProjection.x = vecTarget.y;
 		vecProjection.y = vecTarget.x;
 
-		return UTIL_VecToYaw( vecProjection - GetLocalOrigin() );
+		return UTIL_VecToYaw( vecProjection - GetAbsOrigin() );
 	}
 #ifdef MAPBASE
 	// Allow hint nodes to override the yaw without needing to control AI
@@ -9422,7 +9422,7 @@ float CAI_BaseNPC::CalcIdealYaw( const Vector &vecTarget )
 #endif
 	else
 	{
-		return UTIL_VecToYaw ( vecTarget - GetLocalOrigin() );
+		return UTIL_VecToYaw ( vecTarget - GetAbsOrigin() );
 	}
 }
 
@@ -9622,7 +9622,7 @@ void CAI_BaseNPC::HandleAnimEvent( animevent_t *pEvent )
 			//DevMsg( "Turned!\n" );
 			SetIdealActivity( ACT_IDLE );
 			Forget( bits_MEMORY_TURNING );
-			SetBoneController( 0, GetLocalAngles().y );
+			SetBoneController( 0, GetAbsAngles().y );
 			IncrementInterpolationFrame();
 			break;
 		}
@@ -10901,7 +10901,7 @@ Vector CAI_BaseNPC::GetShootEnemyDir( const Vector &shootOrigin, bool bNoisy )
 	else
 	{
 		Vector forward;
-		AngleVectors( GetLocalAngles(), &forward );
+		AngleVectors( GetAbsAngles(), &forward );
 		return forward;
 	}
 }
@@ -13874,7 +13874,7 @@ bool CAI_BaseNPC::OverrideMove( float flInterval )
 float CAI_BaseNPC::VecToYaw( const Vector &vecDir )
 {
 	if (vecDir.x == 0 && vecDir.y == 0 && vecDir.z == 0)
-		return GetLocalAngles().y;
+		return GetAbsAngles().y;
 
 	return UTIL_VecToYaw( vecDir );
 }

--- a/sp/src/game/server/ai_basenpc_schedule.cpp
+++ b/sp/src/game/server/ai_basenpc_schedule.cpp
@@ -918,7 +918,7 @@ void CAI_BaseNPC::StartTurn( float flDeltaYaw )
 {
 	float flCurrentYaw;
 	
-	flCurrentYaw = UTIL_AngleMod( GetLocalAngles().y );
+	flCurrentYaw = UTIL_AngleMod( GetAbsAngles().y );
 	GetMotor()->SetIdealYaw( UTIL_AngleMod( flCurrentYaw + flDeltaYaw ) );
 	SetTurnActivity();
 }
@@ -1111,7 +1111,7 @@ void CAI_BaseNPC::StartScriptMoveToTargetTask( int task )
 	{
 		TaskFail(FAIL_NO_TARGET);
 	}
-	else if ( (m_hTargetEnt->GetAbsOrigin() - GetLocalOrigin()).Length() < 1 )
+	else if ( (m_hTargetEnt->GetAbsOrigin() - GetAbsOrigin()).Length() < 1 )
 	{
 		TaskComplete();
 	}
@@ -1576,7 +1576,7 @@ void CAI_BaseNPC::StartTask( const Task_t *pTask )
 		break;
 
 	case TASK_SET_IDEAL_YAW_TO_CURRENT:
-		GetMotor()->SetIdealYaw( UTIL_AngleMod( GetLocalAngles().y ) );
+		GetMotor()->SetIdealYaw( UTIL_AngleMod( GetAbsAngles().y ) );
 		TaskComplete();
 		break;
 
@@ -1730,7 +1730,7 @@ void CAI_BaseNPC::StartTask( const Task_t *pTask )
 			{
 				TaskFail(FAIL_NO_TARGET);
 			}
-			else if ( (pTarget->GetAbsOrigin() - GetLocalOrigin()).Length() < 1 )
+			else if ( (pTarget->GetAbsOrigin() - GetAbsOrigin()).Length() < 1 )
 			{
 				TaskComplete();
 			}
@@ -2965,7 +2965,7 @@ void CAI_BaseNPC::StartTask( const Task_t *pTask )
 		{
 			if ( m_hTargetEnt != NULL )
 			{
-				GetMotor()->SetIdealYaw( UTIL_AngleMod( m_hTargetEnt->GetLocalAngles().y ) );
+				GetMotor()->SetIdealYaw( UTIL_AngleMod( m_hTargetEnt->GetAbsAngles().y ) );
 			}
 
 			if ( m_scriptState != SCRIPT_CUSTOM_MOVE_TO_MARK )
@@ -3294,7 +3294,7 @@ void CAI_BaseNPC::RunTask( const Task_t *pTask )
 				pTarget = GetEnemy();
 			if ( pTarget )
 			{
-				GetMotor()->SetIdealYawAndUpdate( pTarget->GetAbsOrigin() - GetLocalOrigin() , AI_KEEP_YAW_SPEED );
+				GetMotor()->SetIdealYawAndUpdate( pTarget->GetAbsOrigin() - GetAbsOrigin(), AI_KEEP_YAW_SPEED );
 			}
 
 			if ( IsActivityFinished() )


### PR DESCRIPTION
This pull request replaces the "local" origin/angle calls used for NPC facing and aiming with "absolute" origin/angle calls. This fixes issues with NPCs not being able to aim at or face targets while parented to an entity.

Normally, the "local" and "absolute" origin/angles of an entity are identical. They are only different when the entity is parented to another entity. When parented, the "local" origin/angles is relative to the parent, while the "absolute" origin is relative to the world as before. Most NPC calculations use the local origin and angles, presumably because local vectors are cheaper to calculate and NPCs are not normally parented. This causes issues in their navigation and facing code when a NPC is parented, but this PR will fix the latter.

Since the local and absolute origin/angles are identical when an entity is not parented, this also means these changes **do not have any effect on NPCs which are not parented.**

---

#### Does this PR close any issues?
* https://github.com/mapbase-source/source-sdk-2013/issues/254
     * *(Note that the issue suggests replacing **all** instances of local origin/angles in NPC code. This PR only replaces instances that are used for facing/aiming code.)*

<!-- Replace [ ] with [x] for each item your PR satisfies -->
#### PR Checklist
- [x] **My PR follows all guidelines in the CONTRIBUTING.md file**
- [x] My PR targets a `develop` branch OR targets another branch with a specific goal in mind
