### PR TITLE
Improved prop_thumper

### DIFF
--- a/sp/src/game/client/hl2/c_thumper_dust.cpp
+++ b/sp/src/game/client/hl2/c_thumper_dust.cpp
@@ -77,6 +77,13 @@ private:
 void FX_ThumperDust( const CEffectData &data )
 {
 
+#ifndef MAPBASE
+	Vector vecDustColor;
+	vecDustColor.x = 0.85f;
+	vecDustColor.y = 0.75f;
+	vecDustColor.z = 0.52f;
+#endif
+
 	CSmartPtr<ThumperDustEmitter> pSimple = ThumperDustEmitter::Create( "thumperdust" );
 
 	C_BaseEntity *pEnt = C_BaseEntity::Instance( data.m_hEntity );
@@ -113,7 +120,13 @@ void FX_ThumperDust( const CEffectData &data )
 
 	// Setup the color for these particles
 	engine->ComputeLighting( data.m_vOrigin, NULL, true, vecColor );
+
+#ifdef MAPBASE
 	VectorLerp( vecColor, data.m_CustomColors.m_vecColor1, 0.5, vecColor );
+#else
+	VectorLerp( vecColor, vecDustColor, 0.5, vecColor );
+#endif
+
 	vecColor *= 255;
 
 	for ( i = 0; i < numPuffs; i++ )

--- a/sp/src/game/client/hl2/c_thumper_dust.cpp
+++ b/sp/src/game/client/hl2/c_thumper_dust.cpp
@@ -76,10 +76,6 @@ private:
 
 void FX_ThumperDust( const CEffectData &data )
 {
-	Vector vecDustColor;
-	vecDustColor.x = 0.85f;
-	vecDustColor.y = 0.75f;
-	vecDustColor.z = 0.52f;
 
 	CSmartPtr<ThumperDustEmitter> pSimple = ThumperDustEmitter::Create( "thumperdust" );
 
@@ -117,7 +113,7 @@ void FX_ThumperDust( const CEffectData &data )
 
 	// Setup the color for these particles
 	engine->ComputeLighting( data.m_vOrigin, NULL, true, vecColor );
-	VectorLerp( vecColor, vecDustColor, 0.5, vecColor );
+	VectorLerp( vecColor, data.m_CustomColors.m_vecColor1, 0.5, vecColor );
 	vecColor *= 255;
 
 	for ( i = 0; i < numPuffs; i++ )

--- a/sp/src/game/server/hl2/prop_thumper.cpp
+++ b/sp/src/game/server/hl2/prop_thumper.cpp
@@ -19,9 +19,11 @@
 #define THUMPER_RADIUS 1000
 #endif
 
+#ifdef MAPBASE
 #define SF_NO_DUST		1
 #define SF_NO_SHAKE		2
 #define SF_DISABLED		4
+#endif
 
 #define STATE_CHANGE_MODIFIER 0.02f
 #define THUMPER_SOUND_DURATION 1.5f
@@ -62,8 +64,10 @@ private:
 	int m_iDustScale;
 	
 
+#ifdef MAPBASE
 	// I would have used color24 instead of color32, but there is no FIELD_COLOR32
 	color32 m_DustColor;
+#endif
 
 	COutputEvent	m_OnThumped;	// Fired when thumper goes off
 
@@ -92,7 +96,9 @@ BEGIN_DATADESC( CPropThumper )
 
 	DEFINE_OUTPUT( m_OnThumped, "OnThumped" ),
 
+#ifdef MAPBASE
 	DEFINE_KEYFIELD( m_DustColor, FIELD_COLOR32, "DustColor" ),
+#endif
 
 END_DATADESC()
 
@@ -105,6 +111,10 @@ void CPropThumper::Spawn( void )
 		SetModelName( AllocPooledString(szModel) );
 	}
 
+#ifdef MAPBASE
+	KeyValue( "DustColor", "216 191 132" );
+#endif
+
 	Precache();
 	SetModel( szModel );
 
@@ -114,10 +124,14 @@ void CPropThumper::Spawn( void )
 
 	BaseClass::Spawn();
 
+#ifdef MAPBASE
 	if (HasSpawnFlags(SF_DISABLED))
 		m_bEnabled = false;
 	else
 		m_bEnabled = true;
+#else
+	m_bEnabled = true;
+#endif
 
 	SetThink( &CPropThumper::Think );
 	SetNextThink( gpGlobals->curtime + 1.0f );
@@ -153,15 +167,6 @@ void CPropThumper::Spawn( void )
 	if ( m_iEffectRadius == 0 )
 		m_iEffectRadius = 1000;
 #endif
-
-	//This isn't very clever, but there needs to be a fallback for maps that dont have a color specified.
-	//Mappers can use 1 1 1 instead of 0 0 0, as it looks the same.
-	if ((m_DustColor.r == 0 && m_DustColor.g == 0 && m_DustColor.b == 0) && !HasSpawnFlags(SF_NO_DUST))
-	{
-		m_DustColor.r = 0.85 * 255;
-		m_DustColor.g = 0.75 * 255;
-		m_DustColor.b = 0.52 * 255;
-	}
 
 }
 
