### PR TITLE
Add `filtername` to brush doors from HL:S

### DIFF
--- a/sp/src/game/server/doors.cpp
+++ b/sp/src/game/server/doors.cpp
@@ -13,7 +13,7 @@
 #include "engine/IEngineSound.h"
 #include "physics_npc_solver.h"
 
-#ifdef HL1_DLL || MAPBASE
+#if defined(HL1_DLL) || defined(MAPBASE)
 #include "filters.h"
 #endif
 
@@ -54,7 +54,7 @@ BEGIN_DATADESC( CBaseDoor )
 	DEFINE_KEYFIELD( m_bForceClosed, FIELD_BOOLEAN, "forceclosed" ),
 	DEFINE_FIELD( m_bDoorGroup, FIELD_BOOLEAN ),
 
-#ifdef HL1_DLL || MAPBASE
+#if defined(HL1_DLL) || defined(MAPBASE)
 	DEFINE_KEYFIELD( m_iBlockFilterName,	FIELD_STRING,	"filtername" ),
 	DEFINE_FIELD( m_hBlockFilter, FIELD_EHANDLE ),
 #endif
@@ -500,7 +500,7 @@ void CBaseDoor::Activate( void )
 		break;
 	}
 
-#ifdef HL1_DLL || MAPBASE
+#if defined(HL1_DLL) || defined(MAPBASE)
 	// Get a handle to my filter entity if there is one
 	if (m_iBlockFilterName != NULL_STRING)
 	{
@@ -615,7 +615,7 @@ void CBaseDoor::DoorTouch( CBaseEntity *pOther )
 	// Ignore touches by anything but players.
 	if ( !pOther->IsPlayer() )
 	{
-#ifdef HL1_DLL || MAPBASE
+#if defined(HL1_DLL) || defined(MAPBASE)
 		if( PassesBlockTouchFilter( pOther ) && m_toggle_state == TS_GOING_DOWN )
 		{
 			DoorGoUp();
@@ -661,7 +661,7 @@ void CBaseDoor::DoorTouch( CBaseEntity *pOther )
 	}
 }
 
-#ifdef HL1_DLL || MAPBASE
+#if defined(HL1_DLL) || defined(MAPBASE)
 bool CBaseDoor::PassesBlockTouchFilter(CBaseEntity *pOther)
 {
 	CBaseFilter* pFilter = (CBaseFilter*)(m_hBlockFilter.Get());

--- a/sp/src/game/server/doors.cpp
+++ b/sp/src/game/server/doors.cpp
@@ -13,7 +13,7 @@
 #include "engine/IEngineSound.h"
 #include "physics_npc_solver.h"
 
-#ifdef HL1_DLL
+#ifdef HL1_DLL || MAPBASE
 #include "filters.h"
 #endif
 
@@ -54,7 +54,7 @@ BEGIN_DATADESC( CBaseDoor )
 	DEFINE_KEYFIELD( m_bForceClosed, FIELD_BOOLEAN, "forceclosed" ),
 	DEFINE_FIELD( m_bDoorGroup, FIELD_BOOLEAN ),
 
-#ifdef HL1_DLL
+#ifdef HL1_DLL || MAPBASE
 	DEFINE_KEYFIELD( m_iBlockFilterName,	FIELD_STRING,	"filtername" ),
 	DEFINE_FIELD( m_hBlockFilter, FIELD_EHANDLE ),
 #endif
@@ -500,7 +500,7 @@ void CBaseDoor::Activate( void )
 		break;
 	}
 
-#ifdef HL1_DLL
+#ifdef HL1_DLL || MAPBASE
 	// Get a handle to my filter entity if there is one
 	if (m_iBlockFilterName != NULL_STRING)
 	{
@@ -615,7 +615,7 @@ void CBaseDoor::DoorTouch( CBaseEntity *pOther )
 	// Ignore touches by anything but players.
 	if ( !pOther->IsPlayer() )
 	{
-#ifdef HL1_DLL
+#ifdef HL1_DLL || MAPBASE
 		if( PassesBlockTouchFilter( pOther ) && m_toggle_state == TS_GOING_DOWN )
 		{
 			DoorGoUp();
@@ -661,7 +661,7 @@ void CBaseDoor::DoorTouch( CBaseEntity *pOther )
 	}
 }
 
-#ifdef HL1_DLL
+#ifdef HL1_DLL || MAPBASE
 bool CBaseDoor::PassesBlockTouchFilter(CBaseEntity *pOther)
 {
 	CBaseFilter* pFilter = (CBaseFilter*)(m_hBlockFilter.Get());

--- a/sp/src/game/server/doors.h
+++ b/sp/src/game/server/doors.h
@@ -141,7 +141,7 @@ public:
 	void			StartMovingSound( void );
 	virtual void	StopMovingSound( void );
 	void			MovingSoundThink( void );
-#ifdef HL1_DLL
+#ifdef HL1_DLL || MAPBASE
 	bool		PassesBlockTouchFilter(CBaseEntity *pOther);
 	string_t	m_iBlockFilterName;
 	EHANDLE		m_hBlockFilter;

--- a/sp/src/game/server/doors.h
+++ b/sp/src/game/server/doors.h
@@ -141,7 +141,7 @@ public:
 	void			StartMovingSound( void );
 	virtual void	StopMovingSound( void );
 	void			MovingSoundThink( void );
-#ifdef HL1_DLL || MAPBASE
+#if defined(HL1_DLL) || defined(MAPBASE)
 	bool		PassesBlockTouchFilter(CBaseEntity *pOther);
 	string_t	m_iBlockFilterName;
 	EHANDLE		m_hBlockFilter;


### PR DESCRIPTION
This PR attempts to enable the `filtername` KV on `func_door`, `func_door_rotating`, and `func_water`, which is present in the SDK, but is ifdefed to only be compiled in HL:S+HLDMS. This PR modifies the relevant ifdefs to also apply to Mapbase, without enabling any code unrelated to the block filter.

The `filtername` KV indicates a filter to determine entities (other than players) that can block the door (could be useful for NPCs). It is actually present in the vanilla FGD entry for func_door, despite not working outside of HL:S. It should be moved to the Door baseclass. A modified FGD entry is as such:
```
	filtername(filterclass) : "Block Filter Name" : : "Filter to use to determine entities that can block the door."
```
This is flagged as a draft, because it needs to be tested further (given HLS is a buggy mess).

---

#### Does this PR close any issues?
* No.

<!-- Replace [ ] with [x] for each item your PR satisfies -->
#### PR Checklist
- [x] **My PR follows all guidelines in the CONTRIBUTING.md file**
- [x] My PR targets a `develop` branch OR targets another branch with a specific goal in mind
