### PR TITLE
Fix prediction not selecting the correct weapon type

### DIFF
--- a/sp/src/game/client/prediction.cpp
+++ b/sp/src/game/client/prediction.cpp
@@ -855,7 +855,7 @@ void CPrediction::RunCommand( C_BasePlayer *player, CUserCmd *ucmd, IMoveHelper 
 		C_BaseCombatWeapon *weapon = dynamic_cast< C_BaseCombatWeapon * >( CBaseEntity::Instance( ucmd->weaponselect ) );
 		if ( weapon )
 		{
-			player->SelectItem( weapon->GetClassname(), ucmd->weaponsubtype );
+			player->SelectItem( weapon->GetName(), ucmd->weaponsubtype );
 		}
 	}
 

--- a/sp/src/game/server/mapbase/weapon_custom_hl2.cpp
+++ b/sp/src/game/server/mapbase/weapon_custom_hl2.cpp
@@ -93,6 +93,7 @@ public:
 	virtual Activity	GetPrimaryAttackActivity(void) { return m_CustomData.m_bHitUsesMissAnim ? ACT_VM_MISSCENTER : BaseClass::GetPrimaryAttackActivity(); }
 
 	const char* GetWeaponScriptName() { return m_iszWeaponScriptName.Get(); }
+	const char* GetName( void ) const { return STRING( m_iClassname ); }
 	virtual int		GetDamageType() { return g_nDamageClassTypeBits[m_CustomData.m_nDamageClass]; }
 
 	virtual void InitCustomWeaponFromData(const void* pData, const char* pszWeaponScript);
@@ -381,6 +382,7 @@ public:
 	CHLCustomWeaponGun();
 	virtual void InitCustomWeaponFromData(const void* pData, const char* pszWeaponScript);
 	const char* GetWeaponScriptName() { return m_iszWeaponScriptName.Get(); }
+	const char* GetName( void ) const { return STRING( m_iClassname ); }
 
 	// Weapon behaviour
 	virtual void			ItemPostFrame(void);				// called each frame by the player PostThink

--- a/sp/src/game/server/player_command.cpp
+++ b/sp/src/game/server/player_command.cpp
@@ -393,7 +393,7 @@ void CPlayerMove::RunCommand ( CBasePlayer *player, CUserCmd *ucmd, IMoveHelper 
 		if ( weapon )
 		{
 			VPROF( "player->SelectItem()" );
-			player->SelectItem( weapon->GetClassname(), ucmd->weaponsubtype );
+			player->SelectItem( weapon->GetName(), ucmd->weaponsubtype );
 		}
 	}
 

--- a/sp/src/game/shared/mapbase/weapon_custom_scripted.h
+++ b/sp/src/game/shared/mapbase/weapon_custom_scripted.h
@@ -60,6 +60,7 @@ public:
 	bool			IsPredicted( void ) const { return m_iszClientScripts[0] != '\0'; }
 
 	const char*		GetWeaponScriptName() { return m_iszWeaponScriptName[0] != '\0' ? m_iszWeaponScriptName : BaseClass::GetWeaponScriptName(); }
+	const char*		GetName() const { return m_iszWeaponScriptName[0] != '\0' ? STRING( m_iClassname ) : BaseClass::GetName(); }
 
 	// Weapon selection
 	bool			HasAnyAmmo( void );						// Returns true is weapon has ammo


### PR DESCRIPTION
This pull request fixes weapon selection prediction not working in Mapbase. The issue is caused by calling `GetClassname` instead of `GetName`, which on the client is stored in a static char array that's overwritten while searching for a weapon to select.

This was originally done for the custom weapons feature: https://github.com/mapbase-source/source-sdk-2013/commit/0ae65a5a64eefeaf2e8db2a838964a1b1015a47f

In order to retain the behavior intended by that commit, I overrode `GetName` on the custom weapon classes to return the classname instead.

---

<!-- Replace [ ] with [x] for each item your PR satisfies -->
#### PR Checklist
- [x] **My PR follows all guidelines in the CONTRIBUTING.md file**
- [x] My PR targets a `develop` branch OR targets another branch with a specific goal in mind
