### PR TITLE
Replicate %alphatexture from Gmod

### DIFF
--- a/sp/src/utils/vrad/vradstaticprops.cpp
+++ b/sp/src/utils/vrad/vradstaticprops.cpp
@@ -528,14 +528,10 @@ public:
 			if ( pVMT->LoadFromBuffer( pMaterialName, buf ) )
 			{
 				bFound = true;
-				if ( pVMT->FindKey("$alphatest") || pVMT->FindKey("$translucent") || pVMT->FindKey("%alphatexture") )
+				KeyValues *pBaseTexture = pVMT->FindKey("%alphatexture");
+				if ( pBaseTexture || pVMT->FindKey("$alphatest") || pVMT->FindKey("$translucent") )
 				{
-					KeyValues *pBaseTexture = NULL;
-					if ( pVMT->FindKey("%alphatexture") )
-					{
-						pBaseTexture = pVMT->FindKey("%alphatexture");
-					}
-					else
+					if ( !pBaseTexture )
 					{
 						pBaseTexture = pVMT->FindKey("$basetexture");
 					}

--- a/sp/src/utils/vrad/vradstaticprops.cpp
+++ b/sp/src/utils/vrad/vradstaticprops.cpp
@@ -528,9 +528,17 @@ public:
 			if ( pVMT->LoadFromBuffer( pMaterialName, buf ) )
 			{
 				bFound = true;
-				if ( pVMT->FindKey("$translucent") || pVMT->FindKey("$alphatest") )
+				if ( pVMT->FindKey("$alphatest") || pVMT->FindKey("$translucent") || pVMT->FindKey("%alphatexture") )
 				{
-					KeyValues *pBaseTexture = pVMT->FindKey("$basetexture");
+					KeyValues *pBaseTexture = NULL;
+					if ( pVMT->FindKey("%alphatexture") )
+					{
+						pBaseTexture = pVMT->FindKey("%alphatexture");
+					}
+					else
+					{
+						pBaseTexture = pVMT->FindKey("$basetexture");
+					}
 					if ( pBaseTexture )
 					{
 						const char *pBaseTextureName = pBaseTexture->GetString();


### PR DESCRIPTION
### Description
If present, texture shadows will be generated from alpha of `%alphatexture` instead of `$basetexture`. This also permits texture shadows from static props without `$translucent` or `$alphatest` being present.

I also moved `$alphatest` check before `$translucent` check, because it's probably more common (not that that really speeds much up).

I refrained from renaming the now inaccurately-named variables because I didn't want to accidentally break anything.

### Additional information
For more information, see [VDC page](https://developer.valvesoftware.com/wiki/alphatexture) and https://github.com/Facepunch/garrysmod-requests/issues/2603

### Legalese
All code is either written by me or is existing SDK code. Permission is granted to use my changes as you see fit; no credit is necessary.

---

#### Does this PR close any issues?
* No

<!-- Replace [ ] with [x] for each item your PR satisfies -->
#### PR Checklist
- [x] **My PR follows all guidelines in the CONTRIBUTING.md file**
- [x] My PR targets a `develop` branch OR targets another branch with a specific goal in mind
