### PR TITLE
Fix scaled physics prop save/restore

### DIFF
--- a/sp/src/game/server/props.cpp
+++ b/sp/src/game/server/props.cpp
@@ -41,6 +41,7 @@
 #include "physics_collisionevent.h"
 #include "gamestats.h"
 #include "vehicle_base.h"
+#include "physics_saverestore.h"
 #ifdef MAPBASE
 #include "mapbase/GlobalStrings.h"
 #include "collisionutils.h"
@@ -7186,6 +7187,7 @@ bool UTIL_CreateScaledPhysObject( CBaseAnimating *pInstance, float flScale )
 
 	pInstance->VPhysicsDestroyObject();
 	pInstance->VPhysicsSetObject( pNewObject );
+	g_pPhysSaveRestoreManager->AssociateModel( pNewObject, pInstance->GetModelIndex() );
 
 	// Increase our model bounds
 	const model_t *pModel = modelinfo->GetModel( pInstance->GetModelIndex() );


### PR DESCRIPTION
Creating a scaled physics object involves deleting the unscaled object and creating a new one. However the new physics object was not registered in the physics saverestore handler.

Test by creating scaled prop_physics entities, save, restore, observe broken physics or game crash.

This is missing in Valve's code as well.

---

#### PR Checklist
- [x] **My PR follows all guidelines in the CONTRIBUTING.md file**
- [x] My PR targets a `develop` branch OR targets another branch with a specific goal in mind
