### PR TITLE
[TF2] Game Instructor support and integration into training/notification HUD

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,6 +238,14 @@ Other sources:
 
 //-------------------------------------------------------------------------------------------------------------------------
 
+Mapbase additionally contains the following features originally created for Team Fortress 2 Classic:
+
+- TF-Style Instructor Hint Background by MaartenS11
+- TF-Style Instructor Hint Icons by Wheat (This is asset-based and not reflected in the code)
+- env_instructor_hint team and class support by azzy
+
+//-------------------------------------------------------------------------------------------------------------------------
+
 If there is anything missing from this list, please contact Blixibon.
 
 //=========================================================================================================================

--- a/src/game/client/c_baselesson.cpp
+++ b/src/game/client/c_baselesson.cpp
@@ -1660,7 +1660,11 @@ void CScriptedIconLesson::ProcessOpenGameEvents( const CScriptedIconLesson *pRoo
 				}
 
 				MEM_ALLOC_CREDIT();
+#ifdef MAPBASE
+				CScriptedIconLesson *pOpenLesson = CreateLessonCopy();
+#else
 				CScriptedIconLesson *pOpenLesson = new CScriptedIconLesson( GetName(), false, true );
+#endif
 
 				// Run copy macros on all scriptable variables (see: LESSON_VARIABLE_FACTORY definition)
 #define LESSON_VARIABLE_MACRO			LESSON_VARIABLE_COPY
@@ -2711,13 +2715,13 @@ bool CScriptedIconLesson::ProcessElementAction( int iAction, bool bNot, const ch
 bool CScriptedIconLesson::ProcessElementAction( int iAction, bool bNot, const char *pchVarName, EHANDLE &hVar, const CGameInstructorSymbol *pchParamName, float fParam, C_BaseEntity *pParam, const char *pchParam )
 {
 	// First try to let the mod act on the action
-	/*bool bModHandled = false;
+	bool bModHandled = false;
 	bool bModReturn = Mod_ProcessElementAction( iAction, bNot, pchVarName, hVar, pchParamName, fParam, pParam, pchParam, bModHandled );
 
 	if ( bModHandled )
 	{
 		return bModReturn;
-	}*/
+	}
 
 	C_BaseEntity *pVar = hVar.Get();
 
@@ -3945,5 +3949,5 @@ void CScriptedIconLesson::PreReadLessonsFromFile()
 	CScriptedIconLesson::LessonActionMap.Insert( "get potential use target", LESSON_ACTION_GET_POTENTIAL_USE_TARGET );
 
 	// Add mod actions to the map
-	//Mod_PreReadLessonsFromFile();
+	Mod_PreReadLessonsFromFile();
 }

--- a/src/game/client/c_baselesson.cpp
+++ b/src/game/client/c_baselesson.cpp
@@ -18,6 +18,9 @@
 #include "vstdlib/IKeyValuesSystem.h"
 #ifdef MAPBASE
 #include "usermessages.h"
+#ifdef TF_CLIENT_DLL
+#include "c_tf_player.h"
+#endif
 #endif
 
 // memdbgon must be the last include file in a .cpp file!!!

--- a/src/game/client/c_baselesson.cpp
+++ b/src/game/client/c_baselesson.cpp
@@ -1336,6 +1336,22 @@ void CScriptedIconLesson::Init()
 			// Initialize from the key value file
 			InitFromKeys( GetGameInstructor().GetScriptKeys() );
 
+#if defined(MAPBASE) && defined(TF_CLIENT_DLL)
+			// Enable tf_scan_potential_use_target if this lesson utilizes use_target
+			extern ConVar tf_scan_potential_use_target;
+			CGameInstructorSymbol szUseTargetEvent( "use_target" );
+
+			CUtlVector< LessonEvent_t > &openEvents = m_OpenEvents;
+			for ( int i = 0; i < openEvents.Count(); i++ )
+			{
+				if ( openEvents[i].szEventName == szUseTargetEvent )
+				{
+					tf_scan_potential_use_target.SetValue( 1 );
+					break;
+				}
+			}
+#endif
+
 			if ( m_iPriority >= LESSON_PRIORITY_MAX )
 			{
 				DevWarning( "Priority level not set for lesson: %s\n", GetName() );
@@ -3657,7 +3673,7 @@ bool CScriptedIconLesson::ProcessElementAction( int iAction, bool bNot, const ch
 			return true;
 		}
 
-		/*case LESSON_ACTION_GET_POTENTIAL_USE_TARGET:
+		case LESSON_ACTION_GET_POTENTIAL_USE_TARGET:
 		{
 			int iTemp = static_cast<int>( fParam );
 
@@ -3708,7 +3724,7 @@ bool CScriptedIconLesson::ProcessElementAction( int iAction, bool bNot, const ch
 			}
 
 			return true;
-		}*/
+		}
 	}
 
 	DevWarning( "Invalid lesson action type used with \"%s\" variable type.\n", pchVarName );

--- a/src/game/client/c_baselesson.cpp
+++ b/src/game/client/c_baselesson.cpp
@@ -448,6 +448,8 @@ void CIconLesson::Init()
 
 	m_iIconTargetPos		= ICON_TARGET_EYE_POSITION;
 	m_szHudHint				= "";
+	m_iHintEntSpawnFlags	= 0;
+	m_iHintEntTeam			= 0;
 #else
 	m_szCaptionColor		= "255,255,255";// Default to white
 #endif
@@ -700,6 +702,36 @@ bool CIconLesson::ShouldDisplay() const
 			return false;
 		}
 	}
+
+#ifdef MAPBASE
+	if ( m_iHintEntSpawnFlags || m_iHintEntTeam )
+	{
+		C_BasePlayer *pLocalPlayer = GetGameInstructor().GetLocalPlayer();
+		if ( pLocalPlayer )
+		{
+#ifdef TF_CLIENT_DLL
+			C_TFPlayer *pTFPlayer = static_cast<C_TFPlayer*>( pLocalPlayer );
+			if ( m_iHintEntSpawnFlags )
+			{
+				int iClass = pTFPlayer->GetPlayerClass()->GetClassIndex();
+				int bits = pow(2, iClass);
+				if ( !(m_iHintEntSpawnFlags & bits) )
+				{
+					return false;
+				}
+			}
+#endif
+			if ( m_iHintEntTeam )
+			{
+				int iTeam = pLocalPlayer->GetTeamNumber();
+				if ( m_iHintEntTeam != iTeam )
+				{
+					return false;
+				}
+			}
+		}
+	}
+#endif
 
 	// Ok to display
 	return true;
@@ -1033,6 +1065,9 @@ Vector CIconLesson::GetIconTargetPosition( C_BaseEntity *pIconTarget )
 																										\
 	LESSON_VARIABLE_MACRO( ICON_TARGET_POS, m_iIconTargetPos, int )								\
 	LESSON_VARIABLE_MACRO_STRING( HUD_HINT_AFTER_LEARNED, m_szHudHint, CGameInstructorSymbol )					\
+																										\
+	LESSON_VARIABLE_MACRO( ENT_SPAWNFLAGS, m_iHintEntSpawnFlags, int )									\
+	LESSON_VARIABLE_MACRO( ENT_TEAM, m_iHintEntTeam, int )												\
 
 
 // Create keyvalues name symbol

--- a/src/game/client/c_baselesson.h
+++ b/src/game/client/c_baselesson.h
@@ -405,6 +405,10 @@ public:
 
 	bool ProcessElements( IGameEvent *event, const CUtlVector< LessonElement_t > *pElements );
 
+#ifdef MAPBASE
+	virtual CScriptedIconLesson *CreateLessonCopy()	{ return new CScriptedIconLesson( GetName(), false, true ); }
+#endif
+
 private:
 	void InitElementsFromKeys( CUtlVector< LessonElement_t > *pLessonElements, KeyValues *pKey );
 	void InitElementsFromElements( CUtlVector< LessonElement_t > *pLessonElements, const CUtlVector< LessonElement_t > *pLessonElements2 );
@@ -431,6 +435,7 @@ private:
 private:
 	static CUtlDict< int, int > LessonActionMap;
 
+protected:
 	EHANDLE					m_hLocalPlayer;
 	float					m_fOutput;
 	CHandle<C_BaseEntity>	m_hEntity1;
@@ -442,6 +447,7 @@ private:
 	float					m_fFloat1;
 	float					m_fFloat2;
 
+private:
 	CUtlVector< CGameInstructorSymbol >	m_PrerequisiteNames;
 	CUtlVector< LessonEvent_t >	m_OpenEvents;
 	CUtlVector< LessonEvent_t >	m_CloseEvents;

--- a/src/game/client/c_baselesson.h
+++ b/src/game/client/c_baselesson.h
@@ -277,6 +277,9 @@ protected:
 	};
 
 	CGameInstructorSymbol	m_szHudHint;
+
+	int		m_iHintEntSpawnFlags;
+	int		m_iHintEntTeam;
 #endif
 };
 

--- a/src/game/client/c_baseplayer.h
+++ b/src/game/client/c_baseplayer.h
@@ -319,6 +319,9 @@ public:
 	bool				IsPoisoned( void ) { return m_Local.m_bPoisoned; }
 
 	C_BaseEntity				*GetUseEntity();
+#ifdef MAPBASE // From Alien Swarm SDK
+	virtual C_BaseEntity		*GetPotentialUseEntity() { return GetUseEntity(); }
+#endif
 
 	// Vehicles...
 	IClientVehicle			*GetVehicle();

--- a/src/game/client/c_gameinstructor.cpp
+++ b/src/game/client/c_gameinstructor.cpp
@@ -171,8 +171,7 @@ void C_GameInstructor::Shutdown()
 //=========================================================
 void C_GameInstructor::UpdateHiddenByOtherElements()
 {
-	//bool bHidden = Mod_HiddenByOtherElements();
-	bool bHidden = false;
+	bool bHidden = Mod_HiddenByOtherElements();
 
 	if ( bHidden && !m_bHiddenDueToOtherElements )
 		StopAllLessons();
@@ -1276,8 +1275,23 @@ void C_GameInstructor::ReadLessonsFromFile( const char *pchFileName )
 			continue;
 		}
 
