### PR TITLE
fix env_sun sprite flicker/disappearing when you look at it bug

### DIFF
--- a/sp/src/game/client/glow_overlay.cpp
+++ b/sp/src/game/client/glow_overlay.cpp
@@ -159,7 +159,7 @@ void CGlowOverlay::UpdateSkyGlowObstruction( float zFar, bool bCacheFullSceneSta
 	if ( PixelVisibility_IsAvailable() )
 	{
 		// Trace a ray at the object. 
-		Vector pos = CurrentViewOrigin() + m_vDirection * zFar * 0.999f;
+		Vector pos = CurrentViewOrigin() + m_vDirection * zFar * 0.99f;
 
 		// UNDONE: Can probably do only the pixelvis query in this case if you can figure out where
 		// to put it - or save the position of this trace

--- a/sp/src/game/client/glow_overlay.cpp
+++ b/sp/src/game/client/glow_overlay.cpp
@@ -207,7 +207,7 @@ void CGlowOverlay::UpdateGlowObstruction( const Vector &vToGlow, bool bCacheFull
 		if ( m_bInSky )
 		{
 			const CViewSetup *pViewSetup = view->GetViewSetup();
-			Vector pos = CurrentViewOrigin() + m_vDirection * (pViewSetup->zFar * 0.999f);
+			Vector pos = CurrentViewOrigin() + m_vDirection * (pViewSetup->zFar * 0.99f);
 			pixelvis_queryparams_t params;
 			params.Init( pos, m_flProxyRadius, CalcGlowAspect() );
 			params.bSizeInScreenspace = true;


### PR DESCRIPTION
fixes env_sun sprite flickering/disappearing when you look at it on some maps

code for fix is from VDC fixes page:
https://developer.valvesoftware.com/wiki/General_SDK_Snippets_%26_Fixes#Fix_env_sun_sprite_disappearing_in_sky_when_you_look_at_it

#### Does this PR close any issues?
no

#### PR Checklist
- [x] **My PR follows all guidelines in the CONTRIBUTING.md file**
- [x] My PR targets a `develop` branch OR targets another branch with a specific goal in mind
