### PR TITLE
Added new Console Variables for modifying max jump distance of npcs

### DIFF
--- a/sp/src/game/server/ai_basenpc_movement.cpp
+++ b/sp/src/game/server/ai_basenpc_movement.cpp
@@ -23,9 +23,9 @@
 #include "tier0/memdbgon.h"
 
 #ifdef MAPBASE
-ConVar ai_jump_max_distance_up( "ai_jump_max_distance_up", "80", FCVAR_CHEAT );
+ConVar ai_jump_max_up( "ai_jump_max_up", "80", FCVAR_CHEAT );
 ConVar ai_jump_max_distance( "ai_jump_max_distance", "250", FCVAR_CHEAT );
-ConVar ai_jump_max_distance_down( "ai_jump_max_distance_down", "192", FCVAR_CHEAT );
+ConVar ai_jump_max_down( "ai_jump_max_down", "192", FCVAR_CHEAT );
 #endif
 
 //=============================================================================
@@ -325,9 +325,9 @@ bool CAI_BaseNPC::IsJumpLegal( const Vector &startPos, const Vector &apex, const
 bool CAI_BaseNPC::IsJumpLegal( const Vector &startPos, const Vector &apex, const Vector &endPos ) const
 {
 #ifdef MAPBASE
-	float MAX_JUMP_RISE = ai_jump_max_distance_up.GetFloat();
+	float MAX_JUMP_RISE = ai_jump_max_up.GetFloat();
 	float MAX_JUMP_DISTANCE = ai_jump_max_distance.GetFloat();
-	float MAX_JUMP_DROP = ai_jump_max_distance_down.GetFloat();
+	float MAX_JUMP_DROP = ai_jump_max_down.GetFloat();
 #else
 	const float MAX_JUMP_RISE		= 80.0f;
 	const float MAX_JUMP_DISTANCE	= 250.0f;

--- a/sp/src/game/server/ai_basenpc_movement.cpp
+++ b/sp/src/game/server/ai_basenpc_movement.cpp
@@ -22,6 +22,12 @@
 // memdbgon must be the last include file in a .cpp file!!!
 #include "tier0/memdbgon.h"
 
+#ifdef MAPBASE
+ConVar ai_jump_max_distance_up( "ai_jump_max_distance_up", "80", FCVAR_CHEAT );
+ConVar ai_jump_max_distance( "ai_jump_max_distance", "250", FCVAR_CHEAT );
+ConVar ai_jump_max_distance_down( "ai_jump_max_distance_down", "192", FCVAR_CHEAT );
+#endif
+
 //=============================================================================
 // PATHING & HIGHER LEVEL MOVEMENT
 //-----------------------------------------------------------------------------
@@ -318,9 +324,15 @@ bool CAI_BaseNPC::IsJumpLegal( const Vector &startPos, const Vector &apex, const
 //-----------------------------------------------------------------------------
 bool CAI_BaseNPC::IsJumpLegal( const Vector &startPos, const Vector &apex, const Vector &endPos ) const
 {
+#ifdef MAPBASE
+	float MAX_JUMP_RISE = ai_jump_max_distance_up.GetFloat();
+	float MAX_JUMP_DISTANCE = ai_jump_max_distance.GetFloat();
+	float MAX_JUMP_DROP = ai_jump_max_distance_down.GetFloat();
+#else
 	const float MAX_JUMP_RISE		= 80.0f;
 	const float MAX_JUMP_DISTANCE	= 250.0f;
 	const float MAX_JUMP_DROP		= 192.0f;
+#endif
 
 	return IsJumpLegal( startPos, apex, endPos, MAX_JUMP_RISE, MAX_JUMP_DROP, MAX_JUMP_DISTANCE );
 }


### PR DESCRIPTION
This PR adds three new Console Variables that mappers can use to change the maximum jump distance for npcs. Mappers can make npcs jump down or up any height they please. They can also make npcs be able to jump across bigger gaps.

Here are the new commands:
- ai_jump_max_up
- ai_jump_max_distance
- ai_jump_max_down

---

It solves issue #425 

<!-- Replace [ ] with [x] for each item your PR satisfies -->
#### PR Checklist
- [x] **My PR follows all guidelines in the CONTRIBUTING.md file**
- [x] My PR targets a `develop` branch OR targets another branch with a specific goal in mind