+#ifdef MAPBASE
+		const char *pszLessonType = m_pScriptKeys->GetString( "lesson_type", "locator" );
+		if ( pszLessonType )
+		{
+			if (FStrEq( pszLessonType, "locator" ))
+			{
+				DefineLesson( new CScriptedIconLesson( m_pScriptKeys->GetName(), false, false ) );
+			}
+			else if (!Mod_DefineLessonType( m_pScriptKeys->GetName(), pszLessonType ))
+			{
+				Warning( "Lesson \"%s\" has unknown type \"%s\"\n", m_pScriptKeys->GetName(), pszLessonType );
+			}
+		}
+#else
 		CScriptedIconLesson *pNewLesson = new CScriptedIconLesson(m_pScriptKeys->GetName(), false, false);
 		GetGameInstructor().DefineLesson(pNewLesson);
+#endif
 	}
 
 	m_pScriptKeys = NULL;

--- a/src/game/client/c_gameinstructor.h
+++ b/src/game/client/c_gameinstructor.h
@@ -47,6 +47,10 @@ public:
 
 	void DefineLesson( CBaseLesson *pLesson );
 
+#ifdef MAPBASE
+	bool Mod_DefineLessonType( const char *pszLessonName, const char *pszLessonType );
+#endif
+
 	const CBaseLesson * GetLesson( const char *pchLessonName );
 	bool IsLessonOfSameTypeOpen( const CBaseLesson *pLesson ) const;
 
@@ -60,6 +64,7 @@ public:
 	void PlaySound( const char *pchSoundName );
 
 	bool OpenOpportunity( CBaseLesson *pLesson );
+	void CloseOpportunity( CBaseLesson *pLesson );
 
 	void DumpOpenOpportunities( void );
 
@@ -83,7 +88,6 @@ private:
 	void StopAllLessons( void );
 
 	void CloseAllOpenOpportunities( void );
-	void CloseOpportunity( CBaseLesson *pLesson );
 
 	void InitLessonPrerequisites( void );
 

--- a/src/game/client/c_mod_lesson_stubs.cpp
+++ b/src/game/client/c_mod_lesson_stubs.cpp
@@ -1,0 +1,89 @@
+//========= Copyright © 1996-2008, Valve Corporation, All rights reserved. ============//
+//
+// Purpose:		Stub for custom mod lesson actions. 
+//				This is so that mods can do actions 
+//				Remove this file from the mod's vpc and include your own.
+//
+//=============================================================================//
+
+#include "cbase.h"
+
+#include "c_gameinstructor.h"
+#include "c_baselesson.h"
+
+// memdbgon must be the last include file in a .cpp file!!!
+#include "tier0/memdbgon.h"
+
+
+extern ConVar gameinstructor_verbose;
+
+
+enum Mod_LessonAction
+{
+	// Enum starts from end of LessonAction
+	LESSON_ACTION_MOD_CUSTOM_ACTION_STUB = LESSON_ACTION_MOD_START,
+	
+	LESSON_ACTION_TOTAL
+};
+
+
+void CScriptedIconLesson::Mod_PreReadLessonsFromFile( void )
+{
+	// Add custom actions to the map
+	CScriptedIconLesson::LessonActionMap.Insert( "custom action stub", LESSON_ACTION_MOD_CUSTOM_ACTION_STUB );
+}
+
+
+bool CScriptedIconLesson::Mod_ProcessElementAction( int iAction, bool bNot, const char *pchVarName, EHANDLE &hVar, const CGameInstructorSymbol *pchParamName, float fParam, C_BaseEntity *pParam, const char *pchParam, bool &bModHandled )
+{
+	// Assume we're going to handle the action
+	bModHandled = true;
+
+	C_BaseEntity *pVar;
+	pVar = hVar.Get();
+
+	switch ( iAction )
+	{
+		case LESSON_ACTION_MOD_CUSTOM_ACTION_STUB:
+		{
+			float flStub = 0.0f; //pVar->GetStubValue();
+
+			if ( gameinstructor_verbose.GetInt() > 0 && ShouldShowSpew() )
+			{
+				ConColorMsg( CBaseLesson::m_rgbaVerbosePlain, "\t[%s]->GetStubValue() ", pchVarName );
+				ConColorMsg( CBaseLesson::m_rgbaVerboseName, "%.1f ", flStub );
+				ConColorMsg( CBaseLesson::m_rgbaVerbosePlain, ( bNot ) ? ( ">= [%s] " ) : ( "< [%s] " ), pchParamName->String() );
+				ConColorMsg( CBaseLesson::m_rgbaVerboseName, "%.1f\n", fParam );
+			}
+
+			return ( flStub ) ? ( flStub >= fParam ) : ( flStub < fParam );
+		}
+
+		default:
+			// Didn't handle this action
+			bModHandled = false;
+			break;
+	}
+
+	return false;
+}
+
+
+bool C_GameInstructor::Mod_HiddenByOtherElements( void )
+{
+	return false;
+}
+
+
+#ifdef MAPBASE
+//
+// This function allows you to add new lesson types beyond the default icon hints.
+// Use this to integrate instructor lessons into another game-specific HUD element.
+//
+// Note that, due to some technical constraints, your custom type must still derive from CScriptedIconLesson.
+//
+bool C_GameInstructor::Mod_DefineLessonType( const char *pszLessonName, const char *pszLessonType )
+{
+	return false;
+}
+#endif

--- a/src/game/client/client_mapbase.vpc
+++ b/src/game/client/client_mapbase.vpc
@@ -4,9 +4,6 @@
 //	Project Script
 //-----------------------------------------------------------------------------
 
-$Include "$SRCDIR\game\client\client_mapbase_hl2.vpc"	[$HL2||$EPISODIC||$HL2MP]
-$Include "$SRCDIR\game\client\client_mapbase_tf.vpc"	[$TF]
-
 $Configuration
 {
 	$Compiler
@@ -30,6 +27,7 @@ $Project
 		$File	"c_baselesson.h"
 		$File	"c_gameinstructor.cpp"
 		$File	"c_gameinstructor.h"
+		$File	"c_mod_lesson_stubs.cpp"
 		$File	"hud_locator_target.cpp"
 		$File	"hud_locator_target.h"
 		$File	"c_postprocesscontroller.cpp"
@@ -81,3 +79,6 @@ $Project
 		$Lib	"raytrace"
 	}
 }
+
+$Include "$SRCDIR\game\client\client_mapbase_hl2.vpc"	[$HL2||$EPISODIC||$HL2MP]
+$Include "$SRCDIR\game\client\client_mapbase_tf.vpc"	[$TF]

--- a/src/game/client/client_mapbase_tf.vpc
+++ b/src/game/client/client_mapbase_tf.vpc
@@ -6,6 +6,11 @@
 
 $Project
 {
+	$Folder "Source Files"
+	{
+		-$File	"c_mod_lesson_stubs.cpp"
+	}
+
 	$Folder	"Source Files"
 	{
 		$Folder	"Mapbase"
@@ -13,6 +18,8 @@ $Project
 			$Folder	"TF"
 			{
 				$File	"mapbase\tf\tf_hud_external_timer.cpp"
+				$File	"mapbase\c_tf_lesson.cpp"
+				$File	"mapbase\c_tf_lesson.h"
 			}
 		}
 	}

--- a/src/game/client/hud.cpp
+++ b/src/game/client/hud.cpp
@@ -1237,6 +1237,9 @@ void CHudIcons::Init()
 #ifdef HL2_CLIENT_DLL
 	LoadHudTextures( textureList, "scripts/instructor_textures_hl2", NULL );
 #endif
+#ifdef TF_CLIENT_DLL
+	LoadHudTextures( textureList, "scripts/instructor_textures_tf", NULL );
+#endif
 	LoadHudTextures( textureList, "scripts/instructor_modtextures", NULL );
 
 	int c = textureList.Count();

