### PR TITLE
[TF2] Fix further conflicts between game_menu and voice menu

### DIFF
--- a/src/game/client/menu.h
+++ b/src/game/client/menu.h
@@ -42,7 +42,9 @@ public:
 	void SelectMenuItem( int menu_item );
 
 #ifdef MAPBASE
-	bool IsMenuMapDefined() const { return m_bMapDefinedMenu; }
+	bool IsGenericMenu() const { return m_iMenuType == MENU_TYPE_GENERIC; }
+	bool IsMenuMapDefined() const { return m_iMenuType == MENU_TYPE_MAP_DEFINED; }
+	bool IsVoiceMenu() const { return m_iMenuType == MENU_TYPE_KEYVALUES; }
 #endif
 
 private:
@@ -81,8 +83,15 @@ private:
 	float			m_flSelectionTime;
 
 #ifdef MAPBASE
-	// Indicates this menu is defined by game_menu
-	bool			m_bMapDefinedMenu;
+	enum MenuType_t
+	{
+		MENU_TYPE_GENERIC,
+		MENU_TYPE_KEYVALUES,	// Indicates this menu was initiated with ShowMenu_KeyValueItems (voice menu)
+		MENU_TYPE_MAP_DEFINED,	// Indicates this menu is defined by game_menu
+	};
+
+	MenuType_t		m_iMenuType;
+
 	bool			m_bPlayingFadeout;
 #endif
 

--- a/src/game/client/voice_menu.cpp
+++ b/src/game/client/voice_menu.cpp
@@ -93,6 +93,17 @@ void OpenVoiceMenu( int index )
 	}
 }
 
+#ifdef MAPBASE
+// Function called externally to ensure voice menu is overridden by game_menu, etc.
+void OverrideActiveVoiceMenu()
+{
+	if ( g_ActiveVoiceMenu != 0 )
+	{
+		g_ActiveVoiceMenu = 0;
+	}
+}
+#endif
+
 static void OpenVoiceMenu_1( void )
 {
 	OpenVoiceMenu( 1 );


### PR DESCRIPTION
This PR fixes the voice menu overriding `game_menu`'s options when the UI shows the opposite, and also fixes the voice menu using the wrong appearance.

The former is caused by `g_ActiveVoiceMenu` not being cleared when a `game_menu` is activated, causing the voice menu to swallow the menu input. Since `g_ActiveVoiceMenu` is static to `voice_menu.cpp`, I added a new function that's externally linked from there and activated when a `game_menu` is shown. I've gated it behind `TF_CLIENT_DLL` for now since no other project implements `voice_menu.cpp` by default, although a better implementation should be considered in the future so that non-TF2 mods which implement the voice menu don't miss this fix.

The latter is a conditional reversion of a bug fix: The menu technically has two different font definitions and colors between the title of the menu and its items. However, the voice menu's items were not recognized as actual items by the HUD, so it only showed them with properties intended for the menu's title. The changes made for `game_menu` coincidentally fixed this. In order to retain the original appearance and behavior of the voice menu, the menu will now revert this fix when it is opened via `ShowMenu_KeyValueItems` (which, by default, is only used with the voice menu). New cvars called `hud_menu_voice_use_item_color`, `hud_menu_voice_use_item_font`, and `hud_menu_voice_use_item_anim` have been added to selectively enable certain fixed behavior.

---

<!-- Replace [ ] with [x] for each item your PR satisfies -->
#### PR Checklist
- [x] **My PR follows all guidelines in the CONTRIBUTING.md file**
- [x] My PR targets a `develop` branch OR targets another branch with a specific goal in mind
