### PR TITLE
[TF2] Add support for Arena mode in TF bots

### DIFF
--- a/src/game/server/tf/bot/behavior/engineer/tf_bot_engineer_build.cpp
+++ b/src/game/server/tf/bot/behavior/engineer/tf_bot_engineer_build.cpp
@@ -22,11 +22,19 @@
 // this was useful when engineers build at their normal (slow) rate to make sure initial sentries get built in time
 ConVar tf_raid_engineer_infinte_metal( "tf_raid_engineer_infinte_metal", "1", FCVAR_CHEAT | FCVAR_DEVELOPMENTONLY );
 
+#ifdef MAPBASE
+ConVar tf_bot_arena_build_teleporter( "tf_bot_arena_build_teleporter", "0" );
+#endif
+
 
 //---------------------------------------------------------------------------------------------
 Action< CTFBot > *CTFBotEngineerBuild::InitialContainedAction( CTFBot *me )
 {
+#ifdef MAPBASE
+	if ( TFGameRules()->IsPVEModeActive() || ( TFGameRules()->IsInArenaMode() && !tf_bot_arena_build_teleporter.GetBool() ) )
+#else
 	if ( TFGameRules()->IsPVEModeActive() )
+#endif
 	{
 		return new CTFBotEngineerMoveToBuild;
 	}

--- a/src/game/server/tf/bot/behavior/engineer/tf_bot_engineer_move_to_build.cpp
+++ b/src/game/server/tf/bot/behavior/engineer/tf_bot_engineer_move_to_build.cpp
@@ -58,6 +58,11 @@ void CTFBotEngineerMoveToBuild::CollectBuildAreas( CTFBot *me )
 	m_sentryAreaVector.RemoveAll();
 
 	CUtlVector< CTFNavArea * > pointAreaVector;
+#ifdef MAPBASE
+	// Gamemodes such as arena may use control points outside of the actual CP mode
+	// This is used to check if there's a valid control point, as GetControlPointCenterArea is used elsewhere in engineer AI
+	CTFNavArea *pointCenterArea = NULL;
+#endif
 	Vector pointCentroid = vec3_origin;
 	float pointEnemyIncursion = 0.0f;
 	int i;
@@ -110,6 +115,10 @@ void CTFBotEngineerMoveToBuild::CollectBuildAreas( CTFBot *me )
 		if ( !ctrlPoint )
 			return;
 
+#ifdef MAPBASE
+		pointCenterArea = TheTFNavMesh()->GetControlPointCenterArea( ctrlPoint->GetPointIndex() );
+#endif
+
 		const CUtlVector< CTFNavArea * > *ctrlPointAreaVector = TheTFNavMesh()->GetControlPointAreas( ctrlPoint->GetPointIndex() );
 
 		if ( ctrlPointAreaVector )
@@ -161,7 +170,12 @@ void CTFBotEngineerMoveToBuild::CollectBuildAreas( CTFBot *me )
 // 					continue;
 // 			}
 
+#ifdef MAPBASE
+			// Control points may exist outside of CP mode
+			if ( pointCenterArea )
+#else
 			if ( TFGameRules()->GetGameType() == TF_GAMETYPE_CP )
+#endif
 			{
 				// don't build directly on the point
 				if ( visibleArea->HasAttributeTF( TF_NAV_CONTROL_POINT ) )

--- a/src/game/server/tf/bot/behavior/scenario/capture_point/tf_bot_capture_point.cpp
+++ b/src/game/server/tf/bot/behavior/scenario/capture_point/tf_bot_capture_point.cpp
@@ -55,6 +55,15 @@ ActionResult< CTFBot >	CTFBotCapturePoint::Update( CTFBot *me, float interval )
 		return SuspendFor( new CTFBotSeekAndDestroy( roamTime ), "Seek and destroy until a point becomes available" );
 	}
 
+#ifdef MAPBASE
+	if ( TFGameRules()->IsInArenaMode() )
+	{
+		// CollectCapturePoints() can still count a locked point in arena mode. Wait until it's open before zeroing in
+		if ( !TeamplayGameRules()->TeamMayCapturePoint( me->GetTeamNumber(), point->GetPointIndex() ) )
+			return SuspendFor( new CTFBotSeekAndDestroy, "Seek and destroy until a point becomes available" );
+	}
+#endif
+
 	if ( point->GetTeamNumber() == me->GetTeamNumber() )
 	{
 		return ChangeTo( new CTFBotDefendPoint, "We need to defend our point(s)" );

--- a/src/game/server/tf/bot/behavior/tf_bot_scenario_monitor.cpp
+++ b/src/game/server/tf/bot/behavior/tf_bot_scenario_monitor.cpp
@@ -287,6 +287,21 @@ Action< CTFBot > *CTFBotScenarioMonitor::DesiredScenarioAndClassAction( CTFBot *
 		DevMsg( "%3.2f: %s: Gametype is CP, but I can't find a point to capture or defend!\n", gpGlobals->curtime, me->GetDebugIdentifier() );
 		return new CTFBotCapturePoint;
 	}
+#ifdef MAPBASE
+	else if ( TFGameRules()->GetGameType() == TF_GAMETYPE_ARENA )
+	{
+		// if we have a point we can capture - do it
+		CUtlVector< CTeamControlPoint * > captureVector;
+		TFGameRules()->CollectCapturePoints( me, &captureVector );
+
+		if ( captureVector.Count() > 0 )
+		{
+			return new CTFBotCapturePoint;
+		}
+
+		return new CTFBotSeekAndDestroy;
+	}
+#endif
 	else
 	{
 		// scenario not implemented yet - just fight

--- a/src/game/server/tf/bot/behavior/tf_bot_seek_and_destroy.cpp
+++ b/src/game/server/tf/bot/behavior/tf_bot_seek_and_destroy.cpp
@@ -83,9 +83,14 @@ ActionResult< CTFBot >	CTFBotSeekAndDestroy::Update( CTFBot *me, float interval 
 			}
 		}
 		
-		if ( !TFGameRules()->RoundHasBeenWon() && me->GetTimeLeftToCapture() < tf_bot_offense_must_push_time.GetFloat() )
+		// Added proper fix to the bot offense push time bug that causes seek and destroy to never happen
+		// Basically just check for these gamemodes and otherwise allow seek and destroy at all times
+		if (TFGameRules()->GetGameType() == TF_GAMETYPE_ESCORT || TFGameRules()->GetGameType() == TF_GAMETYPE_CP)
 		{
-			return Done( "Time to push for the objective" );
+			if (!TFGameRules()->RoundHasBeenWon() && me->GetTimeLeftToCapture() < tf_bot_offense_must_push_time.GetFloat())
+			{
+				return Done("Time to push for the objective");
+			}
 		}
 	}
 

--- a/src/game/server/tf/bot/behavior/tf_bot_seek_and_destroy.h
+++ b/src/game/server/tf/bot/behavior/tf_bot_seek_and_destroy.h
@@ -35,6 +35,8 @@ public:
 
 	virtual const char *GetName( void ) const	{ return "SeekAndDestroy"; };
 
+	bool IsPointLocked( CTFBot *me, CTeamControlPoint *point );
+
 private:
 	CTFNavArea *m_goalArea;
 	CTFNavArea *ChooseGoalArea( CTFBot *me );

--- a/src/game/server/tf/bot/tf_bot.cpp
+++ b/src/game/server/tf/bot/tf_bot.cpp
@@ -2286,7 +2286,8 @@ float CTFBot::GetTimeLeftToCapture( void ) const
 		return TFGameRules()->GetActiveRoundTimer()->GetTimeRemaining();
 	}
 
