### PR TITLE
Fix water refraction bleeding

### DIFF
--- a/sp/src/game/client/viewrender.cpp
+++ b/sp/src/game/client/viewrender.cpp
@@ -6595,6 +6595,10 @@ void CAboveWaterView::CRefractionView::Setup()
 	m_DrawFlags = DF_RENDER_REFRACTION | DF_CLIP_Z | 
 		DF_RENDER_UNDERWATER | DF_FUDGE_UP | 
 		DF_DRAW_ENTITITES ;
+
+#ifdef MAPBASE
+	m_DrawFlags |= DF_RENDER_ABOVEWATER;
+#endif
 }
 
 
@@ -6611,11 +6615,19 @@ void CAboveWaterView::CRefractionView::Draw()
 	int nSaveViewID = CurrentViewID();
 	SetupCurrentView( origin, angles, VIEW_REFRACTION );
 
+#ifdef MAPBASE
+	DrawSetup( GetOuter()->m_waterHeight + 2.f, m_DrawFlags, GetOuter()->m_waterZAdjust );
+#else
 	DrawSetup( GetOuter()->m_waterHeight, m_DrawFlags, GetOuter()->m_waterZAdjust );
+#endif
 
 	SetFogVolumeState( GetOuter()->m_fogInfo, true );
 	SetClearColorToFogColor();
+#ifdef MAPBASE
+	DrawExecute( GetOuter()->m_waterHeight + 2.f, VIEW_REFRACTION, GetOuter()->m_waterZAdjust );
+#else
 	DrawExecute( GetOuter()->m_waterHeight, VIEW_REFRACTION, GetOuter()->m_waterZAdjust );
+#endif
 
 #ifdef PORTAL
 	// deal with stencil

--- a/sp/src/game/client/viewrender.cpp
+++ b/sp/src/game/client/viewrender.cpp
@@ -164,6 +164,10 @@ static ConVar r_ForceWaterLeaf( "r_ForceWaterLeaf", "1", 0, "Enable for optimiza
 static ConVar mat_drawwater( "mat_drawwater", "1", FCVAR_CHEAT );
 static ConVar mat_clipz( "mat_clipz", "1" );
 
+#ifdef MAPBASE
+static ConVar r_water_use_fix_for_bleeding("r_water_use_fix_for_bleeding", "1", FCVAR_ARCHIVE, "Enable hack that adjusts the clipping plane so it fixes bleeding (2x expensive)");
+#endif
+
 
 //-----------------------------------------------------------------------------
 // Other convars
@@ -6597,7 +6601,9 @@ void CAboveWaterView::CRefractionView::Setup()
 		DF_DRAW_ENTITITES ;
 
 #ifdef MAPBASE
-	m_DrawFlags |= DF_RENDER_ABOVEWATER;
+	// Single check if enough, no need to repeat that in Draw just for +2.f
+	if (r_water_use_fix_for_bleeding.GetBool())
+		m_DrawFlags |= DF_RENDER_ABOVEWATER;
 #endif
 }
 

--- a/sp/src/game/client/viewrender.cpp
+++ b/sp/src/game/client/viewrender.cpp
@@ -165,7 +165,7 @@ static ConVar mat_drawwater( "mat_drawwater", "1", FCVAR_CHEAT );
 static ConVar mat_clipz( "mat_clipz", "1" );
 
 #ifdef MAPBASE
-static ConVar r_water_use_fix_for_bleeding("r_water_use_fix_for_bleeding", "1", FCVAR_ARCHIVE, "Enable hack that adjusts the clipping plane so it fixes bleeding (2x expensive)");
+static ConVar r_water_use_fix_for_bleeding("r_water_use_fix_for_bleeding", "1", FCVAR_ARCHIVE, "Enable hack that adjusts the clipping plane so it fixes bleeding");
 #endif
 
 


### PR DESCRIPTION
My approach to fix that well known issue with water in SDK. Controllable by `r_water_use_fix_for_bleeding` convar (has `ARCHIVE` flag).
**Note:** Bleeding can still occur at greater water distances or with stronger refraction

<img width="810" height="405" alt="comparison" src="https://github.com/user-attachments/assets/5fceca0a-e7ed-4754-9268-33b6619aa965" />


---

#### Does this PR close any issues?
No

<!-- Replace [ ] with [x] for each item your PR satisfies -->
#### PR Checklist
- [X] **My PR follows all guidelines in the CONTRIBUTING.md file**
- [X] My PR targets a `develop` branch OR targets another branch with a specific goal in mind
