### PR TITLE
Added an ability to use the headlights on all the vehicles in the game, these headlights are also more customizable.

### DIFF
--- a/sp/src/game/client/c_prop_vehicle.cpp
+++ b/sp/src/game/client/c_prop_vehicle.cpp
@@ -46,6 +46,12 @@ IMPLEMENT_CLIENTCLASS_DT(C_PropVehicleDriveable, DT_PropVehicleDriveable, CPropV
 	RecvPropVector( RECVINFO( m_vecEyeExitEndpoint ) ),
 	RecvPropBool( RECVINFO( m_bHasGun ) ),
 	RecvPropVector( RECVINFO( m_vecGunCrosshair ) ),
+
+#ifdef MAPBASE
+	RecvPropFloat( RECVINFO ( m_flHeadlightScale ) ),
+	RecvPropInt( RECVINFO ( m_clrHeadlightColor ) ),
+#endif
+
 END_RECV_TABLE()
 
 

--- a/sp/src/game/client/c_prop_vehicle.h
+++ b/sp/src/game/client/c_prop_vehicle.h
@@ -118,6 +118,11 @@ protected:
 	bool						m_bExitAnimOn;
 	float						m_flFOV;
 
+#ifdef MAPBASE
+	float						m_flHeadlightScale;
+	color32						m_clrHeadlightColor;
+#endif
+
 	Vector						m_vecGunCrosshair;
 	CInterpolatedVar<Vector>	m_iv_vecGunCrosshair;
 	Vector						m_vecEyeExitEndpoint;

--- a/sp/src/game/client/c_vehicle_jeep.cpp
+++ b/sp/src/game/client/c_vehicle_jeep.cpp
@@ -68,6 +68,10 @@ void C_PropJeep::Simulate( void )
 				return;
 
 			m_pHeadlight->TurnOn();
+#ifdef MAPBASE
+			m_pHeadlight->SetColor( m_clrHeadlightColor );
+			m_pHeadlight->SetScale( m_flHeadlightScale );
+#endif
 		}
 
 		QAngle vAngle;

--- a/sp/src/game/client/flashlighteffect.cpp
+++ b/sp/src/game/client/flashlighteffect.cpp
@@ -508,6 +508,18 @@ CHeadlightEffect::~CHeadlightEffect()
 	
 }
 
+#ifdef MAPBASE
+void CHeadlightEffect::SetColor(color32 color)
+{
+	m_clrHeadlightColors = color;
+}
+
+void CHeadlightEffect::SetScale(float scale)
+{
+	m_flHeadlightScale = scale;
+}
+#endif
+
 void CHeadlightEffect::UpdateLight( const Vector &vecPos, const Vector &vecDir, const Vector &vecRight, const Vector &vecUp, int nDistance )
 {
 	if ( IsOn() == false )
@@ -526,15 +538,31 @@ void CHeadlightEffect::UpdateLight( const Vector &vecPos, const Vector &vecDir, 
 		
 	state.m_vecLightOrigin = vecPos;
 
+#ifdef MAPBASE
+	//Made it a bit bigger than the original
+	state.m_fHorizontalFOVDegrees = 54.0f * m_flHeadlightScale;
+	state.m_fVerticalFOVDegrees = 36.0f * m_flHeadlightScale;
+#else
 	state.m_fHorizontalFOVDegrees = 45.0f;
 	state.m_fVerticalFOVDegrees = 30.0f;
+#endif
+
 	state.m_fQuadraticAtten = r_flashlightquadratic.GetFloat();
 	state.m_fLinearAtten = r_flashlightlinear.GetFloat();
 	state.m_fConstantAtten = r_flashlightconstant.GetFloat();
+
+#ifdef MAPBASE
+	state.m_Color[0] = m_clrHeadlightColors.r / 255;
+	state.m_Color[1] = m_clrHeadlightColors.g / 255;
+	state.m_Color[2] = m_clrHeadlightColors.b / 255;
+	state.m_Color[3] = m_clrHeadlightColors.a / 255;
+#else
 	state.m_Color[0] = 1.0f;
 	state.m_Color[1] = 1.0f;
 	state.m_Color[2] = 1.0f;
 	state.m_Color[3] = r_flashlightambient.GetFloat();
+#endif
+
 	state.m_NearZ = r_flashlightnear.GetFloat();
 	state.m_FarZ = r_flashlightfar.GetFloat();
 	state.m_bEnableShadows = true;

--- a/sp/src/game/client/flashlighteffect.h
+++ b/sp/src/game/client/flashlighteffect.h
@@ -56,6 +56,14 @@ public:
 	CHeadlightEffect();
 	~CHeadlightEffect();
 
+#ifdef MAPBASE
+	float m_flHeadlightScale;
+	color32 m_clrHeadlightColors;
+
+	void SetScale(float scale);
+	void SetColor(color32 color);
+#endif
+
 	virtual void UpdateLight(const Vector &vecPos, const Vector &vecDir, const Vector &vecRight, const Vector &vecUp, int nDistance);
 };
 

--- a/sp/src/game/client/hl2/c_vehicle_airboat.cpp
+++ b/sp/src/game/client/hl2/c_vehicle_airboat.cpp
@@ -517,6 +517,10 @@ void C_PropAirboat::UpdateHeadlight()
 				return;
 
 			m_pHeadlight->TurnOn();
+#ifdef MAPBASE
+			m_pHeadlight->SetColor( m_clrHeadlightColor );
+			m_pHeadlight->SetScale( m_flHeadlightScale );
+#endif
 		}
 
 		// The headlight is emitted from an attachment point so that it can move

