### PR TITLE
Refactor: Encapsulate FireOutput Calls in New Functions (OnStartTouchAll, OnEndTouchAll)

### DIFF
--- a/sp/src/game/server/triggers.cpp
+++ b/sp/src/game/server/triggers.cpp
@@ -509,7 +509,7 @@ void CBaseTrigger::StartTouch(CBaseEntity *pOther)
 		if ( bAdded && ( m_hTouchingEntities.Count() == 1 ) )
 		{
 			// First entity to touch us that passes our filters
-			m_OnStartTouchAll.FireOutput( pOther, this );
+			OnStartTouchAll(pOther);
 		}
 	}
 }
@@ -564,10 +564,31 @@ void CBaseTrigger::EndTouch(CBaseEntity *pOther)
 		// Didn't find one?
 		if ( !bFoundOtherTouchee /*&& !m_bDisabled*/ )
 		{
-			m_OnEndTouchAll.FireOutput(pOther, this);
+			OnEndTouchAll(pOther);
 		}
 	}
 }
+#ifdef MAPBASE
+
+//-----------------------------------------------------------------------------
+// Purpose: Called when an entity starts touching us.
+// Input  : pOther - The entity that is touching us.
+//-----------------------------------------------------------------------------
+void CBaseTrigger::OnStartTouchAll(CBaseEntity* pOther)
+{
+	m_OnStartTouchAll.FireOutput(pOther, this);
+}
+
+//-----------------------------------------------------------------------------
+// Purpose: Called when an entity stops touching us.
+// Input  : pOther - The entity that was touching us.
+//-----------------------------------------------------------------------------
+void CBaseTrigger::OnEndTouchAll(CBaseEntity* pOther)
+{
+	m_OnEndTouchAll.FireOutput(pOther, this);
+}
+
+#endif // MAPBASE
 
 //-----------------------------------------------------------------------------
 // Purpose: Return true if the specified entity is touching us

--- a/sp/src/game/server/triggers.h
+++ b/sp/src/game/server/triggers.h
@@ -86,9 +86,6 @@ public:
 	virtual void OnEndTouchAll(CBaseEntity* pOther);
 #endif // MAPBASE
 
-
-	
-
 	bool IsTouching( CBaseEntity *pOther );
 #ifdef MAPBASE_VSCRIPT
 	bool ScriptIsTouching( HSCRIPT hOther );

--- a/sp/src/game/server/triggers.h
+++ b/sp/src/game/server/triggers.h
@@ -81,6 +81,14 @@ public:
 	virtual bool PassesTriggerFilters(CBaseEntity *pOther);
 	virtual void StartTouch(CBaseEntity *pOther);
 	virtual void EndTouch(CBaseEntity *pOther);
+#ifdef MAPBASE
+	virtual void OnStartTouchAll(CBaseEntity* pOther);
+	virtual void OnEndTouchAll(CBaseEntity* pOther);
+#endif // MAPBASE
+
+
+	
+
 	bool IsTouching( CBaseEntity *pOther );
 #ifdef MAPBASE_VSCRIPT
 	bool ScriptIsTouching( HSCRIPT hOther );


### PR DESCRIPTION
In this PR, I refactored the CBaseTrigger::StartTouch and CBaseTrigger::EndTouch methods to use the newly introduced OnStartTouchAll and OnEndTouchAll functions. These functions encapsulate the FireOutput calls, streamlining the logic and improving code readability. The new functions are defined under the #ifdef MAPBASE directive in triggers.cpp, with corresponding declarations added to triggers.h.

Additionally, this refactor ensures that the FireOutput calls are managed separately from the core logic in StartTouch and EndTouch, facilitating easier maintenance and future updates.

#### Does this PR close any issues?
* None

<!-- Replace [ ] with [x] for each item your PR satisfies -->
#### PR Checklist
- [x] **My PR follows all guidelines in the CONTRIBUTING.md file**
- [x] My PR targets a `develop` branch OR targets another branch with a specific goal in mind