### PR TITLE
[HL2MP] HL2MP bot possession + CHL2MPRules::AllowDefaultItems/Suit

### DIFF
--- a/src/game/client/hl2mp/clientmode_hl2mpnormal.h
+++ b/src/game/client/hl2mp/clientmode_hl2mpnormal.h
@@ -32,6 +32,8 @@ public:
 
 	virtual void	Init();
 	virtual int		GetDeathMessageStartHeight( void );
+
+	virtual void	FireGameEvent( IGameEvent *event );
 };
 
 extern IClientMode *GetClientModeNormal();

--- a/src/game/server/hl2mp/bot/hl2mp_bot.cpp
+++ b/src/game/server/hl2mp/bot/hl2mp_bot.cpp
@@ -668,6 +668,10 @@ void CHL2MPBot::Spawn()
 	SetBrokenFormation( false );
 
 	GetVisionInterface()->ForgetAllKnownEntities();
+
+#ifdef MAPBASE
+	SetUse( &CHL2MPBot::BotUse );
+#endif
 }
 
 
@@ -845,6 +849,45 @@ void CHL2MPBot::Event_Killed( const CTakeDamageInfo &info )
 
 	StopIdleSound();
 }
+
+
+#ifdef MAPBASE
+//-----------------------------------------------------------------------------------------------------
+int CHL2MPBot::ObjectCaps( void )
+{
+	int nCaps = BaseClass::ObjectCaps();
+
+	if ( ( HasAttribute( CHL2MPBot::CAN_POSSESS ) || HasAttribute( CHL2MPBot::IS_NPC ) ) && IsAlive() )
+		nCaps |= FCAP_IMPULSE_USE;
+
+	return nCaps;
+}
+
+//-----------------------------------------------------------------------------------------------------
+void CHL2MPBot::BotUse( CBaseEntity *pActivator, CBaseEntity *pCaller, USE_TYPE useType, float value )
+{
+	if ( HasAttribute( CHL2MPBot::CAN_POSSESS ) )
+	{
+		CHL2MP_Player *pPlayer = ToHL2MPPlayer( pActivator );
+		if ( pPlayer )
+		{
+			CRecipientFilter user;
+			user.AddAllPlayers();
+			user.MakeReliable();
+
+			// Make sure these bots come and go seamlessly
+			UserMessageBegin( user, "HideBotsJoin" );
+				WRITE_CHAR( 2 );
+			MessageEnd();
+
+			if (TheHL2MPBots().BotTakeOverPlayer( pPlayer, false ))
+			{
+				TheHL2MPBots().PlayerTakeOverBot( pPlayer, this );
+			}
+		}
+	}
+}
+#endif
 
 
 //---------------------------------------------------------------------------------------------

--- a/src/game/server/hl2mp/bot/hl2mp_bot.h
+++ b/src/game/server/hl2mp/bot/hl2mp_bot.h
@@ -75,6 +75,11 @@ public:
 
 	virtual CNavArea *GetLastKnownArea( void ) const		{ return static_cast< CNavArea * >( BaseClass::GetLastKnownArea() ); }		// return the last nav area the player occupied - NULL if unknown
 
+#ifdef MAPBASE
+	virtual int			ObjectCaps( void );
+	virtual void		BotUse( CBaseEntity *pActivator, CBaseEntity *pCaller, USE_TYPE useType, float value );
+#endif
+
 	// NextBotPlayer
 	static CBasePlayer *AllocatePlayerEntity( edict_t *pEdict, const char *playerName );
 
@@ -192,6 +197,9 @@ public:
 		ALWAYS_FIRE_WEAPON			= 1<<13,				// constantly fire our weapon
 		TELEPORT_TO_HINT			= 1<<14,				// bot will teleport to hint target instead of walking out from the spawn point
 		AUTO_JUMP					= 1<<18,				// auto jump
+#ifdef MAPBASE
+		CAN_POSSESS					= 1<<19,				// player can switch to this bot
+#endif
 	};
 	void SetAttribute( int attributeFlag );
 	void ClearAttribute( int attributeFlag );

--- a/src/game/server/hl2mp/bot/hl2mp_bot_manager.h
+++ b/src/game/server/hl2mp/bot/hl2mp_bot_manager.h
@@ -98,6 +98,16 @@ public:
 
 	bool RemoveBotFromTeamAndKick( int nTeam );
 
+#ifdef MAPBASE
+	bool CanDoBotTakeover() const;
+	bool CanDoBotTakeoverOn( CHL2MP_Player *pPlayer ) const;
+	bool IsPerformingBotTakeover() const { return m_bPerformingBotTakeover; }
+	void HideBotsJoining( int nNumBots );
+
+	CHL2MPBot *BotTakeOverPlayer( CHL2MP_Player *pPlayer, bool bForIdle = true );
+	void PlayerTakeOverBot( CHL2MP_Player *pPlayer, CHL2MPBot *pBot, bool bKickBot = true );
+#endif
+
 protected:
 	void MaintainBotQuota();
 	void SetIsInOfflinePractice( bool bIsInOfflinePractice );
