### PR TITLE
Fixed a crash when npc_helicopter that is awaiting input is killed

### DIFF
--- a/sp/src/game/server/hl2/npc_attackchopper.cpp
+++ b/sp/src/game/server/hl2/npc_attackchopper.cpp
@@ -3785,9 +3785,12 @@ void CNPC_AttackHelicopter::Event_Killed( const CTakeDamageInfo &info )
 	}
 
 	m_lifeState			= LIFE_DYING;
-
-	CSoundEnvelopeController &controller = CSoundEnvelopeController::GetController();
-	controller.SoundChangeVolume( m_pGunFiringSound, 0.0, 0.1f );
+	
+	if ( GetSleepState() == AISS_WAITING_FOR_INPUT )
+	{
+		CSoundEnvelopeController& controller = CSoundEnvelopeController::GetController();
+		controller.SoundChangeVolume( m_pGunFiringSound, 0.0, 0.1f );
+	}
 
 	if( GetCrashPoint() == NULL )
 	{

--- a/sp/src/game/server/hl2/npc_attackchopper.cpp
+++ b/sp/src/game/server/hl2/npc_attackchopper.cpp
@@ -3786,7 +3786,7 @@ void CNPC_AttackHelicopter::Event_Killed( const CTakeDamageInfo &info )
 
 	m_lifeState			= LIFE_DYING;
 	
-	if ( GetSleepState() == AISS_WAITING_FOR_INPUT )
+	if ( GetSleepState() != AISS_WAITING_FOR_INPUT )
 	{
 		CSoundEnvelopeController& controller = CSoundEnvelopeController::GetController();
 		controller.SoundChangeVolume( m_pGunFiringSound, 0.0, 0.1f );


### PR DESCRIPTION
Fixed the issue where the game would crash if a sleeping npc_helicopter was killed. It's a very small PR, just added an if statement :)

---

This PR fixed issue #325 

<!-- Replace [ ] with [x] for each item your PR satisfies -->
#### PR Checklist
- [x] **My PR follows all guidelines in the CONTRIBUTING.md file**
- [x] My PR targets a `develop` branch OR targets another branch with a specific goal in mind
