### PR TITLE
vscript saverestore and debugger fixes

### DIFF
--- a/sp/src/game/shared/mapbase/vscript_singletons.cpp
+++ b/sp/src/game/shared/mapbase/vscript_singletons.cpp
@@ -5146,6 +5146,11 @@ bool CScriptConvarAccessor::Init()
 	AddBlockedConVar( "cl_allowdownload" );
 	AddBlockedConVar( "cl_allowupload" );
 	AddBlockedConVar( "cl_downloadfilter" );
+#ifdef GAME_DLL
+	AddBlockedConVar( "script_connect_debugger_on_mapspawn" );
+#else
+	AddBlockedConVar( "script_connect_debugger_on_mapspawn_client" );
+#endif
 
 	return true;
 }

--- a/sp/src/vscript/sqdbg/sqdbg/debug.h
+++ b/sp/src/vscript/sqdbg/sqdbg/debug.h
@@ -106,6 +106,7 @@
 			} while(0)
 	#endif
 	#define Verify( x ) Assert(x)
+	#define STATIC_ASSERT( x ) static_assert( x, #x )
 #else
 	#define DebuggerBreak() ((void)0)
 	#define Assert( x ) ((void)0)
@@ -113,11 +114,14 @@
 	#define AssertMsg1( x, msg, a1 ) ((void)0)
 	#define AssertMsg2( x, msg, a1, a2 ) ((void)0)
 	#define Verify( x ) x
+	#define STATIC_ASSERT( x )
 #endif // _DEBUG
 
 #endif
 
 #include <tier0/dbg.h>
+
+#define STATIC_ASSERT COMPILE_TIME_ASSERT
 
 // Misdefined for GCC in platform.h
 #undef UNREACHABLE

--- a/sp/src/vscript/sqdbg/sqdbg/net.h
+++ b/sp/src/vscript/sqdbg/sqdbg/net.h
@@ -842,7 +842,7 @@ public:
 		m_pRecvBufPtr( m_pRecvBuf ),
 		m_bWSAInit( false )
 	{
-		Assert( sizeof(m_pRecvBuf) <= ( 1 << ( sizeof(CMessagePool::message_t::len) * 8 ) ) );
+		STATIC_ASSERT( sizeof(m_pRecvBuf) <= ( 1 << ( sizeof(CMessagePool::message_t::len) * 8 ) ) );
 	}
 };
 

--- a/sp/src/vscript/sqdbg/sqdbg/vec.h
+++ b/sp/src/vscript/sqdbg/sqdbg/vec.h
@@ -306,7 +306,7 @@ public:
 
 	void Free( void *ptr )
 	{
-		Assert( !SEQUENTIAL );
+		STATIC_ASSERT( !SEQUENTIAL );
 		Assert( m_Memory );
 		Assert( ptr );
 
@@ -364,7 +364,7 @@ public:
 
 	void ReleaseShrink()
 	{
-		Assert( SEQUENTIAL );
+		STATIC_ASSERT( SEQUENTIAL );
 
 		if ( !m_Memory )
 			return;
@@ -412,7 +412,7 @@ public:
 
 	void Release()
 	{
-		Assert( SEQUENTIAL );
+		STATIC_ASSERT( SEQUENTIAL );
 
 		if ( !m_Memory || ( !m.LastFreeChunk() && !m.LastFreeIndex() ) )
 			return;
@@ -437,7 +437,7 @@ public:
 
 	void ReleaseTop()
 	{
-		Assert( SEQUENTIAL );
+		STATIC_ASSERT( SEQUENTIAL );
 
 		m.SetLastFreeChunk( m.PrevChunk() );
 		m.SetLastFreeIndex( m.PrevIndex() );
@@ -455,23 +455,23 @@ public:
 
 	vector() : base(), size(0)
 	{
-		Assert( !bExternalMem );
+		STATIC_ASSERT( !bExternalMem );
 	}
 
 	vector( CAllocator &a ) : base(a), size(0)
 	{
-		Assert( bExternalMem );
+		STATIC_ASSERT( bExternalMem );
 	}
 
 	vector( I count ) : base(), size(0)
 	{
-		Assert( !bExternalMem );
+		STATIC_ASSERT( !bExternalMem );
 		base.Alloc( count * sizeof(T) );
 	}
 
 	vector( const vector< T > &src ) : base()
 	{
-		Assert( !bExternalMem );
+		STATIC_ASSERT( !bExternalMem );
 		base.Alloc( src.base.Size() );
 		size = src.size;
 

--- a/sp/src/vscript/vscript_squirrel.cpp
+++ b/sp/src/vscript/vscript_squirrel.cpp
@@ -3835,26 +3835,10 @@ void SquirrelVM::ReadObject( SQObjectPtr &pObj, CUtlBuffer* pBuffer, ReadStateMa
 	case OT_STRING:
 	{
 		int len = pBuffer->GetInt();
-		char *psz;
-
-		if ( len < 1024 )
-		{
-			psz = (char*)stackalloc( len );
-		}
-		else
-		{
-			psz = (char*)malloc( len );
-		}
-
-		pBuffer->Get( psz, len );
-
+		char *psz = (char*)pBuffer->PeekGet( 0 );
+		pBuffer->SeekGet( CUtlBuffer::SEEK_CURRENT, len );
+		Assert( pBuffer->IsValid() );
 		obj._unVal.pString = SQString::Create( _ss(vm_), psz, len );
-
-		if ( len >= 1024 )
-		{
-			free( psz );
-		}
-
 		break;
 	}
 	case OT_TABLE:

--- a/sp/src/vscript/vscript_squirrel.cpp
+++ b/sp/src/vscript/vscript_squirrel.cpp
@@ -3367,7 +3367,8 @@ void SquirrelVM::WriteObject( const SQObjectPtr &obj, CUtlBuffer* pBuffer, Write
 #ifdef _DEBUG
 		bool bAsserted = false;
 
-		if ( pThis->_noutervalues && pThis->_name._type == OT_STRING && pThis->_name._unVal.pString )
+		if ( pThis->_noutervalues && pThis->_name._type == OT_STRING && pThis->_name._unVal.pString &&
+				pThis->_outervalues[0]._type == OT_USERPOINTER )
 		{
 			Assert( pThis->_noutervalues == 1 );
 			Assert( pThis->_outervalues[0]._type == OT_USERPOINTER );
@@ -3771,7 +3772,6 @@ void SquirrelVM::WriteObject( const SQObjectPtr &obj, CUtlBuffer* pBuffer, Write
 	}
 	case OT_USERDATA:
 	case OT_USERPOINTER:
-		Assert(0);
 		break;
 	default:
 		AssertMsgAlways( 0, "SquirrelVM::WriteObject: unknown type" );
@@ -4458,10 +4458,7 @@ void SquirrelVM::ReadObject( SQObjectPtr &pObj, CUtlBuffer* pBuffer, ReadStateMa
 	}
 	case OT_USERDATA:
 	case OT_USERPOINTER:
-	{
-		Assert(0);
 		break;
-	}
 	default:
 		AssertMsgAlways( 0, "SquirrelVM::ReadObject: serialisation error" );
 	}


### PR DESCRIPTION
A few issues I stumbled upon in the last week.

Save/restore of suspended and trapped threads and generators was fixed.

A couple of save/restore assertions which could now be hit due to debugger functions were removed.

On the debugger's side, there are fixes of a couple of crashes, some disassembly fixes and improved user experience.

---

#### PR Checklist
- [x] **My PR follows all guidelines in the CONTRIBUTING.md file**
- [x] My PR targets a `develop` branch OR targets another branch with a specific goal in mind
