### PR TITLE
Fix npc_barnacle_ignite to only work with active flares

### DIFF
--- a/sp/src/game/server/props.cpp
+++ b/sp/src/game/server/props.cpp
@@ -779,7 +779,7 @@ bool CBreakableProp::HandleInteraction( int interactionType, void *data, CBaseCo
 	// Allows flares to ignite barnacles.
 	if ( interactionType == g_interactionBarnacleVictimBite )
 	{
-		if ( npc_barnacle_ignite.GetBool() && sourceEnt->IsOnFire() == false )
+		if ( npc_barnacle_ignite.GetBool() && sourceEnt->IsOnFire() == false && m_hFlareEnt )
 		{
 			sourceEnt->Ignite( 25.0f );
 			KillFlare( this, m_hFlareEnt, PROP_FLARE_IGNITE_SUBSTRACT );


### PR DESCRIPTION
This PR fixes the behavior of `npc_barnacle_ignite 1`. Currently, whenever the cvar is enabled, any physics prop that is bitten by the Barnacle ignites it. The PR adds a check to the ignite condition so that it only ignites the Barnacle when it is biting a burning flare.

---

#### Does this PR close any issues?
* No

<!-- Replace [ ] with [x] for each item your PR satisfies -->
#### PR Checklist
- [x] **My PR follows all guidelines in the CONTRIBUTING.md file**
- [x] My PR targets a `develop` branch OR targets another branch with a specific goal in mind
