### PR TITLE
Add convar to disable alt-firing for AR2

### DIFF
--- a/sp/src/creategameprojects.bat
+++ b/sp/src/creategameprojects.bat
@@ -1,1 +1,2 @@
 devtools\bin\vpc.exe /hl2 /episodic +game /mksln games.sln
+pause

--- a/sp/src/game/server/globals.cpp
+++ b/sp/src/game/server/globals.cpp
@@ -25,5 +25,3 @@
 Vector			g_vecAttackDir;
 int				g_iSkillLevel;
 bool			g_fGameOver;
-
-ConVar sv_custom_gamemode("sv_custom_gamemode", "tactical_combat", FCVAR_GAMEDLL | FCVAR_HIDDEN);

--- a/sp/src/game/server/globals.cpp
+++ b/sp/src/game/server/globals.cpp
@@ -25,3 +25,5 @@
 Vector			g_vecAttackDir;
 int				g_iSkillLevel;
 bool			g_fGameOver;
+
+ConVar sv_custom_gamemode("sv_custom_gamemode", "tactical_combat", FCVAR_GAMEDLL | FCVAR_HIDDEN);

--- a/sp/src/game/server/hl2/npc_combine.cpp
+++ b/sp/src/game/server/hl2/npc_combine.cpp
@@ -49,6 +49,48 @@ ConVar npc_combine_altfire_not_allies_only( "npc_combine_altfire_not_allies_only
 ConVar npc_combine_new_cover_behavior( "npc_combine_new_cover_behavior", "1", FCVAR_NONE, "Mapbase: Toggles small patches for parts of npc_combine AI related to soldiers failing to take cover. These patches are minimal and only change cases where npc_combine would otherwise look at an enemy without shooting or run up to the player to melee attack when they don't have to. Consult the Mapbase wiki for more information." );
 
 ConVar npc_combine_fixed_shootpos( "npc_combine_fixed_shootpos", "0", FCVAR_NONE, "Mapbase: Toggles fixed Combine soldier shoot position." );
+
+// Un-hardcode grenade stuff, they marked with FCVAR_HIDDEN because constant stuff prob can't be altered at run-time
+ConVar npc_combine_grenade_throw_speed("npc_combine_grenade_throw_speed", "650", FCVAR_HIDDEN);
+ConVar npc_combine_grenade_timer("npc_combine_grenade_timer", "3.5", FCVAR_HIDDEN);
+ConVar npc_combine_grenade_flush_time("npc_combine_grenade_flush_time", "3.0", FCVAR_HIDDEN);
+ConVar npc_combine_grenade_flush_dist("npc_combine_grenade_flush_dist", "256.0", FCVAR_HIDDEN);
+ConVar npc_combine_grenade_min_clear_dist("npc_combine_grenade_min_clear_dist", "250", FCVAR_HIDDEN);
+
+ConVar npc_combine_limp_health("npc_combine_limp_health", "20", FCVAR_HIDDEN);
+
+ConVar npc_combine_min_crouch_dist("npc_combine_min_crouch_dist", "256.0", FCVAR_HIDDEN);
+
+// Not sure if necessary but it's good to have
+ConVar npc_combine_eye_standing_position_posX("npc_combine_eye_standing_position_posX", "0", FCVAR_HIDDEN);
+ConVar npc_combine_eye_standing_position_posY("npc_combine_eye_standing_position_posY", "0", FCVAR_HIDDEN);
+ConVar npc_combine_eye_standing_position_posZ("npc_combine_eye_standing_position_posZ", "66", FCVAR_HIDDEN);
+
+ConVar npc_combine_gun_standing_position_posX("npc_combine_gun_standing_position_posX", "0", FCVAR_HIDDEN);
+ConVar npc_combine_gun_standing_position_posY("npc_combine_gun_standing_position_posY", "0", FCVAR_HIDDEN);
+ConVar npc_combine_gun_standing_position_posZ("npc_combine_gun_standing_position_posZ", "57", FCVAR_HIDDEN);
+
+ConVar npc_combine_eye_crouching_position_posX("npc_combine_eye_crouching_position_posX", "0", FCVAR_HIDDEN);
+ConVar npc_combine_eye_crouching_position_posY("npc_combine_eye_crouching_position_posY", "0", FCVAR_HIDDEN);
+ConVar npc_combine_eye_crouching_position_posZ("npc_combine_eye_crouching_position_posZ", "40", FCVAR_HIDDEN);
+
+ConVar npc_combine_gun_crouching_position_posX("npc_combine_gun_crouching_position_posX", "0", FCVAR_HIDDEN);
+ConVar npc_combine_gun_crouching_position_posY("npc_combine_gun_crouching_position_posY", "0", FCVAR_HIDDEN);
+ConVar npc_combine_gun_crouching_position_posZ("npc_combine_gun_crouching_position_posZ", "36", FCVAR_HIDDEN);
+
+ConVar npc_combine_shotgun_standing_position_posX("npc_combine_shotgun_standing_position_posX", "0", FCVAR_HIDDEN);
+ConVar npc_combine_shotgun_standing_position_posY("npc_combine_shotgun_standing_position_posY", "0", FCVAR_HIDDEN);
+ConVar npc_combine_shotgun_standing_position_posZ("npc_combine_shotgun_standing_position_posZ", "36", FCVAR_HIDDEN);
+
+ConVar npc_combine_shotgun_crouching_position_posX("npc_combine_shotgun_crouching_position_posX", "0", FCVAR_HIDDEN);
+ConVar npc_combine_shotgun_crouching_position_posY("npc_combine_shotgun_crouching_position_posY", "0", FCVAR_HIDDEN);
+ConVar npc_combine_shotgun_crouching_position_posZ("npc_combine_shotgun_crouching_position_posZ", "36", FCVAR_HIDDEN);
+
+ConVar npc_combine_hacked_gunpos_position_posX("npc_combine_hacked_gunpos_position_posX", "0", FCVAR_HIDDEN);
+ConVar npc_combine_hacked_gunpos_position_posY("npc_combine_hacked_gunpos_position_posY", "0", FCVAR_HIDDEN);
+ConVar npc_combine_hacked_gunpos_position_posZ("npc_combine_hacked_gunpos_position_posZ", "55", FCVAR_HIDDEN);
+
+ConVar npc_combine_move_and_shoot_delay("npc_combine_move_and_shoot_delay", "0.75", FCVAR_HIDDEN);
 #endif
 
 #define COMBINE_SKIN_DEFAULT		0
@@ -56,24 +98,24 @@ ConVar npc_combine_fixed_shootpos( "npc_combine_fixed_shootpos", "0", FCVAR_NONE
 
 
 #ifndef MAPBASE
-#define COMBINE_GRENADE_THROW_SPEED 650
-#define COMBINE_GRENADE_TIMER		3.5
-#define COMBINE_GRENADE_FLUSH_TIME	3.0		// Don't try to flush an enemy who has been out of sight for longer than this.
-#define COMBINE_GRENADE_FLUSH_DIST	256.0	// Don't try to flush an enemy who has moved farther than this distance from the last place I saw him.
+#define COMBINE_GRENADE_THROW_SPEED npc_combine_grenade_throw_speed.GetFloat()
+#define COMBINE_GRENADE_TIMER		npc_combine_grenade_timer.GetFloat()
+#define COMBINE_GRENADE_FLUSH_TIME	npc_combine_grenade_flush_time.GetFloat()		// Don't try to flush an enemy who has been out of sight for longer than this.
+#define COMBINE_GRENADE_FLUSH_DIST	npc_combine_grenade_flush_dist.GetFloat()	// Don't try to flush an enemy who has moved farther than this distance from the last place I saw him.
 #endif
 
-#define COMBINE_LIMP_HEALTH				20
+#define COMBINE_LIMP_HEALTH				npc_combine_limp_health.GetInt()
 #ifndef MAPBASE
-#define	COMBINE_MIN_GRENADE_CLEAR_DIST	250
+#define	COMBINE_MIN_GRENADE_CLEAR_DIST	npc_combine_grenade_min_clear_dist.GetInt()
 #endif
 
-#define COMBINE_EYE_STANDING_POSITION	Vector( 0, 0, 66 )
-#define COMBINE_GUN_STANDING_POSITION	Vector( 0, 0, 57 )
-#define COMBINE_EYE_CROUCHING_POSITION	Vector( 0, 0, 40 )
-#define COMBINE_GUN_CROUCHING_POSITION	Vector( 0, 0, 36 )
-#define COMBINE_SHOTGUN_STANDING_POSITION	Vector( 0, 0, 36 )
-#define COMBINE_SHOTGUN_CROUCHING_POSITION	Vector( 0, 0, 36 )
-#define COMBINE_MIN_CROUCH_DISTANCE		256.0
+#define COMBINE_EYE_STANDING_POSITION	Vector( npc_combine_eye_standing_position_posX.GetFloat(), npc_combine_eye_standing_position_posY.GetFloat(), npc_combine_eye_standing_position_posZ.GetFloat() )
+#define COMBINE_GUN_STANDING_POSITION	Vector( npc_combine_gun_standing_position_posX.GetFloat(), npc_combine_gun_standing_position_posY.GetFloat(), npc_combine_gun_standing_position_posZ.GetFloat() )
+#define COMBINE_EYE_CROUCHING_POSITION	Vector( npc_combine_eye_crouching_position_posX.GetFloat(), npc_combine_eye_crouching_position_posY.GetFloat(), npc_combine_eye_crouching_position_posZ.GetFloat() )
+#define COMBINE_GUN_CROUCHING_POSITION	Vector( npc_combine_gun_crouching_position_posX.GetFloat(), npc_combine_gun_crouching_position_posY.GetFloat(), npc_combine_gun_crouching_position_posZ.GetFloat() )
+#define COMBINE_SHOTGUN_STANDING_POSITION	Vector( npc_combine_shotgun_standing_position_posX.GetFloat(), npc_combine_shotgun_standing_position_posY.GetFloat(), npc_combine_shotgun_standing_position_posZ.GetFloat() )
+#define COMBINE_SHOTGUN_CROUCHING_POSITION	Vector( npc_combine_shotgun_crouching_position_posX.GetFloat(), npc_combine_shotgun_crouching_position_posY.GetFloat(), npc_combine_shotgun_crouching_position_posZ.GetFloat() )
+#define COMBINE_MIN_CROUCH_DISTANCE		npc_combine_min_crouch_dist.GetFloat()
 
 //-----------------------------------------------------------------------------
 // Static stuff local to this file.
@@ -479,10 +521,10 @@ void CNPC_Combine::Spawn( void )
 
 	m_bFirstEncounter	= true;// this is true when the grunt spawns, because he hasn't encountered an enemy yet.
 
-	m_HackedGunPos = Vector ( 0, 0, 55 );
+	m_HackedGunPos = Vector(npc_combine_hacked_gunpos_position_posX.GetFloat(), npc_combine_hacked_gunpos_position_posY.GetFloat(), npc_combine_hacked_gunpos_position_posZ.GetFloat());
 
 	m_flStopMoveShootTime = FLT_MAX; // Move and shoot defaults on.
-	m_MoveAndShootOverlay.SetInitialDelay( 0.75 ); // But with a bit of a delay.
+	m_MoveAndShootOverlay.SetInitialDelay(npc_combine_move_and_shoot_delay.GetFloat()); // But with a bit of a delay.
 
 	m_flNextLostSoundTime		= 0;
 	m_flAlertPatrolTime			= 0;
@@ -909,7 +951,7 @@ void CNPC_Combine::RunTaskChaseEnemyContinuously( const Task_t *pTask )
 void CNPC_Combine::StartTask( const Task_t *pTask )
 {
 	// NOTE: This reset is required because we change it in TASK_COMBINE_CHASE_ENEMY_CONTINUOUSLY
-	m_MoveAndShootOverlay.SetInitialDelay( 0.75 );
+	m_MoveAndShootOverlay.SetInitialDelay(npc_combine_move_and_shoot_delay.GetFloat());
 
 	switch ( pTask->iTask )
 	{

--- a/sp/src/game/server/hl2/npc_combine.cpp
+++ b/sp/src/game/server/hl2/npc_combine.cpp
@@ -91,6 +91,8 @@ ConVar npc_combine_hacked_gunpos_position_posY("npc_combine_hacked_gunpos_positi
 ConVar npc_combine_hacked_gunpos_position_posZ("npc_combine_hacked_gunpos_position_posZ", "55", FCVAR_HIDDEN);
 
 ConVar npc_combine_move_and_shoot_delay("npc_combine_move_and_shoot_delay", "0.75", FCVAR_HIDDEN);
+
+ConVar npc_combine_disable_elite_alt_firing("npc_combine_disable_elite_alt_firing", "0");
 #endif
 
 #define COMBINE_SKIN_DEFAULT		0
@@ -799,6 +801,8 @@ Class_T	CNPC_Combine::Classify ( void )
 //-----------------------------------------------------------------------------
 bool CNPC_Combine::IsAltFireCapable( void )
 {
+	if (npc_combine_disable_elite_alt_firing.GetBool())
+		return false;
 	// The base class tells us if we're carrying an alt-fire-able weapon.
 	return (IsElite() || m_bAlternateCapable) && BaseClass::IsAltFireCapable();
 }

--- a/sp/src/game/server/hl2/npc_combines.cpp
+++ b/sp/src/game/server/hl2/npc_combines.cpp
@@ -41,6 +41,8 @@ extern ConVar sk_plr_dmg_buckshot;
 
 #ifdef MAPBASE
 	ConVar sk_combine_head_dmg_multiplier( "sk_combine_head_dmg_multiplier", "2" );
+
+	ConVar sk_combine_elites_dont_drop_balls("sk_combine_elites_dont_drop_balls", "0"); // Prevent elites from dropping balls
 #endif
 
 extern ConVar sk_plr_num_shotgun_pellets;
@@ -325,7 +327,7 @@ void CNPC_CombineS::Event_Killed( const CTakeDamageInfo &info )
 	if ( pPlayer != NULL )
 	{
 		// Elites drop alt-fire ammo, so long as they weren't killed by dissolving.
-		if( IsElite() )
+		if( IsElite() && !sk_combine_elites_dont_drop_balls.GetBool() )
 		{
 #ifdef HL2_EPISODIC
 			if ( HasSpawnFlags( SF_COMBINE_NO_AR2DROP ) == false )

--- a/sp/src/game/server/hl2/proto_sniper.cpp
+++ b/sp/src/game/server/hl2/proto_sniper.cpp
@@ -58,6 +58,24 @@ ConVar showsniperdist("showsniperdist", "0" );
 ConVar sniperspeak( "sniperspeak", "0" );
 ConVar sniper_xbox_delay( "sniper_xbox_delay", "1" );
 
+// ConVars for configuring Unhidden Snipers
+ConVar sniper_riflemodel("sniper_riflemodel", "models/weapons/w_snip_sg550.mdl");
+ConVar sniperrifle_offset_x("sniperrifle_offset_x", "10.5");
+ConVar sniperrifle_offset_y("sniperrifle_offset_y", "-2.5");
+ConVar sniperrifle_offset_z("sniperrifle_offset_z", "45.0");
+ConVar sniperrifle_despawn_t("sniperrifle_despawn_t", "5");
+ConVar sniperrifle_use_attachment("sniperrifle_use_attachment", "1");
+ConVar sniperrifle_attachment_point("sniperrifle_attachment_point", "lefthand");
+
+ConVar sniperrifle_offset_x_attachment("sniperrifle_offset_x_attachment", "-3.5");
+ConVar sniperrifle_offset_y_attachment("sniperrifle_offset_y_attachment", "-7.5");
+ConVar sniperrifle_offset_z_attachment("sniperrifle_offset_z_attachment", "0");
+
+ConVar sv_npc_sniper_use_aiming_anims("sv_npc_sniper_use_aiming_anims", "1");
+ConVar sv_npc_sniper_should_rotate_body("sv_npc_sniper_should_rotate_body", "1");
+
+ConVar sk_npc_sniper_easy_delay("sk_npc_sniper_easy_delay", "5.0");
+
 // Moved to HL2_SharedGameRules because these are referenced by shared AmmoDef functions
 extern ConVar sk_dmg_sniper_penetrate_plr;
 extern ConVar sk_dmg_sniper_penetrate_npc;
@@ -407,6 +425,8 @@ private:
 #endif
 
 	COutputEvent				m_OnShotFired;
+
+	CBaseEntity*				m_FakeRifle; // reference to the rifle for non-hidden snipers
 	
 	DEFINE_CUSTOM_AI;
 
@@ -755,7 +775,26 @@ void CProtoSniper::LaserOn( const Vector &vecTarget, const Vector &vecDeviance )
 	
 	// The beam is backwards, sortof. The endpoint is the sniper. This is
 	// so that the beam can be tapered to very thin where it emits from the sniper.
-	m_pBeam->PointsInit( vecInitialAim, GetBulletOrigin() );
+	if (HasSpawnFlags(SF_SNIPER_HIDDEN))
+	{
+		m_pBeam->PointsInit(vecInitialAim, GetBulletOrigin());
+	}
+	else
+	{
+		// Try to make the laser emit from the rifle or the NPC origin
+		if (GetNavigator() != NULL && GetNavigator()->IsGoalActive())
+		{
+			vecInitialAim = vecTarget;
+		}
+		if (m_FakeRifle != NULL)
+		{
+			m_pBeam->PointsInit(vecInitialAim, m_FakeRifle->GetAbsOrigin());
+		}
+		else
+		{
+			m_pBeam->PointsInit(vecInitialAim, GetAbsOrigin());
+		}
+	}
 	m_pBeam->SetBrightness( 255 );
 	m_pBeam->SetNoise( 0 );
 	m_pBeam->SetWidth( 1.0f );
@@ -1107,6 +1146,54 @@ void CProtoSniper::Spawn( void )
 		AddEffects( EF_NODRAW );
 		AddSolidFlags( FSOLID_NOT_SOLID );
 	}
+	else
+	{
+		m_FakeRifle = CreateEntityByName("prop_dynamic_override");
+		if (m_FakeRifle)
+		{
+			bool shouldUseAimingVariables = false;
+			Vector offset;
+			if (sniperrifle_use_attachment.GetBool())
+			{
+				int attachment = LookupAttachment(sniperrifle_attachment_point.GetString());
+				if (attachment)
+				{
+					offset.Init(sniperrifle_offset_x_attachment.GetFloat(), sniperrifle_offset_y_attachment.GetFloat(), sniperrifle_offset_z_attachment.GetFloat());
+					m_FakeRifle->SetParent(this, attachment);
+					shouldUseAimingVariables = true;
+				}
+				else
+				{
+					Warning("Failed to attach to attachment, attachment doesn't exist.\n");
+					offset.Init(sniperrifle_offset_x.GetFloat(), sniperrifle_offset_y.GetFloat(), sniperrifle_offset_z.GetFloat());
+					m_FakeRifle->SetParent(this);
+				}
+			}
+			else
+			{
+				offset.Init(sniperrifle_offset_x.GetFloat(), sniperrifle_offset_y.GetFloat(), sniperrifle_offset_z.GetFloat());
+				m_FakeRifle->SetParent(this);
+			}
+			m_FakeRifle->SetLocalOrigin(offset);
+			m_FakeRifle->SetModel(sniper_riflemodel.GetString());
+			m_FakeRifle->SetCollisionGroup(COLLISION_GROUP_WEAPON);
+			m_FakeRifle->SetOwnerEntity(this);
+			m_FakeRifle->Spawn();
+			m_FakeRifle->Activate();
+
+			m_bloodColor = BLOOD_COLOR_RED;
+			SetMoveType(MOVETYPE_STEP);
+			CapabilitiesAdd(bits_CAP_ANIMATEDFACE);
+			CapabilitiesAdd(bits_CAP_DOORS_GROUP);
+			CapabilitiesAdd(bits_CAP_FRIENDLY_DMG_IMMUNE);
+			CapabilitiesAdd(bits_CAP_MOVE_GROUND);
+			if (sv_npc_sniper_use_aiming_anims.GetBool())
+			{
+				CapabilitiesAdd(bits_CAP_AIM_GUN);
+			}
+			CapabilitiesAdd(bits_CAP_TURN_HEAD);
+		}
+	}
 
 	// Point the cursor straight ahead so that the sniper's
 	// first sweep of the laser doesn't look weird.
@@ -1420,6 +1507,12 @@ int CProtoSniper::OnTakeDamage_Alive( const CTakeDamageInfo &info )
 	if ( info.GetDamageType() == DMG_GENERIC && info.GetInflictor() == this )
 		return CAI_BaseNPC::OnTakeDamage_Alive( newInfo );
 
+	// Allow unhidden snipers to be damaged by normal means
+	if (!HasSpawnFlags(SF_SNIPER_HIDDEN))
+	{
+		return CAI_BaseNPC::OnTakeDamage_Alive(newInfo);
+	}
+
 	if( !(info.GetDamageType() & (DMG_BLAST|DMG_BURN) ) )
 	{
 		// Only blasts and burning hurt
@@ -1504,6 +1597,52 @@ void CProtoSniper::Event_Killed( const CTakeDamageInfo &info )
 		pGib = CreateRagGib( "models/combine_soldier.mdl", GetLocalOrigin(), GetLocalAngles(), (vecForward * flForce) + Vector(0, 0, 600), flFadeTime, bShouldIgnite );
 #endif
 
+	}
+
+	// If we're not hidden, spawn a physics version of our rifle
+	if (!HasSpawnFlags(SF_SNIPER_HIDDEN))
+	{
+		if (m_FakeRifle != NULL)
+		{
+			m_FakeRifle->SetParent(NULL);
+			UTIL_Remove(m_FakeRifle);
+			m_FakeRifle = NULL;
+
+			CBaseEntity* pGunProp = CreateEntityByName("prop_physics");
+			if (pGunProp)
+			{
+				Vector offset;
+				offset.Init(sniperrifle_offset_x.GetFloat(), sniperrifle_offset_y.GetFloat(), sniperrifle_offset_z.GetFloat());
+				pGunProp->SetModel(sniper_riflemodel.GetString());
+				pGunProp->SetAbsOrigin(GetAbsOrigin() + offset);
+				pGunProp->SetAbsAngles(GetAbsAngles());
+				pGunProp->SetCollisionGroup(COLLISION_GROUP_WEAPON);
+				pGunProp->Spawn();
+				pGunProp->Activate();
+
+				variant_t variant;
+				variant.SetFloat(sniperrifle_despawn_t.GetFloat());
+				pGunProp->AcceptInput("KillWhenNotVisible", NULL, NULL, variant, -1);
+
+				IPhysicsObject* pPhys = pGunProp->VPhysicsGetObject();
+
+				if (pPhys)
+				{
+					// Add an extra push in a random direction
+					Vector			vel = RandomVector(-64.0f, 64.0f);
+					AngularImpulse	angImp = RandomAngularImpulse(-300.0f, 300.0f);
+
+					vel[2] = 0.0f;
+					pPhys->AddVelocity(&vel, &angImp);
+				}
+				else
+				{
+					// taken from DropItem code
+					pGunProp->ApplyAbsVelocityImpulse(GetAbsVelocity());
+					pGunProp->ApplyLocalAngularVelocityImpulse(AngularImpulse(0, random->RandomFloat(0, 100), 0));
+				}
+			}
+		}
 	}
 
 	m_OnDeath.FireOutput( info.GetAttacker(), this );
@@ -2056,9 +2195,20 @@ Activity CProtoSniper::NPC_TranslateActivity( Activity eNewActivity )
 {
 	// ACT_IDLE is now just the soldier's unarmed idle animation.
 	// Use a gun-holding animation like what unhidden snipers were using before.
-	if (!HasSpawnFlags( SF_SNIPER_HIDDEN ) && eNewActivity == ACT_IDLE)
+	if (!HasSpawnFlags( SF_SNIPER_HIDDEN ))
 	{
-		eNewActivity = ACT_IDLE_SMG1;
+		if (eNewActivity == ACT_IDLE)
+		{
+			eNewActivity = ACT_IDLE_ANGRY_SMG1; // ACT_IDLE_SMG1
+		}
+		else if (eNewActivity == ACT_WALK)
+		{
+			eNewActivity = ACT_WALK_AIM_RIFLE;
+		}
+		else if (eNewActivity == ACT_RUN)
+		{
+			eNewActivity = ACT_RUN_AIM_RIFLE;
+		}
 	}
 
 	return BaseClass::NPC_TranslateActivity( eNewActivity );
@@ -2245,6 +2395,12 @@ void CProtoSniper::StartTask( const Task_t *pTask )
 #ifdef _XBOX
 				delay += sniper_xbox_delay.GetFloat();
 #endif
+
+				// Add a delay on easy difficulty
+				if (g_pGameRules->IsSkillLevel(SKILL_EASY) && !HasSpawnFlags(SF_SNIPER_HIDDEN))
+				{
+					delay += sk_npc_sniper_easy_delay.GetFloat();
+				}
 
 				if( gpGlobals->curtime - m_flTimeLastAttackedPlayer <= SNIPER_FASTER_ATTACK_PERIOD )
 				{
@@ -2605,6 +2761,14 @@ void CProtoSniper::PrescheduleThink( void )
 	// If the enemy has been out of sight for a full second, mark him eluded.
 	if( GetEnemy() != NULL )
 	{
+		if (sv_npc_sniper_should_rotate_body.GetBool() && !HasSpawnFlags(SF_SNIPER_HIDDEN))
+		{
+			// Rotate and face the target
+			Vector posToLookAt = GetEnemy()->GetAbsOrigin() - GetAbsOrigin();
+			QAngle angles;
+			VectorAngles(posToLookAt, angles);
+			SetAbsAngles(QAngle(0, angles.y, 0));
+		}
 		if( gpGlobals->curtime - GetEnemies()->LastTimeSeen( GetEnemy() ) > 30 )
 		{
 			// Stop pestering enemies after 30 seconds of frustration.

--- a/sp/src/game/server/hl2/weapon_ar2.cpp
+++ b/sp/src/game/server/hl2/weapon_ar2.cpp
@@ -37,6 +37,7 @@
 ConVar sk_weapon_ar2_alt_fire_radius( "sk_weapon_ar2_alt_fire_radius", "10" );
 ConVar sk_weapon_ar2_alt_fire_duration( "sk_weapon_ar2_alt_fire_duration", "2" );
 ConVar sk_weapon_ar2_alt_fire_mass( "sk_weapon_ar2_alt_fire_mass", "150" );
+ConVar sk_weapon_ar2_alt_fire_disabled("sk_weapon_ar2_alt_fire_disabled", "0");
 
 //=========================================================
 //=========================================================
@@ -305,6 +306,9 @@ void CWeaponAR2::DelayedAttack( void )
 	if ( pOwner == NULL )
 		return;
 
+	if (sk_weapon_ar2_alt_fire_disabled.GetBool())
+		return;
+
 	// Deplete the clip completely
 	SendWeaponAnim( ACT_VM_SECONDARYATTACK );
 	m_flNextSecondaryAttack = pOwner->m_flNextAttack = gpGlobals->curtime + SequenceDuration();
@@ -364,6 +368,9 @@ void CWeaponAR2::DelayedAttack( void )
 void CWeaponAR2::SecondaryAttack( void )
 {
 	if ( m_bShotDelayed )
+		return;
+
+	if (sk_weapon_ar2_alt_fire_disabled.GetBool())
 		return;
 
 	// Cannot fire underwater

--- a/sp/src/game/server/mapentities.cpp
+++ b/sp/src/game/server/mapentities.cpp
@@ -593,10 +593,11 @@ void MapEntity_PrecacheEntity( const char *pEntData, int &nStringSize )
 
 extern ConVar sv_custom_gamemode;
 
-ConVar npc_metropolice_early_canal_tweaks("npc_metropolice_early_canal_tweaks", "0");
+// These are all from HL2:WT, since that old code was borked i'm scalvenging some crap from that
+ConVar npc_metropolice_early_canal_tweaks("npc_metropolice_early_canal_tweaks", "1");
 ConVar sv_patch_prop_vehicle_jeep("sv_patch_prop_vehicle_jeep", "0");
-ConVar sv_global_map_tweaks("sv_global_map_tweaks", "0");
-ConVar sv_d1_canals_08_elite_cops_map_tweak("sv_d1_canals_08_elite_cops_map_tweak", "0");
+ConVar sv_global_map_tweaks("sv_global_map_tweaks", "1");
+ConVar sv_d1_canals_08_elite_cops_map_tweak("sv_d1_canals_08_elite_cops_map_tweak", "1");
 ConVar sv_d3_c17_elite_cops_override("sv_d3_c17_elite_cops_override", "-1");
 ConVar sv_d3_c17_07_song_replacement("sv_d3_c17_07_song_replacement", "song31");
 ConVar sv_d3_c17_07_song_spawnflags("sv_d3_c17_07_song_spawnflags", "-1");

--- a/sp/src/game/server/monstermaker.h
+++ b/sp/src/game/server/monstermaker.h
@@ -36,9 +36,13 @@ public:
 	bool IsAvailable();						// Is this spawn destination available for selection?
 	void OnSpawnedNPC( CAI_BaseNPC *pNPC );	// Notify this spawn destination that an NPC has spawned here.
 
+	bool		IsRappelSpawn() { return m_bIsRappelSpawn; }
+
 	float		m_ReuseDelay;		// How long to be unavailable after being selected
 	string_t	m_RenameNPC;		// If not NULL, rename the NPC that spawns here to this.
 	float		m_TimeNextAvailable;// The time at which this destination will be available again.
+	bool		m_bIsRappelSpawn; // Only used by npc_maker_dynamic to tell that this spawn should start the NPC rappeling down
+	string_t	m_ChildModelName; // (Only used by npc_maker_dynamic) If set, the soldier will use a custom model instead of the default one.
 
 	COutputEvent	m_OnSpawnNPC;
 
@@ -179,6 +183,26 @@ protected:
 
 	ThreeStateYesNo_t	m_CriterionVisibility;
 	ThreeStateDist_t	m_CriterionDistance;
+};
+
+class CNPCMakerDynamic : public CNPCMaker
+{
+public:
+	DECLARE_CLASS(CNPCMakerDynamic, CNPCMaker);
+
+	CNPCMakerDynamic(void);
+
+	void MakerThink(void);
+	void Precache(void);
+
+	bool IsDepleted() { return false; }
+
+	virtual bool CanMakeNPC(bool bIgnoreSolidEntities);
+	virtual void MakeNPC(void);
+	virtual CNPCSpawnDestination* FindSpawnDestination();
+	virtual void DeathNotice(CBaseEntity* pVictim);
+
+	DECLARE_DATADESC();
 };
 
 #endif // MONSTERMAKER_H

--- a/sp/src/game/shared/hl2/hl2_gamerules.cpp
+++ b/sp/src/game/shared/hl2/hl2_gamerules.cpp
@@ -1409,7 +1409,7 @@ ConVar  alyx_darkness_force( "alyx_darkness_force", "0", FCVAR_CHEAT | FCVAR_REP
 		CBaseCombatCharacter::SetDefaultRelationship(CLASS_PROTOSNIPER,			CLASS_BARNACLE,			D_NU, 0);
 		CBaseCombatCharacter::SetDefaultRelationship(CLASS_PROTOSNIPER,			CLASS_BULLSEYE,			D_NU, 0);
 		//CBaseCombatCharacter::SetDefaultRelationship(CLASS_PROTOSNIPER,			CLASS_BULLSQUID,		D_NU, 0);
-		CBaseCombatCharacter::SetDefaultRelationship(CLASS_PROTOSNIPER,			CLASS_CITIZEN_PASSIVE,	D_HT, 0);	
+		CBaseCombatCharacter::SetDefaultRelationship(CLASS_PROTOSNIPER,			CLASS_CITIZEN_PASSIVE,	D_NU, 0);
 		CBaseCombatCharacter::SetDefaultRelationship(CLASS_PROTOSNIPER,			CLASS_CITIZEN_REBEL,	D_HT, 0);
 		CBaseCombatCharacter::SetDefaultRelationship(CLASS_PROTOSNIPER,			CLASS_COMBINE,			D_NU, 0);
 		CBaseCombatCharacter::SetDefaultRelationship(CLASS_PROTOSNIPER,			CLASS_COMBINE_GUNSHIP,	D_NU, 0);

--- a/sp/src/vpc_scripts/newer_vs_toolsets.vpc
+++ b/sp/src/vpc_scripts/newer_vs_toolsets.vpc
@@ -10,7 +10,7 @@
 $Conditional VS2015	"0" // Toggles Visual Studio 2015 (v140) toolset
 $Conditional VS2017	"0" // Toggles Visual Studio 2017 (v141) toolset
 $Conditional VS2019	"0" // Toggles Visual Studio 2019 (v142) toolset
-$Conditional VS2022	"0" // Toggles Visual Studio 2022 (v143) toolset
+$Conditional VS2022	"1" // Toggles Visual Studio 2022 (v143) toolset
 
 // 
 // WARNING: If you do not have Visual Studio 2013 installed and try to use VPC, it may produce an error about a missing RegKey.


### PR DESCRIPTION
It would be cool if there was a convar to disable AR2 alt-firing, as it'd would be useful for weapon replacements that wish to disable the alt firing. Also it seems like changing the weapon scripts for the ar2 to disable this doesn't seem to have any effect, and instead just gives it infinite ammo.

---

#### Does this PR close any issues?
* No, i don't think so. Just a suggestion.

<!-- Replace [ ] with [x] for each item your PR satisfies -->
#### PR Checklist
- [x] **My PR follows all guidelines in the CONTRIBUTING.md file**
- [x] My PR targets a `develop` branch OR targets another branch with a specific goal in mind
