### PR TITLE
Fix GetPropFloatArray indexing on Vector members

### DIFF
--- a/sp/src/game/shared/mapbase/vscript_singletons.cpp
+++ b/sp/src/game/shared/mapbase/vscript_singletons.cpp
@@ -1243,17 +1243,20 @@ public:
 				return -1;
 		}
 
-		if ( pInfo->datatype == types::_VEC3 )
-			index /= 3;
+		unsigned int arraysize = pInfo->arraysize;
 
-		if ( index < 0 || (unsigned int)index >= pInfo->arraysize )
+		if ( pInfo->datatype == types::_VEC3 )
+			arraysize *= 3;
+
+		if ( index < 0 || (unsigned int)index >= arraysize )
 			return -1;
 
 		switch ( pInfo->datatype )
 		{
-		case types::_VEC3:
 		case types::_FLOAT:
 			return *(float*)((char*)pEnt + pInfo->GetOffset( index ));
+		case types::_VEC3:
+			return ((float*)((char*)pEnt + pInfo->GetOffset( index / 3 )))[ index % 3 ];
 #ifdef GAME_DLL
 		case types::_DAR_FLOAT:
 		{
@@ -1285,18 +1288,23 @@ public:
 				return;
 		}
 
-		if ( pInfo->datatype == types::_VEC3 )
-			index /= 3;
+		unsigned int arraysize = pInfo->arraysize;
 
-		if ( index < 0 || (unsigned int)index >= pInfo->arraysize )
+		if ( pInfo->datatype == types::_VEC3 )
+			arraysize *= 3;
+
+		if ( index < 0 || (unsigned int)index >= arraysize )
 			return;
 
 		switch ( pInfo->datatype )
 		{
-		case types::_VEC3:
 		case types::_FLOAT:
 			*(float*)((char*)pEnt + pInfo->GetOffset( index )) = value;
 			NetworkStateChanged( pEnt, pInfo->GetOffset( index ) );
+			break;
+		case types::_VEC3:
+			((float*)((char*)pEnt + pInfo->GetOffset( index / 3 )))[ index % 3 ] = value;
+			NetworkStateChanged( pEnt, pInfo->GetOffset( index / 3 ) );
 			break;
 #ifdef GAME_DLL
 		case types::_DAR_FLOAT:


### PR DESCRIPTION
I remember testing this feature, but apparently at some point in development it broke and I didn't check again.

Test with

```c
assert( SERVER_DLL );

local function Set( idx )
{
	NetProps.SetPropFloatArray( player, "m_vecMissPositions", 0.1 + idx, 0 + idx * 3 );
	NetProps.SetPropFloatArray( player, "m_vecMissPositions", 0.2 + idx, 1 + idx * 3 );
	NetProps.SetPropFloatArray( player, "m_vecMissPositions", 0.3 + idx, 2 + idx * 3 );
}

local function Get( idx )
{
	assert( NetProps.GetPropFloatArray( player, "m_vecMissPositions", 0 + idx * 3 ) == 0.1 + idx );
	assert( NetProps.GetPropFloatArray( player, "m_vecMissPositions", 1 + idx * 3 ) == 0.2 + idx );
	assert( NetProps.GetPropFloatArray( player, "m_vecMissPositions", 2 + idx * 3 ) == 0.3 + idx );
}

local size = NetProps.GetPropArraySize( player, "m_vecMissPositions" );

for ( local i = 0; i < size; ++i )
{
	Set( i );
	Get( i );
}

Set( -1 );
Set( size );

assert( NetProps.GetPropFloatArray( player, "m_vecMissPositions", -1 ) == -1.0 );
assert( NetProps.GetPropFloatArray( player, "m_vecMissPositions", 0 + size * 3 ) == -1.0 );

NetProps.SetPropFloatArray( player, "m_Local.m_vecPunchAngle", 0.25, 0 );
NetProps.SetPropFloatArray( player, "m_Local.m_vecPunchAngle", 0.50, 1 );
NetProps.SetPropFloatArray( player, "m_Local.m_vecPunchAngle", 0.75, 2 );
assert( NetProps.GetPropFloatArray( player, "m_Local.m_vecPunchAngle", 0 ) == 0.25 );
assert( NetProps.GetPropFloatArray( player, "m_Local.m_vecPunchAngle", 1 ) == 0.50 );
assert( NetProps.GetPropFloatArray( player, "m_Local.m_vecPunchAngle", 2 ) == 0.75 );

print("done\n");

NetProps.Dump( player, "!test.log" );
/*
m_vecMissPositions <vec3 array> #16
[
	[0.100000 0.200000 0.300000]
	[1.100000 1.200000 1.300000]
	[2.100000 2.200000 2.300000]
	[3.100000 3.200000 3.300000]
	[4.100000 4.200000 4.300000]
	[5.100000 5.200000 5.300000]
	[6.100000 6.200000 6.300000]
	[7.100000 7.200000 7.300000]
	[8.100000 8.200000 8.300000]
	[9.100000 9.200000 9.300000]
	[10.100000 10.200000 10.300000]
	[11.100000 11.200000 11.300000]
	[12.100000 12.200000 12.300000]
	[13.100000 13.200000 13.300000]
	[14.100000 14.200000 14.300000]
	[15.100000 15.200000 15.300000]
]
*/
```

---

#### PR Checklist
- [x] **My PR follows all guidelines in the CONTRIBUTING.md file**
- [x] My PR targets a `develop` branch OR targets another branch with a specific goal in mind
