### PR TITLE
You can now change the headshot damage multiplier for combine soldiers in console

### DIFF
--- a/sp/src/game/server/hl2/npc_combines.cpp
+++ b/sp/src/game/server/hl2/npc_combines.cpp
@@ -38,6 +38,11 @@ ConVar sk_combine_guard_kick( "sk_combine_guard_kick", "0");
 ConVar combine_guard_spawn_health( "combine_guard_spawn_health", "1" );
 
 extern ConVar sk_plr_dmg_buckshot;	
+
+#ifdef MAPBASE
+	ConVar sk_combine_head_dmg_multiplier( "sk_combine_head_dmg_multiplier", "2" );
+#endif
+
 extern ConVar sk_plr_num_shotgun_pellets;
 
 //Whether or not the combine should spawn health on death
@@ -222,8 +227,14 @@ float CNPC_CombineS::GetHitgroupDamageMultiplier( int iHitGroup, const CTakeDama
 	{
 	case HITGROUP_HEAD:
 		{
+			
+#ifdef MAPBASE
+			// Now you don't have to change the headshot damage in 
+			return sk_combine_head_dmg_multiplier.GetFloat();
+#else
 			// Soldiers take double headshot damage
 			return 2.0f;
+#endif
 		}
 	}
 

--- a/sp/src/game/server/hl2/npc_combines.cpp
+++ b/sp/src/game/server/hl2/npc_combines.cpp
@@ -229,7 +229,7 @@ float CNPC_CombineS::GetHitgroupDamageMultiplier( int iHitGroup, const CTakeDama
 		{
 			
 #ifdef MAPBASE
-			// Now you don't have to change the headshot damage in 
+			// Now you can change the multiplier of headshot damage in console!
 			return sk_combine_head_dmg_multiplier.GetFloat();
 #else
 			// Soldiers take double headshot damage


### PR DESCRIPTION
You can now change the headshot damage multiplier for combine soldiers with the brand new sk_combine_head_dmg_multiplier console command! Previously, it was hardcoded in npc_combines.cpp to 2.

---

This PR fixed issue #319 

<!-- Replace [ ] with [x] for each item your PR satisfies -->
#### PR Checklist
- [x] **My PR follows all guidelines in the CONTRIBUTING.md file**
- [x] My PR targets a `develop` branch OR targets another branch with a specific goal in mind