--- a/src/game/client/mapbase/c_tf_lesson.cpp
+++ b/src/game/client/mapbase/c_tf_lesson.cpp
@@ -1,0 +1,787 @@
+//========= Mapbase - https://github.com/mapbase-source/source-sdk-2013 ============//
+//
+// Purpose: TF2 lesson actions + new Game Instructor lesson types which use TF HUD elements
+// 
+// Author: Blixibon
+//
+//=============================================================================//
+
+#include "cbase.h"
+
+#include "c_tf_lesson.h"
+#include "tf_hud_training.h"
+#include "tf_hud_objectivestatus.h"
+#include "tf_hud_notification_panel.h"
+
+//-----------------------------------------------------------------------------
+
+extern ConVar gameinstructor_verbose;
+
+enum Mod_LessonAction
+{
+	// Enum starts from end of LessonAction
+	LESSON_ACTION_IS_TF_CLASS = LESSON_ACTION_MOD_START,
+	LESSON_ACTION_IS_TF_GAMEMODE,
+	LESSON_ACTION_IS_TRAINING,
+	LESSON_ACTION_IS_ROUND_STATE,
+
+	LESSON_ACTION_WEAPON_ID_HAS,
+	LESSON_ACTION_WEAPON_ATTR_HAS,
+
+	LESSON_ACTION_ENEMY_TEAM_HAS_TF_WEAPON,
+
+	//LESSON_ACTION_IN_RESPAWN_ROOM,
+
+	LESSON_ACTION_TOTAL
+};
+
+
+void CScriptedIconLesson::Mod_PreReadLessonsFromFile( void )
+{
+	// Add custom actions to the map
+	CScriptedIconLesson::LessonActionMap.Insert( "is class", LESSON_ACTION_IS_TF_CLASS );
+	CScriptedIconLesson::LessonActionMap.Insert( "is gamemode", LESSON_ACTION_IS_TF_GAMEMODE );
+	CScriptedIconLesson::LessonActionMap.Insert( "is training", LESSON_ACTION_IS_TRAINING );
+	CScriptedIconLesson::LessonActionMap.Insert( "is roundstate", LESSON_ACTION_IS_ROUND_STATE );
+
+	CScriptedIconLesson::LessonActionMap.Insert( "weapon id has", LESSON_ACTION_WEAPON_ID_HAS );
+	CScriptedIconLesson::LessonActionMap.Insert( "weapon attr has", LESSON_ACTION_WEAPON_ATTR_HAS );
+
+	CScriptedIconLesson::LessonActionMap.Insert( "enemy team has weapon", LESSON_ACTION_ENEMY_TEAM_HAS_TF_WEAPON );
+}
+
+bool CScriptedIconLesson::Mod_ProcessElementAction( int iAction, bool bNot, const char *pchVarName, EHANDLE &hVar, const CGameInstructorSymbol *pchParamName, float fParam, C_BaseEntity *pParam, const char *pchParam, bool &bModHandled )
+{
+	// Assume we're going to handle the action
+	bModHandled = true;
+
+	C_BaseEntity *pVar;
+	pVar = hVar.Get();
+
+	switch ( iAction )
+	{
+		case LESSON_ACTION_IS_TF_CLASS:
+		{
+			const char *pszPlayerClass = "undefined";
+
+			C_TFPlayer *pTFPlayer = dynamic_cast<C_TFPlayer *>( pVar );
+			if ( pTFPlayer )
+			{
+				C_TFPlayerClass *pClass = pTFPlayer->GetPlayerClass();
+				if (pClass)
+				{
+					pszPlayerClass = pClass->GetName();
+				}
+			}
+
+			bool bIsClass = FStrEq( pchParam, pszPlayerClass );
+
+			if ( gameinstructor_verbose.GetInt() > 0 && ShouldShowSpew() )
+			{
+				ConColorMsg( CBaseLesson::m_rgbaVerbosePlain, "\t[%s]->IsTFClass() ", pchVarName );
+				ConColorMsg( CBaseLesson::m_rgbaVerboseName, "%s ", pszPlayerClass );
+				ConColorMsg( CBaseLesson::m_rgbaVerbosePlain, ( bNot ) ? ( " != [%s] " ) : ( " == [%s] " ), pchParam );
+			}
+
+			return bNot ? !bIsClass : bIsClass;
+		}
+
+		case LESSON_ACTION_IS_TF_GAMEMODE:
+		{
+			bool bIsGameMode = false;
+			const char *pszGameType = "undefined";
+
+			if ( TFGameRules() )
+			{
+				// Special cases first, then determine directly from game type
+				if ( FStrEq( pchParam, "plr" ) )
+				{
+					bIsGameMode = TFGameRules()->HasMultipleTrains();
+					pszGameType = bIsGameMode ? "plr" : "not plr";
+				}
+				else if ( TFGameRules()->GetGameType() != TF_GAMETYPE_UNDEFINED )
+				{
+					// The +10 is to skip the localization prefix
+					// (removing #Gametype from "#Gametype_CTF")
+					pszGameType = (TFGameRules()->GetGameTypeName() + 10);
+					bIsGameMode = FStrEq( pszGameType, pchParam );
+				}
+			}
+
+			if ( gameinstructor_verbose.GetInt() > 0 && ShouldShowSpew() )
+			{
+				ConColorMsg( CBaseLesson::m_rgbaVerbosePlain, "\t[%s]->IsTFGamemode() ", pchVarName );
+				ConColorMsg( CBaseLesson::m_rgbaVerboseName, "%s ", pszGameType );
+				ConColorMsg( CBaseLesson::m_rgbaVerbosePlain, ( bNot ) ? ( " != [%s] " ) : ( " == [%s] " ), pchParam );
+			}
+
+			return bNot ? !bIsGameMode : bIsGameMode;
+		}
+
+		case LESSON_ACTION_IS_TRAINING:
+		{
+			bool bIsTraining = false;
+
+			if ( TFGameRules() )
+			{
+				bIsTraining = TFGameRules()->IsInTraining();
+			}
+
+			if ( gameinstructor_verbose.GetInt() > 0 && ShouldShowSpew() )
+			{
+				ConColorMsg( CBaseLesson::m_rgbaVerbosePlain, "\t[%s]->IsInTraining() ", pchVarName );
+				ConColorMsg( CBaseLesson::m_rgbaVerbosePlain, ( bNot ) ? ( " != [%s] " ) : ( " == [%s] " ), bIsTraining ? "true" : "false" );
+			}
+
+			return bNot ? !bIsTraining : bIsTraining;
+		}
+
+		case LESSON_ACTION_IS_ROUND_STATE:
+		{
+			bool bIsRoundState = false;
+			const char *pszRoundState = "undefined";
+
+			if ( TFGameRules() )
+			{
+				int nRoundState = TFGameRules()->State_Get();
+				switch (nRoundState)
+				{
+					case GR_STATE_PREROUND:			pszRoundState = "preround"; break;
+					case GR_STATE_RND_RUNNING:		pszRoundState = "running"; break;
+					case GR_STATE_TEAM_WIN:			pszRoundState = "win"; break;
+					case GR_STATE_RESTART:			pszRoundState = "restart"; break;
+					case GR_STATE_STALEMATE:		pszRoundState = "stalemate"; break;
+					case GR_STATE_GAME_OVER:		pszRoundState = "gameover"; break;
+					case GR_STATE_BONUS:			pszRoundState = "bonus"; break;
+					case GR_STATE_BETWEEN_RNDS:		pszRoundState = "between"; break;
+				}
+
+				bIsRoundState = FStrEq( pszRoundState, pchParam );
+			}
+
+			if ( gameinstructor_verbose.GetInt() > 0 && ShouldShowSpew() )
+			{
+				ConColorMsg( CBaseLesson::m_rgbaVerbosePlain, "\t[%s]->IsTFRoundState() ", pchVarName );
+				ConColorMsg( CBaseLesson::m_rgbaVerboseName, "%s ", pszRoundState );
+				ConColorMsg( CBaseLesson::m_rgbaVerbosePlain, ( bNot ) ? ( " != [%s] " ) : ( " == [%s] " ), pchParam );
+			}
+
+			return bNot ? !bIsRoundState : bIsRoundState;
+		}
+
+		case LESSON_ACTION_WEAPON_ID_HAS:
+		{
+			C_BaseCombatCharacter *pBCC = NULL;
+			C_BaseCombatWeapon *pWeapon = NULL;
+
+			if ( pVar )
+			{
+				pBCC = pVar->MyCombatCharacterPointer();
+				if ( !pBCC )
+				{
+					pWeapon = pVar->MyCombatWeaponPointer();
+				}
+			}
+
+			if ( !pBCC && !pWeapon )
+			{
+				if ( gameinstructor_verbose.GetInt() > 0 && ShouldShowSpew() )
+				{
+					ConColorMsg( CBaseLesson::m_rgbaVerbosePlain, ( bNot ) ? ( "\t![%s]->HasWeaponID([%llu] " ) : ( "\t[%s]->HasWeaponID([%llu] " ), pchVarName, (itemid_t)fParam );
+					ConColorMsg( CBaseLesson::m_rgbaVerboseName, "\"%s\"", pchParam );
+					ConColorMsg( CBaseLesson::m_rgbaVerbosePlain, ")\n" );
+					ConColorMsg( CBaseLesson::m_rgbaVerboseClose, "\tVar handle as BaseCombatCharacter or BaseCombatWeapon returned NULL!\n" );
+				}
+
+				return false;
+			}
+			
+			if ( pBCC )
+			{
+				for (int i=0;i<MAX_WEAPONS;i++) 
+				{
+					if ( pBCC->GetWeapon(i) )
+					{
+						if ( gameinstructor_verbose.GetInt() > 0 && ShouldShowSpew() )
+						{
+							ConColorMsg( CBaseLesson::m_rgbaVerbosePlain, ( bNot ) ? ( "\t![%s]->HasWeaponID([%llu]) " ) : ( "\t[%s]->HasWeaponID([%llu]) " ), pchVarName, (itemid_t)fParam );
+							ConColorMsg( CBaseLesson::m_rgbaVerbosePlain, ( bNot ) ? ( " != [%hu (%s)]\n" ) : ( " == [%hu (%s)]\n" ), pBCC->GetWeapon(i)->GetAttributeContainer()->GetItem()->GetItemDefIndex(), pBCC->GetWeapon(i)->GetClassname() );
+						}
+
+						if ( pBCC->GetWeapon(i)->GetAttributeContainer()->GetItem()->GetItemDefIndex() == (itemid_t)fParam )
+						{
+							pWeapon = pBCC->GetWeapon(i);
+							break;
+						}
+					}
+				}
+
+				/*if ( gameinstructor_verbose.GetInt() > 0 && ShouldShowSpew() )
+				{
+					ConColorMsg( CBaseLesson::m_rgbaVerbosePlain, ( bNot ) ? ( "\t![%s]->HasWeaponID([%llu]) " ) : ( "\t[%s]->HasWeaponID([%llu]) " ), pchVarName, (itemid_t)fParam );
+					ConColorMsg( CBaseLesson::m_rgbaVerbosePlain, ( bNot ) ? ( " != [%llu] " ) : ( " == [%llu] " ), (itemid_t)fParam );
+				}*/
+			}
+			else if ( pWeapon )
+			{
+				if ( gameinstructor_verbose.GetInt() > 0 && ShouldShowSpew() )
+				{
+					ConColorMsg( CBaseLesson::m_rgbaVerbosePlain, ( bNot ) ? ( "\t![%s]->HasWeaponID([%llu]) " ) : ( "\t[%s]->HasWeaponID([%llu]) " ), pchVarName, (itemid_t)fParam );
+					ConColorMsg( CBaseLesson::m_rgbaVerbosePlain, ( bNot ) ? ( " != [%hu (%s)]\n" ) : ( " == [%hu (%s)]\n" ), pWeapon->GetAttributeContainer()->GetItem()->GetItemDefIndex(), pWeapon->GetClassname() );
+				}
+
+				if ( pWeapon->GetAttributeContainer()->GetItem()->GetItemDefIndex() != (itemid_t)fParam )
+				{
+					pWeapon = NULL;
+				}
+			}
+
+			return bNot ? pWeapon == NULL : pWeapon != NULL;
+		}
+
+		case LESSON_ACTION_WEAPON_ATTR_HAS:
+		{
+			// TODO: Figure out way to anonymously check if weapon has an attribute
+			Warning( "\"weapon attr has\" not implemented\n" );
+			return bNot ? !false : false;
+
+#if 0
+			C_BaseCombatCharacter *pBCC = NULL;
+			C_BaseCombatWeapon *pWeapon = NULL;
+
+			if ( pVar )
+			{
+				pBCC = pVar->MyCombatCharacterPointer();
+				if ( !pBCC )
+				{
+					pWeapon = pVar->MyCombatWeaponPointer();
+				}
+			}
+
+			if ( !pBCC && !pWeapon )
+			{
+				if ( gameinstructor_verbose.GetInt() > 0 && ShouldShowSpew() )
+				{
+					ConColorMsg( CBaseLesson::m_rgbaVerbosePlain, ( bNot ) ? ( "\t![%s]->HasWeaponAttribute([%s] " ) : ( "\t[%s]->HasWeaponAttribute([%s])\n" ), pchVarName, pchParam );
+					ConColorMsg( CBaseLesson::m_rgbaVerboseClose, "\tVar handle as BaseCombatCharacter or BaseCombatWeapon returned NULL!\n" );
+				}
+
+				return false;
+			}
+
+			if ( pBCC )
+			{
+				for (int i=0;i<MAX_WEAPONS;i++) 
+				{
+					if ( pBCC->GetWeapon(i) )
+					{
+						if ( gameinstructor_verbose.GetInt() > 0 && ShouldShowSpew() )
+						{
+							ConColorMsg( CBaseLesson::m_rgbaVerbosePlain, ( bNot ) ? ( "\t![%s]->HasWeaponAttribute([%s]) " ) : ( "\t[%s]->HasWeaponAttribute([%s]) " ), pchVarName, pchParam );
+							ConColorMsg( CBaseLesson::m_rgbaVerbosePlain, ( bNot ) ? ( " != [%hu (%s)]\n" ) : ( " == [%hu (%s)]\n" ), pBCC->GetWeapon(i)->GetAttributeContainer()->GetItem()->GetItemDefIndex(), pBCC->GetWeapon(i)->GetClassname() );
+						}
+						
+						if ( pBCC->GetWeapon(i)->GetAttributeList()->GetAttributeByName( pchParam ) )
+						{
+							pWeapon = pBCC->GetWeapon(i);
+							break;
+						}
+					}
+				}
+
+				/*if ( gameinstructor_verbose.GetInt() > 0 && ShouldShowSpew() )
+				{
+					ConColorMsg( CBaseLesson::m_rgbaVerbosePlain, ( bNot ) ? ( "\t![%s]->HasWeaponID([%llu]) " ) : ( "\t[%s]->HasWeaponID([%llu]) " ), pchVarName, (itemid_t)fParam );
+					ConColorMsg( CBaseLesson::m_rgbaVerbosePlain, ( bNot ) ? ( " != [%llu] " ) : ( " == [%llu] " ), (itemid_t)fParam );
+				}*/
+			}
+			else if ( pWeapon )
+			{
+				if ( gameinstructor_verbose.GetInt() > 0 && ShouldShowSpew() )
+				{
+					ConColorMsg( CBaseLesson::m_rgbaVerbosePlain, ( bNot ) ? ( "\t![%s]->HasWeaponAttribute([%llu]) " ) : ( "\t[%s]->HasWeaponAttribute([%llu]) " ), pchVarName, (itemid_t)fParam );
+					ConColorMsg( CBaseLesson::m_rgbaVerbosePlain, ( bNot ) ? ( " != [%hu (%s)]\n" ) : ( " == [%hu (%s)]\n" ), pWeapon->GetAttributeContainer()->GetItem()->GetItemDefIndex(), pWeapon->GetClassname() );
+				}
+
+				if ( !pWeapon->GetAttributeList()->GetAttributeByName( pchParam ) )
+				{
+					pWeapon = NULL;
+				}
+			}
+
+			return bNot ? !pWeapon : pWeapon;
+#endif
+		}
+
+		case LESSON_ACTION_ENEMY_TEAM_HAS_TF_WEAPON:
+		{
+			bool bEnemyHasWeapon = false;
+
+			C_TFPlayer *pLocalPlayer = dynamic_cast<C_TFPlayer *>(pVar);
+
+			if ( pLocalPlayer )
+			{
+				for ( int i = 1; i < gpGlobals->maxClients; i++ )
+				{
+					C_TFPlayer *pTFPlayer = ToTFPlayer( UTIL_PlayerByIndex( i ) );
+					if ( !pTFPlayer || pTFPlayer->GetTeamNumber() == pLocalPlayer->GetTeamNumber() || !IsValidTFTeam( pTFPlayer->GetTeamNumber() ) )
+						continue;
+
+					if ( pchParam && *pchParam )
+					{
+						if ( pTFPlayer->Weapon_OwnsThisType( pchParam ) )
+						{
+							bEnemyHasWeapon = true;
+							break;
+						}
+					}
+					else
+					{
+						// Check by direct ID
+						for (int i=0;i<MAX_WEAPONS;i++) 
+						{
+							if ( pTFPlayer->GetWeapon(i) )
+							{
+								if ( gameinstructor_verbose.GetInt() > 0 && ShouldShowSpew() )
+								{
+									ConColorMsg( CBaseLesson::m_rgbaVerbosePlain, ( bNot ) ? ( "\t![%s]->EnemyHasTFWeapon([%llu]) " ) : ( "\t[%s]->EnemyHasTFWeapon([%llu]) " ), pchVarName, (itemid_t)fParam );
+									ConColorMsg( CBaseLesson::m_rgbaVerbosePlain, ( bNot ) ? ( " != [%hu (%s)]\n" ) : ( " == [%hu (%s)]\n" ), pTFPlayer->GetWeapon(i)->GetAttributeContainer()->GetItem()->GetItemDefIndex(), pTFPlayer->GetWeapon(i)->GetClassname() );
+								}
+
+								if ( pTFPlayer->GetWeapon(i)->GetAttributeContainer()->GetItem()->GetItemDefIndex() == (itemid_t)fParam )
+								{
+									bEnemyHasWeapon = true;
+									break;
+								}
+							}
+						}
+					}
+				}
+			}
+
+			if ( gameinstructor_verbose.GetInt() > 0 && ShouldShowSpew() )
+			{
+				ConColorMsg( CBaseLesson::m_rgbaVerbosePlain, "\t[%s]->EnemyHasTFWeapon()", pchVarName );
+				ConColorMsg( CBaseLesson::m_rgbaVerbosePlain, ( bNot ) ? ( " != [%s] " ) : ( " == [%s] " ), pchParam );
+			}
+
+			return bNot ? !bEnemyHasWeapon : bEnemyHasWeapon;
+		}
+
+		default:
+			// Didn't handle this action
+			bModHandled = false;
+			break;
+	}
+
+	return false;
+}
+
+
+bool C_GameInstructor::Mod_HiddenByOtherElements( void )
+{
+	return false;
+}
+
+bool C_GameInstructor::Mod_DefineLessonType( const char *pszLessonName, const char *pszLessonType )
+{
+	if ( FStrEq( pszLessonType, "tf_training_objective" ) )
+	{
+		DefineLesson( new CTFObjectiveLesson( m_pScriptKeys->GetName(), false, false ) );
+		return true;
+	}
+	else if ( FStrEq( pszLessonType, "tf_notification" ) )
+	{
+		DefineLesson( new CTFNotificationLesson( m_pScriptKeys->GetName(), false, false ) );
+		return true;
+	}
+
+	return false;
+}
+
+//-----------------------------------------------------------------------------
+//
+// CTFBaseLesson
+//
+//-----------------------------------------------------------------------------
+
+#define TF_LESSON_MIN_TIME_ON_SCREEN_TO_MARK_DISPLAYED 1.5f
+#define TF_LESSON_DISTANCE_UPDATE_RATE 0.25f
+
+void CTFBaseLesson::Init()
+{
+	ListenForGameEvent( "localplayer_respawn" );
+	//ListenForGameEvent( "client_disconnect" );
+	//ListenForGameEvent( "round_start" );
+}
+
+//=========================================================
+//=========================================================
+void CTFBaseLesson::Update()
+{
+	if ( !DoDelayedPlayerSwaps() )
+		return;
+
+	// Check if it has been onscreen long enough to count as being displayed
+	if ( m_fOnScreenStartTime != 0.0f )
+	{
+		if ( gpGlobals->curtime - m_fOnScreenStartTime >= TF_LESSON_MIN_TIME_ON_SCREEN_TO_MARK_DISPLAYED )
+		{
+			// Lesson on screen long enough to be counted as displayed
+			m_bWasDisplayed = true;
+
+			// Also apply to root (since we use it to keep track of when to show these hints)
+			if ( GetRoot() )
+			{
+				CTFBaseLesson *pRoot = assert_cast<CTFBaseLesson*>(GetRoot());
+				if ( pRoot )
+				{
+					pRoot->MarkAsDisplayed();
+				}
+			}
+		}
+	}
+
+	if ( m_fUpdateDistanceTime < gpGlobals->curtime )
+	{
+		// Update it's distance from the local player
+		C_BaseEntity *pTarget = m_hEntity1.Get(); // m_hIconTarget.Get()
+		C_BasePlayer *pLocalPlayer = GetGameInstructor().GetLocalPlayer();
+
+		if ( !pLocalPlayer || !pTarget || pLocalPlayer == pTarget )
+		{
+			m_fCurrentDistance = 0.0f;
+		}
+		else
+		{
+			m_fCurrentDistance = pLocalPlayer->EyePosition().DistTo( pTarget->WorldSpaceCenter() );
+		}
+
+		m_fUpdateDistanceTime = gpGlobals->curtime + TF_LESSON_DISTANCE_UPDATE_RATE;
+	}
+
+	//BaseClass::Update();
+}
+
+//=========================================================
+//=========================================================
+void CTFBaseLesson::UpdateInactive()
+{
+	if ( !DoDelayedPlayerSwaps() )
+		return;
+
+	if ( m_fUpdateDistanceTime < gpGlobals->curtime )
+	{
+		// Update it's distance from the local player
+		C_BaseEntity *pTarget = m_hEntity1.Get(); // m_hIconTarget.Get()
+		C_BasePlayer *pLocalPlayer = GetGameInstructor().GetLocalPlayer();
+
+		if ( !pLocalPlayer || !pTarget || pLocalPlayer == pTarget )
+		{
+			m_fCurrentDistance = 0.0f;
+		}
+		else
+		{
+			m_fCurrentDistance = pLocalPlayer->EyePosition().DistTo( pTarget->WorldSpaceCenter() );
+		}
+
+		m_fUpdateDistanceTime = gpGlobals->curtime + TF_LESSON_DISTANCE_UPDATE_RATE;
+	}
+
+	//BaseClass::UpdateInactive();
+}
+
+//=========================================================
+//=========================================================
+bool CTFBaseLesson::ShouldDisplay() const
+{
+	if ( !IsInstructing() )
+	{
+		// Already displayed this session
+		if ( GetRoot() && GetRoot()->WasDisplayed() )
+			return false;
+
+		if ( TFGameRules() )
+		{
+			// Not while waiting for players
+			if ( TFGameRules()->IsInWaitingForPlayers() )
+				return false;
+
+			// For now, no hints in arena prep stage so we don't overlap with the player count
+			if ( TFGameRules()->IsInArenaMode() && TFGameRules()->State_Get() == GR_STATE_PREROUND )
+				return false;
+		}
+	}
+
+	// Ok to display
+	return BaseClass::ShouldDisplay();
+}
+
+//=========================================================
+//=========================================================
+void CTFBaseLesson::FireGameEvent( IGameEvent *event )
+{
+	if ( FStrEq( event->GetName(), "localplayer_respawn" ) && IsInstructing() && !m_bCanOpenWhenDead )
+	{
+		// Close active lessons on respawn
+		SetCloseReason( "Player respawned" );
+		GetGameInstructor().CloseOpportunity( this );
+	}
+	/*else if ( FStrEq( event->GetName(), "client_disconnect" ) )
+	{
+		// UNDONE: Allow TF lessons to show again when connecting to another server
+		GetGameInstructor().CloseOpportunity( this );
+		m_bWasDisplayed = false;
+	}*/
+	/*else if ( FStrEq( event->GetName(), "round_start" ) )
+	{
+		// UNDONE: Reset on round start
+		GetGameInstructor().CloseOpportunity( this );
+		m_bWasDisplayed = false;
+	}*/
+
+	BaseClass::FireGameEvent( event );
+}
+
+//-----------------------------------------------------------------------------
+//
+// CTFObjectiveLesson
+//
+//-----------------------------------------------------------------------------
+
+#define TF_LESSON_MIN_TIME_ON_SCREEN_TO_MARK_DISPLAYED 1.5f
+#define TF_LESSON_DISTANCE_UPDATE_RATE 0.25f
+
+CTFObjectiveLesson *CTFObjectiveLesson::g_pActiveTFObjectiveLesson = NULL;
+
+void CTFObjectiveLesson::Init()
+{
+}
+
+//=========================================================
+//=========================================================
+void CTFObjectiveLesson::Start()
+{
+	if ( !DoDelayedPlayerSwaps() )
+		return;
+
+	// Shouldn't show these lessons if we're actually in training
+	if ( !TFGameRules() || TFGameRules()->IsInTraining() )
+		return;
+
+	CTFHudObjectiveStatus *pStatus = GET_HUDELEMENT( CTFHudObjectiveStatus );
+	if ( pStatus )
+	{
+		if ( g_pActiveTFObjectiveLesson && g_pActiveTFObjectiveLesson->IsInstructing() )
+		{
+			// Replace the currently active lesson
+			g_pActiveTFObjectiveLesson->SetCloseReason( "Replaced with another lesson" );
+			GetGameInstructor().CloseOpportunity( g_pActiveTFObjectiveLesson );
+		}
+
+		g_pActiveTFObjectiveLesson = this;
+
+		pStatus->SetTrainingGameInstructor( true );
+
+		if ( V_strchr( m_szOnscreenIcon.String(), '%' ) )
+		{
+			char szImage[MAX_PATH] = { 0 };
+
+			char szToken[256];
+			V_strncpy( szToken, m_szOnscreenIcon.String(), sizeof( szToken ) );
+
+			bool bVar = false;
+			const char *token = strtok( szToken, "%" );
+			while (token != NULL)
+			{
+				if (bVar)
+				{
+					if (V_strnicmp( token, "team", 4 ) == 0)
+					{
+						C_BasePlayer *pPlayer = GetGameInstructor().GetLocalPlayer();
+						int iTeam = pPlayer ? pPlayer->GetTeamNumber() : TEAM_UNASSIGNED;
+						if (iTeam < 0 || iTeam >= TF_TEAM_COUNT)
+							iTeam = TEAM_UNASSIGNED;
+
+						if (FStrEq(token + 4, "_short"))
+						{
+							V_strncat( szImage, g_aTeamNamesShort[iTeam], sizeof( szImage ) );
+						}
+						else
+						{
+							V_strncat( szImage, g_aTeamNames[iTeam], sizeof( szImage ) );
+						}
+					}
+				}
+				else
+				{
+					V_strncat( szImage, token, sizeof( szImage ) );
+				}
+
+				bVar = !bVar;
+				token = strtok( NULL, "%" );
+			}
+
+			pStatus->SetTrainingImage( szImage );
+		}
+		else
+		{
+			pStatus->SetTrainingImage( m_szOnscreenIcon.String() );
+		}
+
+		pStatus->SetTrainingObjective( m_szDisplayParamText.String() );
+		pStatus->SetTrainingText( m_szDisplayText.String() );
+
+		pStatus->SetTrainingOverridePos( m_bFixedPosition, m_fFixedPositionX, m_fFixedPositionY );
+
+		TFGameRules()->SetShowingTFObjectiveLesson( true );
+
+		// HACKHACK: Can't put these in Init() due to base class usage
+		m_bNoIconTarget			= true;
+		m_bAllowNodrawTarget	= true;
+
+		m_fOnScreenStartTime = gpGlobals->curtime;
+	}
+}
+
+//=========================================================
+//=========================================================
+void CTFObjectiveLesson::Stop()
+{
+	if ( !DoDelayedPlayerSwaps() )
+		return;
+	
+	if ( !TFGameRules() )
+		return;
+
+	if ( IsInstructing() )
+	{
+		// Set to false within CTFHudTraining
+		TFGameRules()->SetShowingTFObjectiveLesson( false );
+		
+		CTFHudObjectiveStatus *pStatus = GET_HUDELEMENT( CTFHudObjectiveStatus );
+		if ( pStatus )
+		{
+			pStatus->SetTrainingGameInstructor( false );
+		}
+
+		Assert( g_pActiveTFObjectiveLesson == this );
+		g_pActiveTFObjectiveLesson = NULL;
+	}
+
+	m_fOnScreenStartTime = 0.0f;
+	m_fStartTime = 0.0f;
+}
+
+//-----------------------------------------------------------------------------
+//
+// CTFNotificationLesson
+//
+//-----------------------------------------------------------------------------
+
+CTFNotificationLesson *CTFNotificationLesson::g_pActiveTFNotificationLesson = NULL;
+
+void CTFNotificationLesson::Init()
+{
+	ListenForGameEvent( "localplayer_respawn" );
+}
+
+//=========================================================
+//=========================================================
+void CTFNotificationLesson::Start()
+{
+	if ( !DoDelayedPlayerSwaps() )
+		return;
+
+	CHudNotificationPanel *pNotificationPanel = GET_HUDELEMENT( CHudNotificationPanel );
+	if ( pNotificationPanel )
+	{
+		if ( g_pActiveTFNotificationLesson && g_pActiveTFNotificationLesson->IsInstructing() )
+		{
+			// Replace the currently active lesson
+			g_pActiveTFNotificationLesson->SetCloseReason( "Replaced with another lesson" );
+			GetGameInstructor().CloseOpportunity( g_pActiveTFNotificationLesson );
+		}
+
+		g_pActiveTFNotificationLesson = this;
+
+		char szImage[MAX_PATH] = { 0 };
+
+		if ( V_strchr( m_szOnscreenIcon.String(), '%' ) )
+		{
+			char szToken[256];
+			V_strncpy( szToken, m_szOnscreenIcon.String(), sizeof( szToken ) );
+
+			bool bVar = false;
+			const char *token = strtok( szToken, "%" );
+			while (token != NULL)
+			{
+				if (bVar)
+				{
+					if (V_strnicmp( token, "team", 4 ) == 0)
+					{
+						C_BasePlayer *pPlayer = GetGameInstructor().GetLocalPlayer();
+						int iTeam = pPlayer ? pPlayer->GetTeamNumber() : TEAM_UNASSIGNED;
+						if (iTeam < 0 || iTeam >= TF_TEAM_COUNT)
+							iTeam = TEAM_UNASSIGNED;
+
+						if (FStrEq(token + 4, "_short"))
+						{
+							V_strncat( szImage, g_aTeamNamesShort[iTeam], sizeof( szImage ) );
+						}
+						else
+						{
+							V_strncat( szImage, g_aTeamNames[iTeam], sizeof( szImage ) );
+						}
+					}
+				}
+				else
+				{
+					V_strncat( szImage, token, sizeof( szImage ) );
+				}
+
+				bVar = !bVar;
+				token = strtok( NULL, "%" );
+			}
+		}
+
+		wchar_t wszText[MAX_TRAINING_MSG_LENGTH];
+		CTFHudTraining::FormatTrainingText( m_szDisplayText.String(), wszText );
+
+		C_BasePlayer *pLocalPlayer = C_BasePlayer::GetLocalPlayer();
+
+		pNotificationPanel->SetupNotifyCustom( wszText, szImage, pLocalPlayer ? pLocalPlayer->GetTeamNumber() : TEAM_UNASSIGNED, m_fTimeout );
+
+		// HACKHACK: Can't put these in Init() due to base class usage
+		m_bNoIconTarget			= true;
+		m_bAllowNodrawTarget	= true;
+
+		m_fOnScreenStartTime = gpGlobals->curtime;
+	}
+}
+
+//=========================================================
+//=========================================================
+void CTFNotificationLesson::Stop()
+{
+	if ( !DoDelayedPlayerSwaps() )
+		return;
+	
+	if ( !TFGameRules() )
+		return;
+
+	if ( IsInstructing() )
+	{
+		CHudNotificationPanel *pNotificationPanel = GET_HUDELEMENT( CHudNotificationPanel );
+		if ( pNotificationPanel )
+		{
+			pNotificationPanel->HideNotify();
+		}
+
+		Assert( g_pActiveTFNotificationLesson == this );
+		g_pActiveTFNotificationLesson = NULL;
+	}
+
+	m_fOnScreenStartTime = 0.0f;
+	m_fStartTime = 0.0f;
+}

