### PR TITLE
[MP] Add prediction for disabled/forced buttons

### DIFF
--- a/src/game/client/c_baseplayer.cpp
+++ b/src/game/client/c_baseplayer.cpp
@@ -306,6 +306,13 @@ END_RECV_TABLE()
 		RecvPropBool		( RECVINFO( m_bInTriggerFall ) ),
 #endif
 
+#ifdef MAPBASE_MP
+		// These are transmitted so that prediction is aware of what buttons are disabled
+		// (e.g. weapons don't fire when +attack is disabled)
+		RecvPropInt			( RECVINFO( m_afButtonDisabled ) ),
+		RecvPropInt			( RECVINFO( m_afButtonForced ) ),
+#endif
+
 	END_RECV_TABLE()
 
 	

--- a/src/game/client/c_baseplayer.h
+++ b/src/game/client/c_baseplayer.h
@@ -463,6 +463,11 @@ public:
 
 	int				m_nButtons;
 
+#ifdef MAPBASE_MP
+	int				m_afButtonDisabled;	// A mask of input flags that are cleared automatically
+	int				m_afButtonForced;	// These are forced onto the player's inputs
+#endif
+
 	CUserCmd		*m_pCurrentCommand;
 
 	// Movement constraints

--- a/src/game/client/prediction.cpp
+++ b/src/game/client/prediction.cpp
@@ -901,6 +901,12 @@ void CPrediction::RunCommand( C_BasePlayer *player, CUserCmd *ucmd, IMoveHelper 
 	gpGlobals->curtime		= player->m_nTickBase * TICK_INTERVAL;
 	gpGlobals->frametime	= m_bEnginePaused ? 0 : TICK_INTERVAL;
 
+#ifdef MAPBASE_MP
+	// Add and subtract buttons we're forcing on the player
+	ucmd->buttons |= player->m_afButtonForced;
+	ucmd->buttons &= ~player->m_afButtonDisabled;
+#endif
+
 	g_pGameMovement->StartTrackPredictionErrors( player );
 
 // TODO

--- a/src/game/server/player.cpp
+++ b/src/game/server/player.cpp
@@ -9106,6 +9106,14 @@ void SendProxy_ShiftPlayerSpawnflags( const SendProp *pProp, const void *pStruct
 		SendPropBool		( SENDINFO( m_bInTriggerFall ) ),
 #endif
 
+#ifdef MAPBASE_MP
+		// These are transmitted so that prediction is aware of what buttons are disabled
+		// (e.g. weapons don't fire when +attack is disabled)
+		// Number of bits is based on in_buttons.h
+		SendPropInt			( SENDINFO( m_afButtonDisabled ), 27, SPROP_UNSIGNED ),
+		SendPropInt			( SENDINFO( m_afButtonForced ), 27, SPROP_UNSIGNED ),
+#endif
+
 	END_SEND_TABLE()
 
 

--- a/src/game/server/player.h
+++ b/src/game/server/player.h
@@ -959,8 +959,15 @@ public:
 	int						m_afButtonPressed;
 	int						m_afButtonReleased;
 	int						m_afButtonLast;
+#ifdef MAPBASE_MP
+	// These are transmitted so that prediction is aware of what buttons are disabled
+	// (e.g. weapons don't fire when +attack is disabled)
+	CNetworkVar( int, m_afButtonDisabled );	// A mask of input flags that are cleared automatically
+	CNetworkVar( int, m_afButtonForced );	// These are forced onto the player's inputs
+#else
 	int						m_afButtonDisabled;	// A mask of input flags that are cleared automatically
 	int						m_afButtonForced;	// These are forced onto the player's inputs
+#endif
 
 	CNetworkVar( bool, m_fOnTarget );		//Is the crosshair on a target?
 


### PR DESCRIPTION
This PR networks each player's disabled/forced buttons and makes clientside prediction commands account for them. This fixes prediction errors when attempting to use a disabled button or not pressing a forced button. For example, prior to this PR, if the player attempted to fire their weapon while `IN_ATTACK` is disabled, their viewmodel and bullet FX would act as if the weapon was fired.

The disabled/forced buttons feature is used by `player_speedmod`, `trigger_playermovement`, and some VScript functions which allow their direct control.

---

<!-- Replace [ ] with [x] for each item your PR satisfies -->
#### PR Checklist
- [x] **My PR follows all guidelines in the CONTRIBUTING.md file**
- [x] My PR targets a `develop` branch OR targets another branch with a specific goal in mind
