### PR TITLE
[TF2] Fix trigger_fall not working in TF2

### DIFF
--- a/src/game/server/player.cpp
+++ b/src/game/server/player.cpp
@@ -5533,6 +5533,10 @@ void CBasePlayer::Spawn( void )
 	}
 
 	m_weaponFiredTimer.Invalidate();
+
+#ifdef MAPBASE
+	m_bInTriggerFall = false;
+#endif
 }
 
 void CBasePlayer::Activate( void )

--- a/src/game/server/tf/tf_player.cpp
+++ b/src/game/server/tf/tf_player.cpp
@@ -9222,6 +9222,13 @@ int CTFPlayer::OnTakeDamage( const CTakeDamageInfo &inputInfo )
 	{
 		bAllowDamage = true;
 	}
+#ifdef MAPBASE
+	else if ( info.GetDamageType() & DMG_FALL && m_bInTriggerFall )
+	{
+		// trigger_fall should always kill
+		bAllowDamage = true;
+	}
+#endif
 
 	if ( !TFGameRules()->ApplyOnDamageModifyRules( info, this, bAllowDamage ) )
 	{

--- a/src/game/shared/tf/tf_gamerules.cpp
+++ b/src/game/shared/tf/tf_gamerules.cpp
@@ -13333,6 +13333,14 @@ float CTFGameRules::FlPlayerFallDamage( CBasePlayer *pPlayer )
 	if ( !pTFPlayer )
 		return 0;
 
+#ifdef MAPBASE
+	// trigger_fall overrides all fall damage conditions
+	if ( pTFPlayer->m_bInTriggerFall )
+	{
+		return pPlayer->GetMaxHealth();
+	}
+#endif
+
 	// Karts don't take fall damage
 	if ( pTFPlayer->m_Shared.InCond( TF_COND_HALLOWEEN_KART ) )
 	{


### PR DESCRIPTION
This PR fixes `trigger_fall` not functioning in TF2 due to TF2 having capped fall damage.

---

<!-- Replace [ ] with [x] for each item your PR satisfies -->
#### PR Checklist
- [x] **My PR follows all guidelines in the CONTRIBUTING.md file**
- [x] My PR targets a `develop` branch OR targets another branch with a specific goal in mind
