### PR TITLE
Server ragdoll death poses

### DIFF
--- a/sp/src/game/server/ai_basenpc.h
+++ b/sp/src/game/server/ai_basenpc.h
@@ -1180,6 +1180,11 @@ public:
 
 	void				SetDeathPose( const int &iDeathPose ) { m_iDeathPose = iDeathPose; }
 	void				SetDeathPoseFrame( const int &iDeathPoseFrame ) { m_iDeathFrame = iDeathPoseFrame; }
+
+#ifdef MAPBASE
+	int					GetDeathPose() { return m_iDeathPose; }
+	int					GetDeathPoseFrame() { return m_iDeathFrame; }
+#endif
 	
 	void				SelectDeathPose( const CTakeDamageInfo &info );
 	virtual bool		ShouldPickADeathPose( void ) { return true; }

--- a/sp/src/game/server/physics_prop_ragdoll.h
+++ b/sp/src/game/server/physics_prop_ragdoll.h
@@ -75,7 +75,11 @@ public:
 
 	// locals
 	void InitRagdollAnimation( void );
+#ifdef MAPBASE
+	void InitRagdoll( const Vector& forceVector, int forceBone, const Vector& forcePos, matrix3x4_t* pPrevBones, matrix3x4_t* pBoneToWorld, float dt, int collisionGroup, bool activateRagdoll, bool bWakeRagdoll = true, bool bDeathPose = false );
+#else
 	void InitRagdoll( const Vector &forceVector, int forceBone, const Vector &forcePos, matrix3x4_t *pPrevBones, matrix3x4_t *pBoneToWorld, float dt, int collisionGroup, bool activateRagdoll, bool bWakeRagdoll = true );
+#endif
 	
 	void RecheckCollisionFilter( void );
 	void SetDebrisThink();


### PR DESCRIPTION
Allows for server ragdolls to do death poses on death
-----

Command added:
`ai_death_pose_server_enabled 1`


Default, no death pose for server ragdoll

https://github.com/user-attachments/assets/761a9ea0-d6d7-4945-b39c-aa9828092656




Death pose for server ragdoll

https://github.com/user-attachments/assets/428ff7fc-762f-4ab7-b714-9420cb12429f





---
<!-- Replace [ ] with [x] for each item your PR satisfies -->
#### PR Checklist
- [x] **My PR follows all guidelines in the CONTRIBUTING.md file**
- [x] My PR targets a `develop` branch OR targets another branch with a specific goal in mind