--- a/src/game/client/mapbase/c_tf_lesson.h
+++ b/src/game/client/mapbase/c_tf_lesson.h
@@ -1,0 +1,83 @@
+﻿//========= Mapbase - https://github.com/mapbase-source/source-sdk-2013 ============//
+//
+// Purpose: TF2 lesson actions + new Game Instructor lesson types which use TF HUD elements
+// 
+// Author: Blixibon
+//
+//=============================================================================//
+
+#ifndef C_TF_LESSON_H
+#define C_TF_LESSON_H
+#ifdef _WIN32
+#pragma once
+#endif
+
+#include "c_gameinstructor.h"
+#include "c_baselesson.h"
+
+//-----------------------------------------------------------------------------
+// Purpose: An instructor lesson that integrates a TF HUD element instead of
+// a traditional icon hint.
+// 
+// TODO: Lesson classes are seemingly set up so that there can be non-icon
+// lessons, but those lessons cannot be loaded by mod_lessons or use game events.
+// An overhaul of the lesson system would be needed for this lesson type to derive
+// directly from these non-icon lesson classes.
+//-----------------------------------------------------------------------------
+class CTFBaseLesson : public CScriptedIconLesson
+{
+public:
+	DECLARE_LESSON( CTFBaseLesson, CScriptedIconLesson )
+
+	void Init( void ); 	// NOT virtual, each constructor calls their own
+	virtual void Update( void );
+	virtual void UpdateInactive( void );
+
+	void MarkAsDisplayed() { m_bWasDisplayed = true; }
+	virtual bool ShouldDisplay( void ) const;
+	virtual void FireGameEvent( IGameEvent *event );
+
+private:
+};
+
+//-----------------------------------------------------------------------------
+// Purpose: An instructor lesson that uses the training objective UI.
+//-----------------------------------------------------------------------------
+class CTFObjectiveLesson : public CTFBaseLesson
+{
+public:
+	DECLARE_LESSON( CTFObjectiveLesson, CTFBaseLesson )
+
+	void Init( void ); 	// NOT virtual, each constructor calls their own
+	virtual void Start( void );
+	virtual void Stop( void );
+
+	virtual CScriptedIconLesson *CreateLessonCopy()	{ return new CTFObjectiveLesson( GetName(), false, true ); }
+
+private:
+
+	// Pointer to the lesson currently displayed on the HUD
+	static CTFObjectiveLesson *g_pActiveTFObjectiveLesson;
+};
+
+//-----------------------------------------------------------------------------
+// Purpose: An instructor lesson that uses the notification UI.
+//-----------------------------------------------------------------------------
+class CTFNotificationLesson : public CTFBaseLesson
+{
+public:
+	DECLARE_LESSON( CTFNotificationLesson, CTFBaseLesson )
+
+	void Init( void ); 	// NOT virtual, each constructor calls their own
+	virtual void Start( void );
+	virtual void Stop( void );
+
+	virtual CScriptedIconLesson *CreateLessonCopy()	{ return new CTFNotificationLesson( GetName(), false, true ); }
+
+private:
+
+	// Pointer to the lesson currently displayed on the HUD
+	static CTFNotificationLesson *g_pActiveTFNotificationLesson;
+};
+
+#endif

