### PR TITLE
Fix ExtractKeyvalue() not extracting strings correctly

### DIFF
--- a/sp/src/game/server/saverestore_gamedll.cpp
+++ b/sp/src/game/server/saverestore_gamedll.cpp
@@ -173,7 +173,13 @@ bool ExtractKeyvalue( void *pObject, typedescription_t *pFields, int iNumFields,
 			case FIELD_MODELNAME:
 			case FIELD_SOUNDNAME:
 			case FIELD_STRING:
+#ifdef MAPBASE
+				// All datadesc string values use string_t
+				// See analogous implementation in ParseKeyvalue() above
+				Q_strncpy( szValue, ((string_t *)((char *)pObject + fieldOffset))->ToCStr(), iMaxLen );
+#else
 				Q_strncpy( szValue, ((char *)pObject + fieldOffset), iMaxLen );
+#endif
 				return true;
 
 			case FIELD_TIME:


### PR DESCRIPTION
This PR fixes the `ExtractKeyvalue` function in `saverestore_gamedll.cpp` not extracting strings correctly. This fixes instances in which getting a string value using `GetKeyValue`, `logic_keyfield`, etc. returns invalid data.

---

<!-- Replace [ ] with [x] for each item your PR satisfies -->
#### PR Checklist
- [x] **My PR follows all guidelines in the CONTRIBUTING.md file**
- [x] My PR targets a `develop` branch OR targets another branch with a specific goal in mind