@@ -228,16 +233,26 @@ void CPropThumper::Thump ( void )
 		data.m_vOrigin = vOrigin;
 		data.m_flScale = m_iDustScale * m_flPlaybackRate;
 
+#ifdef MAPBASE
 		data.m_bCustomColors = true;
 		data.m_CustomColors.m_vecColor1.x = (float)m_DustColor.r / 255;
 		data.m_CustomColors.m_vecColor1.y = (float)m_DustColor.g / 255;
 		data.m_CustomColors.m_vecColor1.z = (float)m_DustColor.b / 255;
+#endif
 
-		if (!HasSpawnFlags(SF_NO_DUST))
-			DispatchEffect("ThumperDust", data);
+#ifdef MAPBASE
+		if ( !HasSpawnFlags( SF_NO_DUST ) )
+			DispatchEffect( "ThumperDust", data );
+#else
+		DispatchEffect("ThumperDust", data);
+#endif
 
-		if (!HasSpawnFlags(SF_NO_SHAKE))
-			UTIL_ScreenShake(vOrigin, 10.0 * m_flPlaybackRate, m_flPlaybackRate, m_flPlaybackRate / 2, THUMPER_RADIUS * m_flPlaybackRate, SHAKE_START, false);
+#ifdef MAPBASE
+		if ( !HasSpawnFlags( SF_NO_SHAKE ) )
+			UTIL_ScreenShake( vOrigin, 10.0 * m_flPlaybackRate, m_flPlaybackRate, m_flPlaybackRate / 2, THUMPER_RADIUS * m_flPlaybackRate, SHAKE_START, false );
+#else
+		UTIL_ScreenShake( vOrigin, 10.0 * m_flPlaybackRate, m_flPlaybackRate, m_flPlaybackRate / 2, THUMPER_RADIUS * m_flPlaybackRate, SHAKE_START, false );
+#endif
 
 	}
 

--- a/sp/src/game/server/hl2/prop_thumper.cpp
+++ b/sp/src/game/server/hl2/prop_thumper.cpp
@@ -19,6 +19,9 @@
 #define THUMPER_RADIUS 1000
 #endif
 
+#define SF_NO_DUST		1
+#define SF_NO_SHAKE		2
+#define SF_DISABLED		4
 
 #define STATE_CHANGE_MODIFIER 0.02f
 #define THUMPER_SOUND_DURATION 1.5f
@@ -58,6 +61,10 @@ private:
 	EHANDLE m_hRepellantEnt;
 	int m_iDustScale;
 	
+
+	// I would have used color24 instead of color32, but there is no FIELD_COLOR32
+	color32 m_DustColor;
+
 	COutputEvent	m_OnThumped;	// Fired when thumper goes off
 
 #if HL2_EPISODIC
@@ -84,6 +91,9 @@ BEGIN_DATADESC( CPropThumper )
 	DEFINE_INPUTFUNC( FIELD_VOID, "Enable", InputEnable ),
 
 	DEFINE_OUTPUT( m_OnThumped, "OnThumped" ),
+
+	DEFINE_KEYFIELD( m_DustColor, FIELD_COLOR32, "DustColor" ),
+
 END_DATADESC()
 
 void CPropThumper::Spawn( void )
@@ -104,7 +114,10 @@ void CPropThumper::Spawn( void )
 
 	BaseClass::Spawn();
 
-	m_bEnabled = true;
+	if (HasSpawnFlags(SF_DISABLED))
+		m_bEnabled = false;
+	else
+		m_bEnabled = true;
 
 	SetThink( &CPropThumper::Think );
 	SetNextThink( gpGlobals->curtime + 1.0f );