--- a/src/game/client/tf/c_tf_player.cpp
+++ b/src/game/client/tf/c_tf_player.cpp
@@ -220,6 +220,10 @@ ConVar tf_taunt_first_person( "tf_taunt_first_person", "0", FCVAR_NONE, "1 = tau
 ConVar tf_romevision_opt_in( "tf_romevision_opt_in", "0", FCVAR_ARCHIVE, "Enable Romevision in Mann vs. Machine mode when available." );
 ConVar tf_romevision_skip_prompt( "tf_romevision_skip_prompt", "0", FCVAR_ARCHIVE, "If nonzero, skip the prompt about sharing Romevision." );
 
+#ifdef MAPBASE
+ConVar tf_scan_potential_use_target( "tf_scan_potential_use_target", "0", FCVAR_NONE, "Allows player to periodically store its \"potential use target\", a generic entity that the player may be looking at or interacting with. May be enabled automatically by game instructor, etc." );
+#endif
+
 
 #define BDAY_HAT_MODEL		"models/effects/bday_hat.mdl"
 #define BOMB_HAT_MODEL		"models/props_lakeside_event/bomb_temp_hat.mdl"
@@ -6057,6 +6061,24 @@ void C_TFPlayer::ClientThink()
 		    engine->ClientCmd("voicemenu 1 8");
 	    }
 	}
