### PR TITLE
[TF2] Fix game_menu conflicting with voice command menu

### DIFF
--- a/src/game/client/menu.h
+++ b/src/game/client/menu.h
@@ -41,6 +41,10 @@ public:
 	bool IsMenuOpen( void );
 	void SelectMenuItem( int menu_item );
 
+#ifdef MAPBASE
+	bool IsMenuMapDefined() const { return m_bMapDefinedMenu; }
+#endif
+
 private:
 	virtual void OnThink();
 	virtual void Paint();

--- a/src/game/client/voice_menu.cpp
+++ b/src/game/client/voice_menu.cpp
@@ -50,6 +50,12 @@ void OpenVoiceMenu( int index )
 	if ( !pMenu )
 		return;
 
+#ifdef MAPBASE
+	// Don't override map-defined menus
+	if ( pMenu->IsMenuMapDefined() && pMenu->IsMenuOpen() )
+		return;
+#endif
+
 	// if they hit the key again, close the menu
 	if ( g_ActiveVoiceMenu == index )
 	{


### PR DESCRIPTION
This PR fixes `game_menu` conflicting with the voice command menu, which in the default SDK is mainly a problem in TF2 mods.

---

<!-- Replace [ ] with [x] for each item your PR satisfies -->
#### PR Checklist
- [x] **My PR follows all guidelines in the CONTRIBUTING.md file**
- [x] My PR targets a `develop` branch OR targets another branch with a specific goal in mind