@@ -107,6 +117,10 @@ protected:
 
 	CUtlVector< CStuckBot * > m_stuckBotVector;
 	CountdownTimer m_stuckDisplayTimer;
+
+#ifdef MAPBASE
+	bool m_bPerformingBotTakeover;
+#endif
 };
 
 // singleton accessor

--- a/src/game/server/hl2mp/hl2mp_player.cpp
+++ b/src/game/server/hl2mp/hl2mp_player.cpp
@@ -244,7 +244,15 @@ void CHL2MP_Player::GiveAllItems( void )
 
 void CHL2MP_Player::GiveDefaultItems( void )
 {
+#ifdef MAPBASE
+	if (HL2MPRules()->AllowDefaultSuit())
+#endif
 	EquipSuit();
+
+#ifdef MAPBASE
+	if (!HL2MPRules()->AllowDefaultItems())
+		return;
+#endif
 
 	CBasePlayer::GiveAmmo( 255,	"Pistol");
 	CBasePlayer::GiveAmmo( 45,	"SMG1");

--- a/src/game/server/hl2mp/hl2mp_player.cpp
+++ b/src/game/server/hl2mp/hl2mp_player.cpp
@@ -1841,7 +1841,7 @@ void CHL2MP_Player::CheckForIdle( void )
 			else if ( mp_idledealmethod.GetInt() == 1 )
 			{
 				//if ( GetTeamNumber() < FIRST_GAME_TEAM )
-				if ( GetTeamNumber() != TEAM_SPECTATOR )
+				if ( GetTeamNumber() == TEAM_SPECTATOR )
 				{
 					bKickPlayer = true;
 				}

--- a/src/game/server/hl2mp/hl2mp_player.h
+++ b/src/game/server/hl2mp/hl2mp_player.h
@@ -107,6 +107,13 @@ public:
 	const char *GetPlayerModelSoundPrefix( void );
 	int	  GetPlayerModelType( void ) { return m_iPlayerSoundType;	}
 
+#ifdef MAPBASE
+	// TF2-style AFK checking
+	void				CheckForIdle( void );
+	void				ResetIdleCheck( void ) { m_flLastAction = gpGlobals->curtime; }
+	bool				IsAwayFromKeyboard( void ) const { return m_bIsAFK; }
+#endif
+
 	int	GetMaxAmmo( int iAmmoIndex ) const;
 	
 	void  DetonateTripmines( void );
@@ -143,6 +150,12 @@ public:
 
 	bool IsThreatAimingTowardMe( CBaseEntity* threat, float cosTolerance = 0.8f ) const;
 	bool IsThreatFiringAtMe( CBaseEntity* threat ) const;
+
+#ifdef MAPBASE
+	void			SetBotTakeOverAvatar( CHL2MP_Player *pAvatar ) { m_pBotTakeOverAvatar = pAvatar; }
+	CHL2MP_Player	*GetBotTakeOverAvatar() const { return m_pBotTakeOverAvatar; }
+#endif
+
 private:
 
 	CNetworkQAngle( m_angEyeAngles );
@@ -168,6 +181,14 @@ private:
 
     bool m_bEnterObserver;
 	bool m_bReady;
+
+#ifdef MAPBASE
+	bool	m_bIsAFK;
+	float	m_flLastAction;
+
+	// Used by bot takeover. If we are a bot, this is our real player. If we are the real player, this is the bot that's taken us over.
+	CHL2MP_Player *m_pBotTakeOverAvatar;
+#endif
 };
 
 inline CHL2MP_Player *ToHL2MPPlayer( CBaseEntity *pEntity )

--- a/src/game/shared/hl2mp/hl2mp_gamerules.cpp
+++ b/src/game/shared/hl2mp/hl2mp_gamerules.cpp
@@ -33,6 +33,9 @@
 	#include "voice_gamemgr.h"
 	#include "hl2mp_gameinterface.h"
 	#include "hl2mp_cvars.h"
+#ifdef MAPBASE
+	#include "bot/hl2mp_bot_manager.h"
+#endif
 
 extern void respawn(CBaseEntity *pEdict, bool fCopyCorpse);
 

--- a/src/game/shared/hl2mp/hl2mp_gamerules.cpp
+++ b/src/game/shared/hl2mp/hl2mp_gamerules.cpp
@@ -308,6 +308,38 @@ void CHL2MPRules::PlayerIdle( CBasePlayer *pPlayer )
 
 	//BaseClass::PlayerIdle( pPlayer );
 }