+
+#ifdef MAPBASE
+	if ( IsLocalPlayer() && tf_scan_potential_use_target.GetBool() && m_flPotentialUseEntityScanTime < gpGlobals->curtime )
+	{
+		// Fire an event if we have a new use entity
+		C_BaseEntity *pOldEnt = m_hPotentialUseEntity;
+		C_BaseEntity *pNewEnt = GetPotentialUseEntity();
+		if ( pNewEnt != pOldEnt && pNewEnt )
+		{
+			IGameEvent *event = gameeventmanager->CreateEvent( "use_target" );
+			if ( event )
+			{
+				event->SetInt( "targetid", pNewEnt->entindex() );
+				gameeventmanager->FireEventClientSide( event );
+			}
+		}
+	}
+#endif
 }
 
 void C_TFPlayer::Touch( CBaseEntity *pOther )

--- a/src/game/client/tf/c_tf_player.h
+++ b/src/game/client/tf/c_tf_player.h
@@ -513,6 +513,11 @@ public:
 
 	bool	IsPlayerOnSteamFriendsList( C_BasePlayer *pPlayer );
 
+#ifdef MAPBASE
+	virtual C_BaseEntity *GetPotentialUseEntity();
+	C_BaseEntity *FindPotentialUseEntity();
+#endif
+
 protected:
 
 	void ResetFlexWeights( CStudioHdr *pStudioHdr );
@@ -966,6 +971,11 @@ private:
 	float m_flTempForceDrawViewModelCycle  = 0.0f;
 
 	CNetworkVar( int, m_iPlayerSkinOverride );
+
+#ifdef MAPBASE
+	EHANDLE	m_hPotentialUseEntity = NULL;
+	float m_flPotentialUseEntityScanTime = 0.0f;
+#endif
 };
 
 inline C_TFPlayer* ToTFPlayer( C_BaseEntity *pEntity )

--- a/src/game/client/tf/tf_hud_notification_panel.cpp
+++ b/src/game/client/tf/tf_hud_notification_panel.cpp
@@ -160,7 +160,7 @@ void CHudNotificationPanel::MsgFunc_HudNotifyCustom( bf_read &msg )
 //-----------------------------------------------------------------------------
 // Purpose: 
 //-----------------------------------------------------------------------------
-void CHudNotificationPanel::SetupNotifyCustom( const char *pszText, const char *pszIcon, int iBackgroundTeam )
+void CHudNotificationPanel::SetupNotifyCustom( const char *pszText, const char *pszIcon, int iBackgroundTeam, float overrideDuration )
 {
 	// Reload the base
 	LoadControlSettings( "resource/UI/notifications/base_notification.res" );
@@ -182,7 +182,7 @@ void CHudNotificationPanel::SetupNotifyCustom( const char *pszText, const char *
 	}
 
 	// set up the fade time
-	m_flFadeTime = gpGlobals->curtime + tf_hud_notification_duration.GetFloat();
+	m_flFadeTime = gpGlobals->curtime + ( overrideDuration > 0.f ? overrideDuration : tf_hud_notification_duration.GetFloat() );
 
 	InvalidateLayout();
 }
