### PR TITLE
game_menu entity

### DIFF
--- a/sp/src/game/client/menu.h
+++ b/sp/src/game/client/menu.h
@@ -26,10 +26,14 @@ class CHudMenu : public CHudElement, public vgui::Panel
 public:
 	CHudMenu( const char *pElementName );
 	void Init( void );
+	void LevelInit( void );
 	void VidInit( void );
 	void Reset( void );
 	virtual bool ShouldDraw( void );
 	void MsgFunc_ShowMenu( bf_read &msg );
+#ifdef MAPBASE
+	void MsgFunc_ShowMenuComplex( bf_read &msg );
+#endif
 	void HideMenu( void );
 	void ShowMenu( const char * menuName, int keySlot );
 	void ShowMenu_KeyValueItems( KeyValues *pKV );
@@ -42,6 +46,8 @@ private:
 	virtual void Paint();
 	virtual void ApplySchemeSettings(vgui::IScheme *pScheme);
 private:
+	float		GetMenuTime( void );
+
 	void		ProcessText( void );
 
 	void PaintString( const wchar_t *text, int textlen, vgui::HFont& font, int x, int y );
@@ -59,6 +65,7 @@ private:
 
 	int				m_nMaxPixels;
 	int				m_nHeight;
+	int				m_nBorder;
 
 	bool			m_bMenuDisplayed;
 	int				m_bitsValidSlots;
@@ -68,6 +75,12 @@ private:
 	bool			m_bMenuTakesInput;
 
 	float			m_flSelectionTime;
+
+#ifdef MAPBASE
+	// Indicates this menu is defined by game_menu
+	bool			m_bMapDefinedMenu;
+	bool			m_bPlayingFadeout;
+#endif
 
 	CPanelAnimationVar( float, m_flOpenCloseTime, "OpenCloseTime", "1" );
 

--- a/sp/src/game/server/maprules.h
+++ b/sp/src/game/server/maprules.h
@@ -9,7 +9,55 @@
 #ifndef MAPRULES_H
 #define MAPRULES_H
 
+#ifdef MAPBASE
+#define MAX_MENU_OPTIONS	10
 
+#define SF_GAMEMENU_ALLPLAYERS			0x0001
+
+//-----------------------------------------------------------------------------
+// Purpose: Displays a custom number menu for player(s)
+//-----------------------------------------------------------------------------
+DECLARE_AUTO_LIST( IGameMenuAutoList );
+class CGameMenu : public CLogicalEntity, public IGameMenuAutoList
+{
+public:
+	DECLARE_CLASS( CGameMenu, CLogicalEntity );
+	DECLARE_DATADESC();
+	CGameMenu();
+
+	void OnRestore();
+	void InputDoRestore( inputdata_t &inputdata );
+
+	void TimeoutThink();
+
+	void ShowMenu( CRecipientFilter &filter, float flDisplayTime = 0.0f );
+	void HideMenu( CRecipientFilter &filter );
+	void MenuSelected( int nSlot, CBaseEntity *pActivator );
+
+	bool IsActive();
+	bool IsActiveOnTarget( CBaseEntity *pPlayer );
+	void RemoveTarget( CBaseEntity *pPlayer );
+
+	// Inputs
+	void InputShowMenu( inputdata_t &inputdata );
+	void InputHideMenu( inputdata_t &inputdata );
+
+private:
+
+	CUtlVector<EHANDLE>	m_ActivePlayers;
+	CUtlVector<float>	m_ActivePlayerTimes;
+
+	float			m_flDisplayTime;
+
+	string_t		m_iszTitle;
+	string_t		m_iszOption[MAX_MENU_OPTIONS];
+
+	// Outputs
+	COutputEvent	m_OnCase[MAX_MENU_OPTIONS];		// Fired for the option chosen
+	COutputInt		m_OutValue;						// Outputs the option chosen
+	COutputEvent	m_OnTimeout;					// Fires when no option was chosen in time
+};
+#endif
 
 #endif		// MAPRULES_H
 

--- a/sp/src/game/shared/gamerules.cpp
+++ b/sp/src/game/shared/gamerules.cpp
@@ -27,6 +27,9 @@
 	#include "player_resource.h"
 	#include "tactical_mission.h"
 	#include "gamestats.h"
+#ifdef MAPBASE
+	#include "maprules.h"
+#endif
 
 #endif
 
@@ -619,6 +622,27 @@ bool CGameRules::ClientCommand( CBaseEntity *pEdict, const CCommand &args )
 	{
 		if( GetVoiceGameMgr()->ClientCommand( static_cast<CBasePlayer*>(pEdict), args ) )
 			return true;
+
+#ifdef MAPBASE
+		if ( FStrEq( args[0], "menuselect" ) )
+		{
+			if ( args.ArgC() >= 2 )
+			{
+				int slot = atoi( args[1] );
+
+				// See if this is from a game_menu
+				for ( int i = 0; i < IGameMenuAutoList::AutoList().Count(); i++ )
+				{
+					CGameMenu *pMenu = static_cast<CGameMenu*>( IGameMenuAutoList::AutoList()[i] );
+					if ( pMenu->IsActiveOnTarget( pEdict ) )
+					{
+						pMenu->MenuSelected( slot, pEdict );
+						return true;
+					}
+				}
+			}
+		}
+#endif
 	}
 
 	return false;

--- a/sp/src/game/shared/mapbase/mapbase_usermessages.cpp
+++ b/sp/src/game/shared/mapbase/mapbase_usermessages.cpp
@@ -20,6 +20,8 @@ void HookMapbaseUserMessages( void )
 {
 	// VScript
 	//HOOK_MESSAGE( ScriptMsg ); // Hooked in CNetMsgScriptHelper
+
+	//HOOK_MESSAGE( ShowMenuComplex ); // Hooked in CHudMenu
 }
 #endif
 
@@ -27,6 +29,8 @@ void RegisterMapbaseUserMessages( void )
 {
 	// VScript
 	usermessages->Register( "ScriptMsg", -1 ); // CNetMsgScriptHelper
+
+	usermessages->Register( "ShowMenuComplex", -1 ); // CHudMenu
 
 #ifdef CLIENT_DLL
 	// TODO: Better placement?


### PR DESCRIPTION
This PR adds a new entity called `game_menu` which displays a custom dialog from `CHudMenu`, which is normally used by multiplayer games to initiate voice commands.

Example:

![mapbase_demo_v8fixes10000](https://github.com/user-attachments/assets/dfbc59cb-b0aa-4219-9d0a-a9a152c321eb)

This PR also contains some changes to `CHudMenu` which are associated with this entity.

---

<!-- Replace [ ] with [x] for each item your PR satisfies -->
#### PR Checklist
- [x] **My PR follows all guidelines in the CONTRIBUTING.md file**
- [x] My PR targets a `develop` branch OR targets another branch with a specific goal in mind