+
+//-----------------------------------------------------------------------------
+// Gets our default items setting.
+//-----------------------------------------------------------------------------
+bool CHL2MPRules::AllowDefaultItems()
+{
+	return m_bAllowDefaultItems;
+}
+
+//-----------------------------------------------------------------------------
+// Sets our default items setting.
+//-----------------------------------------------------------------------------
+void CHL2MPRules::SetAllowDefaultItems( bool toggle )
+{
+	m_bAllowDefaultItems = toggle;
+}
+
+//-----------------------------------------------------------------------------
+// Gets our default suit setting.
+//-----------------------------------------------------------------------------
+bool CHL2MPRules::AllowDefaultSuit()
+{
+	return m_bAllowDefaultSuit;
+}
+
+//-----------------------------------------------------------------------------
+// Sets our default suit setting.
+//-----------------------------------------------------------------------------
+void CHL2MPRules::SetAllowDefaultSuit( bool toggle )
+{
+	m_bAllowDefaultSuit = toggle;
+}
 #endif
 
 

--- a/src/game/shared/hl2mp/hl2mp_gamerules.h
+++ b/src/game/shared/hl2mp/hl2mp_gamerules.h
@@ -139,6 +139,12 @@ public:
 #ifdef MAPBASE
 	void PlayerSpawn( CBasePlayer *pPlayer );
 	void PlayerIdle( CBasePlayer *pPlayer );
+
+	bool	AllowDefaultItems();
+	void	SetAllowDefaultItems( bool toggle );
+
+	bool	AllowDefaultSuit();
+	void	SetAllowDefaultSuit( bool toggle );
 #endif
 
 #endif
@@ -173,6 +179,9 @@ private:
 	bool m_bChangelevelDone;
 
 #ifdef MAPBASE
+	bool m_bAllowDefaultItems = true;
+	bool m_bAllowDefaultSuit = true;
+
 	CNetworkVar( bool, m_bHideBotJoinGame );	// Hides when bots connect and disconnect from the game
 #endif
 #endif

--- a/src/game/shared/hl2mp/hl2mp_gamerules.h
+++ b/src/game/shared/hl2mp/hl2mp_gamerules.h
@@ -135,6 +135,11 @@ public:
 	void	ManageObjectRelocation( void );
 	void    CheckChatForReadySignal( CHL2MP_Player *pPlayer, const char *chatmsg );
 	const char *GetChatFormat( bool bTeamOnly, CBasePlayer *pPlayer );
+ 
+#ifdef MAPBASE
+	void PlayerSpawn( CBasePlayer *pPlayer );
+	void PlayerIdle( CBasePlayer *pPlayer );
+#endif
 
 #endif
 
@@ -166,6 +171,10 @@ private:
 
 #ifndef CLIENT_DLL
 	bool m_bChangelevelDone;
+
+#ifdef MAPBASE
+	CNetworkVar( bool, m_bHideBotJoinGame );	// Hides when bots connect and disconnect from the game
+#endif
 #endif
 };
 

--- a/src/game/shared/mapbase/mapbase_usermessages.cpp
+++ b/src/game/shared/mapbase/mapbase_usermessages.cpp
@@ -32,6 +32,10 @@ void RegisterMapbaseUserMessages( void )
 
 	usermessages->Register( "ShowMenuComplex", -1 ); // CHudMenu
 
+#ifdef HL2MP
+	usermessages->Register( "HideBotsJoin", 1 ); // ClientModeHL2MPNormal
+#endif
+
 #ifdef CLIENT_DLL
 	// TODO: Better placement?
 	HookMapbaseUserMessages();

--- a/src/game/shared/multiplay_gamerules.cpp
+++ b/src/game/shared/multiplay_gamerules.cpp
@@ -680,6 +680,9 @@ ConVarRef suitcharger( "sk_suitcharger" );
 		bool		addDefault;
 		CBaseEntity	*pWeaponEntity = NULL;
 
+#ifdef MAPBASE
+		if (AllowDefaultSuit())
+#endif
 		pPlayer->EquipSuit();
 		
 		addDefault = true;

--- a/src/game/shared/multiplay_gamerules.h
+++ b/src/game/shared/multiplay_gamerules.h
@@ -168,6 +168,10 @@ public:
 	virtual bool CanHaveItem( CBasePlayer *pPlayer, CItem *pItem );
 	virtual void PlayerGotItem( CBasePlayer *pPlayer, CItem *pItem );
 
+#ifdef MAPBASE
+	virtual bool AllowDefaultSuit() { return true; }
+#endif
+
 // Item spawn/respawn control
 	virtual int ItemShouldRespawn( CItem *pItem );
 	virtual float FlItemRespawnTime( CItem *pItem );


### PR DESCRIPTION
This PR adds the ability to have a bot take over a player in HL2MP. It also adds two utility functions to `CHL2MPRules` which had some degree of overlap in code. The changes can be viewed as two separate commits.

The bot possession code takes advantage of AFK handling ported from TF2 by having an additional AFK mode for temporarily replacing the player with a bot, similar to Left 4 Dead. A new attribute can also be added to an existing bot which allows players to possess it by interacting with it, similar to Half-Life: Decay.

---

<!-- Replace [ ] with [x] for each item your PR satisfies -->
#### PR Checklist
- [x] **My PR follows all guidelines in the CONTRIBUTING.md file**
- [x] My PR targets a `develop` branch OR targets another branch with a specific goal in mind