@@ -190,7 +190,7 @@ void CHudNotificationPanel::SetupNotifyCustom( const char *pszText, const char *
 //-----------------------------------------------------------------------------
 // Purpose: 
 //-----------------------------------------------------------------------------
-void CHudNotificationPanel::SetupNotifyCustom( const wchar_t *pszText, const char *pszIcon, int iBackgroundTeam )
+void CHudNotificationPanel::SetupNotifyCustom( const wchar_t *pszText, const char *pszIcon, int iBackgroundTeam, float overrideDuration )
 {
 	// Reload the base
 	LoadControlSettings( "resource/UI/notifications/base_notification.res" );
@@ -212,7 +212,7 @@ void CHudNotificationPanel::SetupNotifyCustom( const wchar_t *pszText, const cha
 	}
 
 	// set up the fade time
-	m_flFadeTime = gpGlobals->curtime + tf_hud_notification_duration.GetFloat();
+	m_flFadeTime = gpGlobals->curtime + ( overrideDuration > 0.f ? overrideDuration : tf_hud_notification_duration.GetFloat() );
 
 	InvalidateLayout();
 }
@@ -234,6 +234,17 @@ void CHudNotificationPanel::SetupNotifyCustom( const wchar_t *pszText, HudNotifi
 
 	InvalidateLayout();
 }
+
+#ifdef MAPBASE
+//-----------------------------------------------------------------------------
+// Purpose: 
+//-----------------------------------------------------------------------------
+void CHudNotificationPanel::HideNotify()
+{
+	// Hides current message
+	m_flFadeTime = 0.0f;
+}
+#endif
 
 //-----------------------------------------------------------------------------
 // Purpose: 

--- a/src/game/client/tf/tf_hud_notification_panel.h
+++ b/src/game/client/tf/tf_hud_notification_panel.h
@@ -45,9 +45,13 @@ public:
 	void	MsgFunc_HudNotify( bf_read &msg );
 	void	MsgFunc_HudNotifyCustom( bf_read &msg );
 
-	void	SetupNotifyCustom( const char *pszText, const char *pszIcon, int iBackgroundTeam );
-	void	SetupNotifyCustom( const wchar_t *pszText, const char *pszIcon, int iBackgroundTeam );
+	void	SetupNotifyCustom( const char *pszText, const char *pszIcon, int iBackgroundTeam, float overrideDuration = 0.0f );
+	void	SetupNotifyCustom( const wchar_t *pszText, const char *pszIcon, int iBackgroundTeam, float overrideDuration = 0.0f );
 	void	SetupNotifyCustom( const wchar_t *pszText, HudNotification_t type, float overrideDuration = 0.0f );
+
+#ifdef MAPBASE
+	void	HideNotify();
+#endif
 
 	virtual void LevelInit( void ) { m_flFadeTime = 0; };
 

--- a/src/game/client/tf/tf_hud_objectivestatus.cpp
+++ b/src/game/client/tf/tf_hud_objectivestatus.cpp
@@ -159,7 +159,7 @@ CControlPointProgressBar *CTFHudObjectiveStatus::GetControlPointProgressBar( voi
 //-----------------------------------------------------------------------------
 // Purpose: 
 //-----------------------------------------------------------------------------
-void CTFHudObjectiveStatus::SetTrainingText( char *text )
+void CTFHudObjectiveStatus::SetTrainingText( const char *text )
 {
 	if ( NULL == m_pTrainingPanel )
   		return;
@@ -170,13 +170,48 @@ void CTFHudObjectiveStatus::SetTrainingText( char *text )
 //-----------------------------------------------------------------------------
 // Purpose: 
 //-----------------------------------------------------------------------------
-void CTFHudObjectiveStatus::SetTrainingObjective( char *text )
+void CTFHudObjectiveStatus::SetTrainingObjective( const char *text )
 {
 	if ( NULL == m_pTrainingPanel )
 		return;
 
 	m_pTrainingPanel->SetTrainingObjective( text );
 }
+
+#ifdef MAPBASE
+//-----------------------------------------------------------------------------
+// Purpose: 
+//-----------------------------------------------------------------------------
+void CTFHudObjectiveStatus::SetTrainingImage( const char *img )
+{
+	if ( NULL == m_pTrainingPanel )
+		return;
+
+	m_pTrainingPanel->SetTrainingImage( img );
+}
+
+//-----------------------------------------------------------------------------
+// Purpose: 
+//-----------------------------------------------------------------------------
+void CTFHudObjectiveStatus::SetTrainingGameInstructor( bool bIsInstructor )
+{
+	if ( NULL == m_pTrainingPanel )
+		return;
+
+	m_pTrainingPanel->SetTrainingGameInstructor( bIsInstructor );
+}
+
+//-----------------------------------------------------------------------------
+// Purpose: 
+//-----------------------------------------------------------------------------
+void CTFHudObjectiveStatus::SetTrainingOverridePos( bool bOverride, float flX, float flY )
+{
+	if ( NULL == m_pTrainingPanel )
+		return;
+
+	m_pTrainingPanel->SetTrainingOverridePos( bOverride, flX, flY );
+}
+#endif
 //=============================================================================
 // HPE_END
 //=============================================================================

--- a/src/game/client/tf/tf_hud_objectivestatus.h
+++ b/src/game/client/tf/tf_hud_objectivestatus.h
@@ -44,8 +44,13 @@ public:
 	// HPE_BEGIN
 	// [msmith] Functions for training stuff.
 	//=============================================================================
-	void SetTrainingText( char *msg);
-	void SetTrainingObjective (char *obj);
+	void SetTrainingText( const char *msg);
+	void SetTrainingObjective (const char *obj);
+#ifdef MAPBASE
+	void SetTrainingImage (const char *img);
+	void SetTrainingGameInstructor (bool bIsInstructor);
+	void SetTrainingOverridePos (bool bOverride, float flX, float flY);
+#endif
 	//=============================================================================
 	// HPE_END
 	//=============================================================================

--- a/src/game/client/tf/tf_hud_training.h
+++ b/src/game/client/tf/tf_hud_training.h
@@ -42,18 +42,39 @@ public:
 	static bool   FormatTrainingText( const char* input, wchar_t* output );
 
 	virtual void  ApplySchemeSettings( vgui::IScheme *pScheme );
+	virtual void  PerformLayout();
 	virtual void  Reset();
 	virtual void  FireGameEvent( IGameEvent *event );
 	virtual bool  IsVisible( void );
 	virtual void  OnTick();
 
-	void          SetTrainingText( char *msg );
-	void          SetTrainingObjective( char *msg );
+	void          SetTrainingText( const char *msg );
+	void          SetTrainingObjective( const char *msg );
+#ifdef MAPBASE
+	void          SetTrainingImage( const char *image );
+	void          SetTrainingOverridePos( bool bOverride, float flX, float flY );
+
+	void          SetTrainingGameInstructor( bool bIsInstructor );
+#endif
 
 private:
 
 	CExRichText		*m_pMsgLabel;
 	CExLabel		*m_pPressSpacebarToContinueLabel;
+#ifdef MAPBASE
+	CExLabel		*m_pGoalLabel;
+	CExLabel		*m_pGoalLabelShadow;
+	CExRichText		*m_pMsgLabelShadow;
+	CTFImagePanel	*m_pMsgBG;
+
+	vgui::ImagePanel	*m_pImage;
+	char			m_szImage[MAX_PATH];
+
+	bool			m_bOverridePos = false;
+	float			m_flOverrideX, m_flOverrideY = 0.0f;
+
+	bool			m_bIsGameInstructor = false;
+#endif
 };
 
 

--- a/src/game/client/tf/tf_hud_trainingmessage.cpp
+++ b/src/game/client/tf/tf_hud_trainingmessage.cpp
@@ -40,6 +40,9 @@ public:
 
 	void			MsgFunc_TrainingMsg( bf_read &msg );
 	void			MsgFunc_TrainingObjective( bf_read &msg );
+#ifdef MAPBASE
+	void			MsgFunc_TrainingImage( bf_read &msg );
+#endif
 
 private:
 };
@@ -47,6 +50,9 @@ private:
 DECLARE_HUDELEMENT( CHudTrainingMsg );
 DECLARE_HUD_MESSAGE( CHudTrainingMsg, TrainingMsg );
 DECLARE_HUD_MESSAGE( CHudTrainingMsg, TrainingObjective );
+#ifdef MAPBASE
+DECLARE_HUD_MESSAGE( CHudTrainingMsg, TrainingImage );
+#endif
 
 //-----------------------------------------------------------------------------
 // Purpose: 
@@ -65,6 +71,9 @@ void CHudTrainingMsg::Init()
 {
 	HOOK_HUD_MESSAGE( CHudTrainingMsg, TrainingMsg );
 	HOOK_HUD_MESSAGE( CHudTrainingMsg, TrainingObjective );
+#ifdef MAPBASE
+	HOOK_HUD_MESSAGE( CHudTrainingMsg, TrainingImage );
+#endif
 }
 
 //-----------------------------------------------------------------------------
@@ -110,4 +119,24 @@ void CHudTrainingMsg::MsgFunc_TrainingObjective( bf_read &msg )
 		pStatus->SetTrainingObjective(szString);
 	}
 }
+
+#ifdef MAPBASE
+//-----------------------------------------------------------------------------
+// Purpose: Activates the hint display
+//-----------------------------------------------------------------------------
+void CHudTrainingMsg::MsgFunc_TrainingImage( bf_read &msg )
+{
+	if ( engine->IsPlayingDemo() )
+		return;
+
+	char szString[MAX_TRAINING_MSG_LENGTH];
+	msg.ReadString( szString, MAX_TRAINING_MSG_LENGTH );
+
+	CTFHudObjectiveStatus *pStatus = GET_HUDELEMENT( CTFHudObjectiveStatus );
+	if ( pStatus )
+	{
+		pStatus->SetTrainingImage(szString);
+	}
+}
+#endif
 

--- a/src/game/server/env_instructor_hint.cpp
+++ b/src/game/server/env_instructor_hint.cpp
@@ -215,7 +215,7 @@ void CEnvInstructorHint::InputShowHint( inputdata_t &inputdata )
 
 		if ( inputdata.value.StringID() != NULL_STRING )
 		{
-			CBaseEntity *pTarget = gEntList.FindEntityByName( NULL, inputdata.value.String() );
+			CBaseEntity *pTarget = gEntList.FindEntityByName( NULL, inputdata.value.String(), NULL, inputdata.pActivator, inputdata.pCaller );
 			pActivator = dynamic_cast<CBasePlayer*>( pTarget );
 			if ( pActivator )
 			{
@@ -263,6 +263,8 @@ void CEnvInstructorHint::InputShowHint( inputdata_t &inputdata )
 #ifdef MAPBASE
 		event->SetString( "hint_start_sound", m_iszStartSound.ToCStr() );
 		event->SetInt( "hint_target_pos", m_iHintTargetPos );
+		event->SetInt( "hint_ent_spawnflags", GetSpawnFlags() );
+		event->SetInt( "hint_ent_team", GetTeamNumber() );
 #endif
 
 		gameeventmanager->FireEvent( event );

--- a/src/game/server/player.cpp
+++ b/src/game/server/player.cpp
@@ -579,6 +579,7 @@ BEGIN_ENT_SCRIPTDESC( CBasePlayer, CBaseCombatCharacter, "The player entity." )
 	DEFINE_SCRIPTFUNC_NAMED( ScriptGetViewModel, "GetViewModel", "Returns the viewmodel of the specified index." )
 	
 	DEFINE_SCRIPTFUNC_NAMED( ScriptGetUseEntity, "GetUseEntity", "Gets the player's current use entity." )
+	DEFINE_SCRIPTFUNC_NAMED( ScriptGetPotentialUseEntity, "GetPotentialUseEntity", "Gets the player's current potential use entity." )
 	DEFINE_SCRIPTFUNC_NAMED( ScriptGetHeldObject, "GetHeldObject", "Gets the player's currently held object IF it is being held by a gravity gun. To check for the player's held +USE object, use the standalone GetPlayerHeldEntity function." )
 
 	// 

--- a/src/game/server/player.h
+++ b/src/game/server/player.h
@@ -428,6 +428,7 @@ public:
 	HSCRIPT					ScriptGetViewModel( int viewmodelindex );
 
 	HSCRIPT					ScriptGetUseEntity() { return ToHScript( GetUseEntity() ); }
+	HSCRIPT					ScriptGetPotentialUseEntity() { return ToHScript( GetPotentialUseEntity() ); }
 	HSCRIPT					ScriptGetHeldObject() { return ToHScript( GetHeldObject() ); }
 #endif
 
@@ -776,6 +777,9 @@ public:
 	void	SetMuzzleFlashTime( float flTime );
 	void	SetUseEntity( CBaseEntity *pUseEntity );
 	CBaseEntity *GetUseEntity();
+#ifdef MAPBASE // From Alien Swarm SDK
+	virtual CBaseEntity *GetPotentialUseEntity() { return GetUseEntity(); }
+#endif
 
 	virtual float GetPlayerMaxSpeed();
 

--- a/src/game/server/server_mapbase.vpc
+++ b/src/game/server/server_mapbase.vpc
@@ -4,9 +4,6 @@
 //	Project Base Script
 //-----------------------------------------------------------------------------
 
-$Include "$SRCDIR\game\server\server_mapbase_hl2.vpc"	[$HL2||$EPISODIC||$HL2MP]
-$Include "$SRCDIR\game\server\server_mapbase_tf.vpc"	[$TF]
-
 $Configuration
 {
 	$Compiler
@@ -102,3 +99,6 @@ $Project
 		$Lib	"responserules" [$NEW_RESPONSE_SYSTEM]
 	}
 }
+
+$Include "$SRCDIR\game\server\server_mapbase_hl2.vpc"	[$HL2||$EPISODIC||$HL2MP]
+$Include "$SRCDIR\game\server\server_mapbase_tf.vpc"	[$TF]

--- a/src/game/server/tf/tf_player.h
+++ b/src/game/server/tf/tf_player.h
@@ -1099,6 +1099,11 @@ public:
 	// Talk control
 	virtual bool		CanPlayerTalk() OVERRIDE;
 
+#ifdef MAPBASE
+	virtual CBaseEntity *GetPotentialUseEntity();
+	CBaseEntity *FindPotentialUseEntity();
+#endif
+
 protected:
 
 	// Creation/Destruction.

--- a/src/game/shared/tf/tf_gamerules.cpp
+++ b/src/game/shared/tf/tf_gamerules.cpp
@@ -3379,6 +3379,10 @@ CTFGameRules::CTFGameRules()
 //=============================================================================
 	m_bIsTrainingHUDVisible.Set( false );
 
+#if defined(MAPBASE) && defined(CLIENT_DLL)
+	m_bShowingTFObjectiveLesson = false;
+#endif
+
 	m_bIsInItemTestingMode.Set( false );
 
 	// Set turbo physics on.  Do it here for now.
@@ -19304,6 +19308,9 @@ BEGIN_DATADESC( CTrainingModeLogic )
 	DEFINE_KEYFIELD( m_nextMapName, FIELD_STRING, "nextMap" ),
 	DEFINE_INPUTFUNC( FIELD_STRING, "ShowTrainingMsg", InputShowTrainingMsg ),
 	DEFINE_INPUTFUNC( FIELD_STRING, "ShowTrainingObjective", InputShowTrainingObjective ),
+#ifdef MAPBASE
+	DEFINE_INPUTFUNC( FIELD_STRING, "ShowTrainingImage", InputShowTrainingImage ),
+#endif
 	DEFINE_INPUTFUNC( FIELD_VOID, "ForcePlayerSpawnAsClassOutput", InputForcePlayerSpawnAsClassOutput ),
 	DEFINE_INPUTFUNC( FIELD_VOID, "KickBots", InputKickAllBots ),
 	DEFINE_INPUTFUNC( FIELD_VOID, "ShowTrainingHUD", InputShowTrainingHUD ),
@@ -19358,6 +19365,17 @@ void CTrainingModeLogic::SetTrainingObjective(const char *text)
 	WRITE_STRING( text );
 	MessageEnd();
 }