@@ -140,6 +153,15 @@ void CPropThumper::Spawn( void )
 	if ( m_iEffectRadius == 0 )
 		m_iEffectRadius = 1000;
 #endif
+
+	//This isn't very clever, but there needs to be a fallback for maps that dont have a color specified.
+	//Mappers can use 1 1 1 instead of 0 0 0, as it looks the same.
+	if ((m_DustColor.r == 0 && m_DustColor.g == 0 && m_DustColor.b == 0) && !HasSpawnFlags(SF_NO_DUST))
+	{
+		m_DustColor.r = 0.85 * 255;
+		m_DustColor.g = 0.75 * 255;
+		m_DustColor.b = 0.52 * 255;
+	}
 
 }
 
@@ -205,8 +227,18 @@ void CPropThumper::Thump ( void )
 		data.m_nEntIndex = entindex();
 		data.m_vOrigin = vOrigin;
 		data.m_flScale = m_iDustScale * m_flPlaybackRate;
-		DispatchEffect( "ThumperDust", data );
-		UTIL_ScreenShake( vOrigin, 10.0 * m_flPlaybackRate, m_flPlaybackRate, m_flPlaybackRate / 2, THUMPER_RADIUS * m_flPlaybackRate, SHAKE_START, false );
+
+		data.m_bCustomColors = true;
+		data.m_CustomColors.m_vecColor1.x = (float)m_DustColor.r / 255;
+		data.m_CustomColors.m_vecColor1.y = (float)m_DustColor.g / 255;
+		data.m_CustomColors.m_vecColor1.z = (float)m_DustColor.b / 255;
+
+		if (!HasSpawnFlags(SF_NO_DUST))
+			DispatchEffect("ThumperDust", data);
+
+		if (!HasSpawnFlags(SF_NO_SHAKE))
+			UTIL_ScreenShake(vOrigin, 10.0 * m_flPlaybackRate, m_flPlaybackRate, m_flPlaybackRate / 2, THUMPER_RADIUS * m_flPlaybackRate, SHAKE_START, false);
+
 	}
 
 	EmitSound( "coast.thumper_dust" );

--- a/sp/src/game/server/hl2/prop_thumper.cpp
+++ b/sp/src/game/server/hl2/prop_thumper.cpp
@@ -40,6 +40,10 @@ public:
 	DECLARE_CLASS( CPropThumper, CBaseAnimating );
 	DECLARE_DATADESC();
 
+#ifdef MAPBASE
+	CPropThumper( void );
+#endif
+
 	virtual void Spawn( void );
 	virtual void Precache( void );
 	virtual void Think ( void );
@@ -102,6 +106,19 @@ BEGIN_DATADESC( CPropThumper )
 
 END_DATADESC()
 
+#ifdef MAPBASE
+CPropThumper::CPropThumper() :
+	m_bEnabled( true ),
+	m_iHammerAttachment( -1 ),
+	m_sndMotor( NULL ),
+	m_hRepellantEnt( NULL ),
+	m_iDustScale( THUMPER_MIN_SCALE )
+{
+	KeyValue( "dustcolor", "217 191 133" );
+}
+#endif 
+
+
 void CPropThumper::Spawn( void )
 {
 	char *szModel = (char *)STRING( GetModelName() );
@@ -110,10 +127,6 @@ void CPropThumper::Spawn( void )
 		szModel = THUMPER_MODEL_NAME;
 		SetModelName( AllocPooledString(szModel) );
 	}
-
-#ifdef MAPBASE
-	KeyValue( "DustColor", "216 191 132" );
-#endif
 
 	Precache();
 	SetModel( szModel );
@@ -125,7 +138,7 @@ void CPropThumper::Spawn( void )
 	BaseClass::Spawn();
 
 #ifdef MAPBASE
-	if (HasSpawnFlags(SF_DISABLED))
+	if ( HasSpawnFlags( SF_DISABLED ) )
 		m_bEnabled = false;
 	else
 		m_bEnabled = true;


### PR DESCRIPTION
Prop_thumper is now more customizable.

This PR adds new spawnflags and a new keyvalue.

**Keyvalues**
- dustcolor - allows mappers to change the color of the dust created by prop_thumper with a keyvalue

**Spawnflags**
- Start disabled
- No dust
- No shake

---

#### PR Checklist
- [x] **My PR follows all guidelines in the CONTRIBUTING.md file**
- [x] My PR targets a `develop` branch OR targets another branch with a specific goal in mind