-	return 0.0f;
+	// Instead of returning 0.0, return FLT_MAX to prevent any other bugs related to this check.
+	return FLT_MAX;
 }
 
 

--- a/src/game/server/tf/bot/tf_bot.cpp
+++ b/src/game/server/tf/bot/tf_bot.cpp
@@ -1381,6 +1381,12 @@ void CTFBot::SetMission( MissionType mission, bool resetBehaviorSystem )
 //-----------------------------------------------------------------------------------------------------
 bool CTFBot::ShouldReEvaluateCurrentClass( void ) const
 {
+#ifdef MAPBASE
+	// Don't change class mid-round in arena mode
+	if ( TFGameRules() && TFGameRules()->IsInArenaMode() && TFGameRules()->GetRoundState() >= GR_STATE_RND_RUNNING )
+		return false;
+#endif
+
 	ETFClass iCurrentClass = ( ETFClass )GetPlayerClass()->GetClassIndex();
 	Assert( iCurrentClass != TF_CLASS_UNDEFINED );
 	TFPlayerClassData_t *classData = GetPlayerClassData( iCurrentClass );

--- a/src/game/server/tf/bot/tf_bot_manager.cpp
+++ b/src/game/server/tf/bot/tf_bot_manager.cpp
@@ -408,6 +408,13 @@ void CTFBotManager::MaintainBotQuota()
 			{
 				nTFBotsOnGameTeams++;
 			}
+#ifdef MAPBASE
+			else if ( TFGameRules()->IsInArenaMode() && tf_arena_use_queue.GetBool() && pPlayer->GetTeamNumber() == TEAM_SPECTATOR )
+			{
+				// Spectators waiting in queue
+				nTFBotsOnGameTeams++;
+			}
+#endif
 		}
 		else
 		{
@@ -471,6 +478,12 @@ void CTFBotManager::MaintainBotQuota()
 			if ( pBot )
 			{
 				pBot->SetAttribute( CTFBot::QUOTA_MANANGED );
+				
+#ifdef MAPBASE
+				// Don't try to change teams on anyone in arena mode queue
+				if ( pBot->GetTeamNumber() != TEAM_UNASSIGNED && TFGameRules()->IsInArenaMode() && tf_arena_use_queue.GetBool() )
+					return;
+#endif
 
 				// join a team before we pick our class, since we use our teammates to decide what class to be
 				pBot->HandleCommand_JoinTeam( "auto" );
@@ -632,7 +645,12 @@ CTFBot* CTFBotManager::GetAvailableBotFromPool()
 		if ( ( pBot->GetFlags() & FL_FAKECLIENT ) == 0 )
 			continue;
 
+#ifdef MAPBASE
+		// Spectators stay quota-managed in arena mode queue
+		if ( ( pBot->GetTeamNumber() == TEAM_SPECTATOR && ( !TFGameRules()->IsInArenaMode() || !tf_arena_use_queue.GetBool() ) ) || pBot->GetTeamNumber() == TEAM_UNASSIGNED )
+#else
 		if ( pBot->GetTeamNumber() == TEAM_SPECTATOR || pBot->GetTeamNumber() == TEAM_UNASSIGNED )
+#endif
 		{
 			pBot->ClearAttribute( CTFBot::QUOTA_MANANGED );
 			return pBot;


### PR DESCRIPTION
This PR adds support for Arena mode to bots in TF2. Bots will initially use their seek and destroy AI, and then they will attempt to capture the point once it is unlocked. Medics and engineers abort their default AI if they are the last members of their team.

This depends on two other otherwise standalone features:

* A fix for spawn room incursion distances not being calculated when there is no `func_respawnroom` in the level.
* An upstream PR which fixes seek and destroy AI when there is no objective. (I think this might be mostly unnecessary, although the time remaining fix may be needed)

Bots are supported with or without the queue enabled.

---

<!-- Replace [ ] with [x] for each item your PR satisfies -->
#### PR Checklist
- [x] **My PR follows all guidelines in the CONTRIBUTING.md file**
- [x] My PR targets a `develop` branch OR targets another branch with a specific goal in mind