+
+#ifdef MAPBASE
+void CTrainingModeLogic::SetTrainingImage(const char *text)
+{
+	CBroadcastRecipientFilter allusers;
+	allusers.MakeReliable();
+	UserMessageBegin( allusers, "TrainingImage" );
+	WRITE_STRING( text );
+	MessageEnd();
+}
+#endif
 
 void CTrainingModeLogic::OnPlayerSpawned( CTFPlayer* pPlayer )
 {
@@ -19523,6 +19541,16 @@ void CTrainingModeLogic::InputShowTrainingObjective( inputdata_t &inputdata )
 	
 	UpdateHUDObjective();
 }
+
+#ifdef MAPBASE
+void CTrainingModeLogic::InputShowTrainingImage( inputdata_t &inputdata )
+{
+	if ( !TFGameRules()->IsInTraining() )
+		return;
+
+	SetTrainingImage( inputdata.value.String() );
+}
+#endif
 
 void CTrainingModeLogic::InputShowTrainingHUD( inputdata_t &inputdata )
 {

--- a/src/game/shared/tf/tf_gamerules.h
+++ b/src/game/shared/tf/tf_gamerules.h
@@ -684,8 +684,18 @@ bool IsCreepWaveMode( void ) const;
 //=============================================================================
 // HPE_END
 //=============================================================================
+
+#if defined(MAPBASE) && defined(CLIENT_DLL)
+	bool IsTrainingHUDVisible( void ) { return (IsInTraining() && m_bIsTrainingHUDVisible) || IsShowingTFObjectiveLesson(); }
+#else
 	bool IsTrainingHUDVisible( void ) { return IsInTraining() && m_bIsTrainingHUDVisible; }
+#endif
 	void SetTrainingHUDVisible( bool bVisible ) { m_bIsTrainingHUDVisible.Set( bVisible ); }
+
+#if defined(MAPBASE) && defined(CLIENT_DLL)
+	bool	IsShowingTFObjectiveLesson() { return m_bShowingTFObjectiveLesson; }
+	void	SetShowingTFObjectiveLesson( bool bShowingLesson ) { m_bShowingTFObjectiveLesson = bShowingLesson; }
+#endif
 
 	virtual bool	IsInItemTestingMode( void ) { return m_bIsInItemTestingMode; }
 	void			SetInItemTestingMode( bool bInTesting ) { m_bIsInItemTestingMode.Set( bInTesting ); }
@@ -1166,6 +1176,10 @@ private:
 //=============================================================================
 	CNetworkVar( bool, m_bIsTrainingHUDVisible );
 
+#if defined(MAPBASE) && defined(CLIENT_DLL)
+	bool	m_bShowingTFObjectiveLesson; // Whether or not the training HUD is currently being used for an instructor lesson
+#endif
+
 	CNetworkVar( bool, m_bIsInItemTestingMode );
 	int		m_iItemTesting_BotAnim;
 	float	m_flItemTesting_BotAnimSpeed;
@@ -1616,6 +1630,9 @@ public:
 	void SetupOnRoundStart( void );
 	void SetTrainingMsg( const char *msg );
 	void SetTrainingObjective( const char *msg );
+#ifdef MAPBASE
+	void SetTrainingImage( const char *msg );
+#endif
 	void OnPlayerSpawned( CTFPlayer *pPlayer );
 	void OnPlayerDied( CTFPlayer *pPlayer, CBaseEntity *pKiller );
 	void OnBotDied( CTFPlayer *pPlayer, CBaseEntity *pKiller );
@@ -1634,6 +1651,9 @@ public:
 	void InputKickAllBots( inputdata_t &inputdata );
 	void InputShowTrainingMsg( inputdata_t &inputdata );
 	void InputShowTrainingObjective( inputdata_t &inputdata );
+#ifdef MAPBASE
+	void InputShowTrainingImage( inputdata_t &inputdata );
+#endif
 	void InputShowTrainingHUD( inputdata_t &inputdata );
 	void InputHideTrainingHUD( inputdata_t &inputdata );
 	void InputEndTraining( inputdata_t &inputdata );

--- a/src/game/shared/tf/tf_usermessages.cpp
+++ b/src/game/shared/tf/tf_usermessages.cpp
@@ -66,6 +66,9 @@ void RegisterUserMessages()
 //=============================================================================
 	usermessages->Register( "TrainingMsg", -1 );	// Displays a training message
 	usermessages->Register( "TrainingObjective", -1 );	// Displays a training objective
+#ifdef MAPBASE
+	usermessages->Register( "TrainingImage", -1 );	// Displays a training image
+#endif
 //=============================================================================
 // HPE_END
 //=============================================================================


### PR DESCRIPTION
This PR makes several changes to adapt the Game Instructor into TF2, many of which were ported from TF2 Classic.

---

#### [`env_instructor_hint` team and TF2 class support](https://github.com/mapbase-source/source-sdk-2013/commit/2e0e22c2606f353b73df46fa30f0efbd0e00deef)
This allows `env_instructor_hint` to transmit its team and spawnflags to the hint, filtering by team and player class. This was originally done for TF2C and has been tweaked so that the team value can be used in HL2DM mods as well.

#### [TF2-style instructor hint HUD](https://github.com/mapbase-source/source-sdk-2013/commit/fbe93bc6ff81527c30667e72d0b82f3d1f262559)
This gives instructor hints background and text shadow panels to make it fit in with other HUD elements in TF2. This was also originally done for TF2C with changes made to coexist with the default hint appearance. This can also theoretically be used outside of TF2 mods by changing `locator_background_style` and having appropriate changes to the `.res` file, although this hasn't been tested.

#### [Restore/port potential use target for Game Instructor with optional TF2 implementation](https://github.com/mapbase-source/source-sdk-2013/commit/0528cc229409bf8f2844f73c4de14219e661db95)
This partially ports the "potential use target" feature included in the Alien Swarm SDK, which can be used by the Game Instructor, but was lost when the Game instructor was initially brought over. It is essentially the entity that the player can immediately interact with, even if the player cannot literally initiate +USE on it. In L4D2, this is used to show hints about picking up items, giving items to teammates, among other things.

This PR also adds an optional implementation of this feature to TF2 for use in the Game Instructor and/or VScript. Normally, the potential use entity is calculated on demand, although a `tf_scan_potential_use_target` cvar can be used to enable periodically scanning and firing the `use_target` event for the potential use targets, which some instructor lessons may listen to. This cvar is enabled automatically if any lessons with `use_target` are detected.

#### [Hook Game Instructor to TF training and notification HUD](https://github.com/mapbase-source/source-sdk-2013/pull/469/commits/74b4fc2d0517c68284026953aea978624c9375b2)
This adds custom lesson actions for TF2 game logic and new lesson types for its HUD elements. Using a new `lesson_type` keyvalue, you can make a lesson use either the training HUD or the notification (`game_text_tf`) HUD instead of the default locator hint. Note that these hints may not support certain display keyvalues, such as icon targets.

As part of this integration, the training HUD now supports an optional image that can be specified in a lesson in the same way as a locator icon. This can also be used directly within training mode with a new `ShowTrainingImage` input on `tf_logic_training_mode`, although this blanks out the message content and must be fired earlier.

Example of an instructor lesson which uses the training HUD:
```
	"TF Training Objective Test"
	{
		"lesson_type"		"tf_training_objective"
		"group"				"tf_test_hints"
		
		"priority"			"30"
		"instance_type"		"2"
		"no_icon_target"	"1"
		
		"display_limit"		"3"
		
		"onscreen_icon"			"cyoa/cyoa_bg_icon_globe"
		"caption_param"			"Objective Hint"
		"caption"				"This is an instructor lesson which uses the training HUD."
		
		"timeout"				"10"

		"open"
		{
			"localplayer_respawn"
			{
				"void is roundstate"	"string running"
			}
		}
	}
```

![202509~2](https://github.com/user-attachments/assets/fc677dd1-473e-4e30-8128-1c8727e674b4)

Note that these new hint types currently cannot be initiated with `env_instructor_hint` and must be defined in `scripts/mod_lessons.txt` or `scripts/instructor_lessons.txt`, although that may change in the future.

Additionally, this PR adds the previously missing `c_mod_lesson_stubs.cpp` from the Alien Swarm SDK with a new stub for custom lesson types, although it is excluded from the TF2 VPC.

---

<!-- Replace [ ] with [x] for each item your PR satisfies -->
#### PR Checklist
- [x] **My PR follows all guidelines in the CONTRIBUTING.md file**
- [x] My PR targets a `develop` branch OR targets another branch with a specific goal in mind
