### PR TITLE
3D skybox in water reflection

### DIFF
--- a/sp/src/game/client/viewrender.cpp
+++ b/sp/src/game/client/viewrender.cpp
@@ -114,6 +114,9 @@ ConVar r_entityclips( "r_entityclips", "1" ); //FIXME: Nvidia drivers before 81.
 static ConVar r_drawopaqueworld( "r_drawopaqueworld", "1", FCVAR_CHEAT );
 static ConVar r_drawtranslucentworld( "r_drawtranslucentworld", "1", FCVAR_CHEAT );
 static ConVar r_3dsky( "r_3dsky","1", 0, "Enable the rendering of 3d sky boxes" );
+#ifdef MAPBASE
+static ConVar r_3dsky_water("r_3dsky_water", "1", FCVAR_ARCHIVE, "Enable the rendering of 3d sky boxes in water");
+#endif
 static ConVar r_skybox( "r_skybox","1", FCVAR_CHEAT, "Enable the rendering of sky boxes" );
 #ifdef TF_CLIENT_DLL
 ConVar r_drawviewmodel( "r_drawviewmodel","1", FCVAR_ARCHIVE );
@@ -4107,6 +4110,29 @@ void CRendering3dView::DrawWorld( float waterZAdjust )
 	render->DrawWorldLists( m_pWorldRenderList, engineFlags, waterZAdjust );
 }
 
+#ifdef MAPBASE
+void CRendering3dView::Draw3DSkybox()
+{
+	if (!(r_3dsky.GetBool() && r_3dsky_water.GetBool()))
+		return;
+
+	CMatRenderContextPtr pRenderContext(materials);
+	pRenderContext->SetHeightClipMode(MATERIAL_HEIGHTCLIPMODE_DISABLE);
+
+	CSkyboxView* pSkyView = new CSkyboxView(m_pMainView);
+
+	pRenderContext->OverrideDepthEnable(true, false);
+	SkyboxVisibility_t nSkyboxVisible = SKYBOX_NOT_VISIBLE;
+	if (pSkyView->Setup(*this, &m_ClearFlags, &nSkyboxVisible))
+		pSkyView->Draw();
+	SafeRelease(pSkyView);
+	pRenderContext->OverrideDepthEnable(false, false);
+
+	EnableWorldFog();
+	render->ViewSetupVis(m_pMainView->ShouldForceNoVis(), 1, &(m_pMainView->GetViewSetup()->origin));
+	pRenderContext->SetHeightClipMode(MATERIAL_HEIGHTCLIPMODE_RENDER_ABOVE_HEIGHT);
+}
+#endif
 
 CMaterialReference g_material_WriteZ; //init'ed on by CViewRender::Init()
 
@@ -5208,7 +5234,12 @@ void CRendering3dView::SetFogVolumeState( const VisibleFogVolumeInfo_t &fogInfo,
 //-----------------------------------------------------------------------------
 SkyboxVisibility_t CSkyboxView::ComputeSkyboxVisibility()
 {
-	return engine->IsSkyboxVisibleFromPoint( origin );
+#ifdef MAPBASE
+	// Use origin of main view (fixes issue where sometimes 3D sky dissapears in water)
+	return engine->IsSkyboxVisibleFromPoint(m_pMainView->GetViewSetup()->origin);
+#else
+	return engine->IsSkyboxVisibleFromPoint(origin);
+#endif
 }
 
 
@@ -5334,10 +5365,13 @@ void CSkyboxView::DrawInternal( view_id_t iSkyBoxViewID, bool bInvokePreAndPostR
 			m_pSky3dParams->fog.farz );
 	}
 	else
+		zNear = 2.0;
+
+	zFar = MAX_TRACE_LENGTH * 2; // Double up zFar to fix 3D skyboxes in water
 #else
 	zNear = 2.0;
-#endif
 	zFar = MAX_TRACE_LENGTH;
+#endif
 
 	// scale origin by sky scale
 	if ( m_pSky3dParams->scale > 0 )
@@ -6079,6 +6113,12 @@ void CBaseWorldView::DrawExecute( float waterHeight, view_id_t viewID, float wat
 
 	if ( m_DrawFlags & DF_DRAW_ENTITITES )
 	{
+#ifdef MAPBASE
+		// Render 3D skybox in water reflection only when rendering entities
+		if (viewID == VIEW_REFLECTION)
+			Draw3DSkybox();
+#endif
+
 		DrawWorld( waterZAdjust );
 		DrawOpaqueRenderables( DepthMode );
 

--- a/sp/src/game/client/viewrender.h
+++ b/sp/src/game/client/viewrender.h
@@ -238,6 +238,10 @@ protected:
 
 	void			DrawWorld( float waterZAdjust );
 
+#ifdef MAPBASE
+	void			Draw3DSkybox();
+#endif
+
 	// Draws all opaque/translucent renderables in leaves that were rendered
 	void			DrawOpaqueRenderables( ERenderDepthMode DepthMode );
 	void			DrawTranslucentRenderables( bool bInSkybox, bool bShadowDepth );


### PR DESCRIPTION
CSGO has had this feature since the Danger Zone update (in December 2018), and GMOD includes it in the **dev** branch (as of when I created this PR). So I decided to implement something similar. I actually tried doing it a long time ago and found out how to implement it.

Controlled by `r_3dsky_water` (defaults to 1) cvar. The expensive mode (or "Reflect All" in the settings) must also be enabled

I don’t see any point in adding `$reflect3dskybox` (it possible btw), since it doesn’t really make sense to control the 3D skybox separately on a per-material basis, that would just be weird to see 3d sky, but not in water

<img width="768" height="512" alt="image" src="https://github.com/user-attachments/assets/2c848b28-f46b-45c2-b3d2-c3b199b05c5e" />

It can be improved, but I don't know how (it doesn't render some props and detail props are gone)

---

#### Does this PR close any issues?
No

#### PR Checklist
- [X] **My PR follows all guidelines in the CONTRIBUTING.md file**
- [X] My PR targets a `develop` branch OR targets another branch with a specific goal in mind