--- a/sp/src/game/server/hl2/vehicle_jeep.cpp
+++ b/sp/src/game/server/hl2/vehicle_jeep.cpp
@@ -1337,6 +1337,19 @@ void CPropJeep::DriveVehicle( float flFrameTime, CUserCmd *ucmd, int iButtonsDow
 {
 	int iButtons = ucmd->buttons;
 
+#ifdef MAPBASE
+	if ( ucmd->impulse == 100 )
+	{
+		if (HeadlightIsOn())
+		{
+			HeadlightTurnOff();
+		}
+		else
+		{
+			HeadlightTurnOn();
+		}
+	}
+#else
 	//Adrian: No headlights on Superfly.
 /*	if ( ucmd->impulse == 100 )
 	{
@@ -1349,6 +1362,7 @@ void CPropJeep::DriveVehicle( float flFrameTime, CUserCmd *ucmd, int iButtonsDow
 			HeadlightTurnOn();
 		}
 	}*/
+#endif
 		
 	// Only handle the cannon if the vehicle has one
 	if ( m_bHasGun )

--- a/sp/src/game/server/hl2/vehicle_jeep.cpp
+++ b/sp/src/game/server/hl2/vehicle_jeep.cpp
@@ -208,6 +208,20 @@ void CPropJeep::Precache( void )
 	BaseClass::Precache();
 }
 
+#ifdef MAPBASE
+void CPropJeep::HeadlightTurnOn( void )
+{
+	EmitSound( "Airboat_headlight_on" );
+	m_bHeadlightIsOn = true;
+}
+
+void CPropJeep::HeadlightTurnOff( void )
+{
+	EmitSound( "Airboat_headlight_off" );
+	m_bHeadlightIsOn = false;
+}
+#endif
+
 //------------------------------------------------
 // Spawn
 //------------------------------------------------

--- a/sp/src/game/server/hl2/vehicle_jeep.h
+++ b/sp/src/game/server/hl2/vehicle_jeep.h
@@ -87,8 +87,13 @@ public:
 	void			DoImpactEffect( trace_t &tr, int nDamageType );
 
 	bool HeadlightIsOn( void ) { return m_bHeadlightIsOn; }
+#ifdef MAPBASE
+	void HeadlightTurnOn( void );
+	void HeadlightTurnOff( void );
+#else
 	void HeadlightTurnOn( void ) { m_bHeadlightIsOn = true; }
 	void HeadlightTurnOff( void ) { m_bHeadlightIsOn = false; }
+#endif
 
 private:
 

--- a/sp/src/game/server/vehicle_base.cpp
+++ b/sp/src/game/server/vehicle_base.cpp
@@ -352,6 +352,11 @@ IMPLEMENT_SERVERCLASS_ST(CPropVehicleDriveable, DT_PropVehicleDriveable)
 	SendPropVector(SENDINFO(m_vecEyeExitEndpoint), -1, SPROP_COORD),
 	SendPropBool(SENDINFO(m_bHasGun)),
 	SendPropVector(SENDINFO(m_vecGunCrosshair), -1, SPROP_COORD),
+#ifdef MAPBASE
+	SendPropFloat(SENDINFO( m_flHeadlightScale ), -1, SPROP_NOSCALE),
+	SendPropInt(SENDINFO( m_clrHeadlightColor ), -1, SPROP_UNSIGNED),
+#endif
+
 END_SEND_TABLE();
 
 BEGIN_DATADESC( CPropVehicleDriveable )
@@ -391,7 +396,10 @@ BEGIN_DATADESC( CPropVehicleDriveable )
 	DEFINE_FIELD( m_bUnableToFire, FIELD_BOOLEAN ),
 	DEFINE_FIELD( m_vecEyeExitEndpoint, FIELD_POSITION_VECTOR ),
 	DEFINE_FIELD( m_vecGunCrosshair, FIELD_VECTOR ),
-
+#ifdef MAPBASE
+	DEFINE_KEYFIELD( m_flHeadlightScale, FIELD_FLOAT, "HeadlightScale" ),
+	DEFINE_KEYFIELD( m_clrHeadlightColor, FIELD_COLOR32, "HeadlightColor" ),
+#endif
 	DEFINE_FIELD( m_bEngineLocked, FIELD_BOOLEAN ),
 	DEFINE_KEYFIELD( m_bLocked, FIELD_BOOLEAN, "VehicleLocked" ),
 	DEFINE_FIELD( m_flMinimumSpeedToEnterExit, FIELD_FLOAT ),
@@ -432,6 +440,11 @@ CPropVehicleDriveable::CPropVehicleDriveable( void ) :
 {
 	m_vecEyeExitEndpoint.Init();
 	m_vecGunCrosshair.Init();
+
+#ifdef MAPBASE
+	KeyValue("HeadlightColor", "255 255 255 255");
+	KeyValue("HeadlightScale", "1");
+#endif
 }
 
 //-----------------------------------------------------------------------------

--- a/sp/src/game/server/vehicle_base.h
+++ b/sp/src/game/server/vehicle_base.h
@@ -313,6 +313,11 @@ public:
 	bool IsExitAnimOn( void ) { return m_bExitAnimOn; }
 	const Vector &GetEyeExitEndpoint( void ) { return m_vecEyeExitEndpoint; }
 
+#ifdef MAPBASE
+	CNetworkVar(float, m_flHeadlightScale);
+	CNetworkVar(color32, m_clrHeadlightColor);
+#endif
+
 protected:
 	// Entering / Exiting
 	bool		m_bEngineLocked;	// Mapmaker override on whether the vehicle's allowed to be turned on/off


### PR DESCRIPTION
You can now enable the headlights on all the vehicles in the game with a key that is bound to the "impulse 100" command.
This PR also adds new keyvalues for all the vehicles in the game.

1. HeadlghtScale - it allows you to make the light much bigger, it's very buggy at high values though.
2. HeadlightColor - it allows you to make the light any color you want.

---

#### Does this PR close any issues?
It closes the #440 issue.

<!-- Replace [ ] with [x] for each item your PR satisfies -->
#### PR Checklist
- [x] **My PR follows all guidelines in the CONTRIBUTING.md file**
- [x] My PR targets a `develop` branch OR targets another branch with a specific goal in mind
