### PR TITLE
[TF2] Fix TF training HUD lessons conflicting with stats panel

### DIFF
--- a/src/game/client/mapbase/c_tf_lesson.cpp
+++ b/src/game/client/mapbase/c_tf_lesson.cpp
@@ -12,6 +12,7 @@
 #include "tf_hud_training.h"
 #include "tf_hud_objectivestatus.h"
 #include "tf_hud_notification_panel.h"
+#include "tf_hud_statpanel.h"
 
 //-----------------------------------------------------------------------------
 
@@ -635,6 +636,13 @@ void CTFObjectiveLesson::Start()
 		pStatus->SetTrainingOverridePos( m_bFixedPosition, m_fFixedPositionX, m_fFixedPositionY );
 
 		TFGameRules()->SetShowingTFObjectiveLesson( true );
+
+		// Hide the stat panel if it's active
+		CTFStatPanel *pStatPanel = GET_HUDELEMENT( CTFStatPanel );
+		if ( pStatPanel )
+		{
+			pStatPanel->Hide();
+		}
 
 		// HACKHACK: Can't put these in Init() due to base class usage
 		m_bNoIconTarget			= true;

--- a/src/game/client/tf/tf_hud_statpanel.cpp
+++ b/src/game/client/tf/tf_hud_statpanel.cpp
@@ -712,6 +712,12 @@ void CTFStatPanel::ShowStatPanel( int iClass, int iTeam, int iCurStatValue, TFSt
 		return;
 	}
 
+#ifdef MAPBASE
+	// Don't interfere with training HUD
+	if ( TFGameRules() && TFGameRules()->IsShowingTFObjectiveLesson() )
+		return;
+#endif
+
 	ClassStats_t &classStats = GetClassStats( iClass );
 	vgui::Label *pLabel = dynamic_cast<Label *>( FindChildByName( "summaryLabel" ) );
 	if ( !pLabel )


### PR DESCRIPTION
This PR fixes instructor lessons that use the training HUD overlapping with the stats panel that appears when the player dies/respawns. At the moment, any active instructor lessons using the training HUD override and hide it.

---

<!-- Replace [ ] with [x] for each item your PR satisfies -->
#### PR Checklist
- [x] **My PR follows all guidelines in the CONTRIBUTING.md file**
- [x] My PR targets a `develop` branch OR targets another branch with a specific goal in mind
