### PR TITLE
[VRAD] small improvements

### DIFF
--- a/sp/src/utils/vrad/leaf_ambient_lighting.cpp
+++ b/sp/src/utils/vrad/leaf_ambient_lighting.cpp
@@ -313,7 +313,11 @@ struct ambientsample_t
 // be discarded.  This has the effect of converging on the best samples when enough are added.
 void AddSampleToList( CUtlVector<ambientsample_t> &list, const Vector &samplePosition, Vector *pCube )
 {
+#ifdef MAPBASE
+	const int MAX_SAMPLES = g_iAmbientCubesPerLeaf;
+#else
 	const int MAX_SAMPLES = 16;
+#endif // MAPBASE
 
 	int index = list.AddToTail();
 	list[index].pos = samplePosition;
@@ -695,7 +699,7 @@ void ComputePerLeafAmbientLighting()
 		{
 			if ( !(dleafs[i].contents & CONTENTS_SOLID) )
 			{
-				Msg("Bad leaf ambient for leaf %d\n", i );
+				Warning("\nBad leaf ambient for leaf %d\n", i );
 			}
 
 			int refLeaf = NearestNeighborWithLight(i);

--- a/sp/src/utils/vrad/lightmap.cpp
+++ b/sp/src/utils/vrad/lightmap.cpp
@@ -1666,8 +1666,10 @@ void ExportDirectLightsToWorldLights()
 
 #define CONSTANT_DOT (.7/2)
 
+#ifndef MAPBASE
 #define NSAMPLES_SUN_AREA_LIGHT 30							// number of samples to take for an
                                                             // non-point sun light
+#endif // MAPBASE
 
 // Helper function - gathers light from sun (emit_skylight)
 void GatherSampleSkyLightSSE( SSE_sampleLightOutput_t &out, directlight_t *dl, int facenum, 
@@ -1693,7 +1695,11 @@ void GatherSampleSkyLightSSE( SSE_sampleLightOutput_t &out, directlight_t *dl, i
 	int nsamples = 1;
 	if ( g_SunAngularExtent > 0.0f )
 	{
+#ifdef MAPBASE
+		nsamples = g_iSunSamplesAreaLight;
+#else
 		nsamples = NSAMPLES_SUN_AREA_LIGHT;
+#endif //MAPBASE
 		if ( do_fast || force_fast )
 			nsamples /= 4;
 	}

--- a/sp/src/utils/vrad/vrad.cpp
+++ b/sp/src/utils/vrad/vrad.cpp
@@ -107,6 +107,11 @@ float		coring = 1.0;	// Light threshold to force to blackness(minimizes lightmap
 qboolean	texscale = true;
 int			dlight_map = 0; // Setting to 1 forces direct lighting into different lightmap than radiosity
 
+#ifdef MAPBASE
+int 		g_iSunSamplesAreaLight = 512; 	// original 30, this was way to little samples
+int 		g_iAmbientCubesPerLeaf = 16;
+#endif // MAPBASE
+
 float		luxeldensity = 1.0;
 unsigned	num_degenerate_faces;
 
@@ -2662,7 +2667,45 @@ int ParseCommandLine( int argc, char **argv, bool *onlydetail )
 				return 1;
 			}
 		}
+#ifdef MAPBASE
+		else if (!Q_stricmp(argv[i], "-SunSamplesAreaLight"))
+		{
+			if (++i < argc && *argv[i])
+			{
+				int iTemp = atoi(argv[i]);
+				if (iTemp < 0)
+				{
+					Warning("Error: expected non-negative value after '-SunSamplesAreaLight'\n");
+					return -1;
+				}
+				g_iSunSamplesAreaLight = iTemp;
+			}
+			else
+			{
+				Warning("Error: expected a value after '-SunSamplesAreaLight'\n");
+				return -1;
+			}
+		}
+		else if (!Q_stricmp(argv[i], "-AmbientCubesPerLeaf"))
+		{
+			if (++i < argc && *argv[i])
+			{
+				int iTemp = atof(argv[i]);
 
+				if (iTemp < 0)
+				{
+					Warning("Error: expected a positive number after '-AmbientCubesPerLeaf'\n");
+					return -1;
+				}
+				g_iAmbientCubesPerLeaf = iTemp;
+			}
+			else
+			{
+				Warning("Error: expected a number after '-AmbientCubesPerLeaf'\n");
+				return -1;
+			}
+		}
+#endif // MAPBASE
 #if ALLOWDEBUGOPTIONS
 		else if (!Q_stricmp(argv[i],"-scale"))
 		{
@@ -2820,6 +2863,10 @@ void PrintUsage( int argc, char **argv )
 		"  -chop           : Smallest number of luxel widths for a bounce patch, used on edges\n"
 		"  -maxchop		   : Coarsest allowed number of luxel widths for a patch, used in face interiors\n"
 		"\n"
+#ifdef MAPBASE
+		"  -SunSamplesAreaLight # : Set max number of samples from the light_enviroment, (default: 512).\n"
+		"  -AmbientCubesPerLeaf # : Lets you scale how many ambient cubes your leaf has, (default: 16).\n"
+#endif // MAPBASE
 		"  -LargeDispSampleRadius: This can be used if there are splotches of bounced light\n"
 		"                          on terrain. The compile will take longer, but it will gather\n"
 		"                          light across a wider area.\n"

--- a/sp/src/utils/vrad/vrad.h
+++ b/sp/src/utils/vrad/vrad.h
@@ -55,6 +55,11 @@
 extern float dispchop; // "-dispchop" tightest number of luxel widths for a patch, used on edges
 extern float g_MaxDispPatchRadius;
 
+#ifdef MAPBASE
+extern int g_iSunSamplesAreaLight;
+extern int g_iAmbientCubesPerLeaf;
+#endif // MAPBASE
+
 //-----------------------------------------------------------------------------
 // forward declarations
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
This PR increases the lighting quality of VRAD:
1: When working with low luxel scales or large surfaces in the Source engine, lighting from the environment light (with -softsun enabled) can appear dirty due to a low number of samples. This PR addresses the issue by improving sample density.

For Users:
Although the default value is 30, you can safely increase it up to 1024 or even 16384. Increasing this value has a negligible impact on computation time (a few seconds or minutes more). For optimal results:

Use -SunSamplesAreaLight 1024 for general improvements.
Use -SunSamplesAreaLight 4096 for very very large surfaces where extensive sunlight coverage occurs.

`-SunSamplesAreaLight  30 `(old vrad stock value)
![image](https://github.com/user-attachments/assets/77059f6c-db55-4509-8496-1386bd78b1b4)
`-SunSamplesAreaLight 8192`
![image](https://github.com/user-attachments/assets/f5dbd226-de17-4c82-9d84-3b0dc7c34947)


2: In many cases where a big levels have a large portal leaf, ambient lighting become less accurate for bounced light. Allowing the user to increase the number of ambient cubes with the -AmbientCubesPerLeaf N command helps solve this issue, also makes lighting of static props more acurate.

For users: The -AmbientCubesPerLeaf N command sets the number of ambient light cubes used for lighting calculations. N represents the number of ambient cubes you want VRAD to generate. VRAD will optimize the number of ambient cubes based on their RGB values (if they are very similar and close to each other, some ambient cubes will be deleted).

`-AmbientCubesPerLeaf 16` (vrad stock value)
![image](https://github.com/user-attachments/assets/66218059-ed3d-433b-a06e-12029c85736b)
`-AmbientCubesPerLeaf 64`
![image](https://github.com/user-attachments/assets/a5a6f9b6-8ba6-4dff-8891-3c960ff451c6)

---

#### Does this PR close any issues?
* (Optional) Insert issue number(s) and any related info here

<!-- Replace [ ] with [x] for each item your PR satisfies -->
#### PR Checklist
- [x] **My PR follows all guidelines in the CONTRIBUTING.md file**
- [x] My PR targets a `develop` branch OR targets another branch with a specific goal in mind
