### PR TITLE
from_zombie applied to spawned headcrab with expiration time instead of duration

### DIFF
--- a/sp/src/game/server/hl2/npc_BaseZombie.cpp
+++ b/sp/src/game/server/hl2/npc_BaseZombie.cpp
@@ -2676,7 +2676,7 @@ void CNPC_BaseZombie::ReleaseHeadcrab( const Vector &vecOrigin, const Vector &ve
 		pCrab->m_iViewHideFlags = m_iViewHideFlags;
 
 		// Add response context for companion response (more reliable than checking for post-death zombie entity)
-		pCrab->AddContext( "from_zombie", "1", 2.0f );
+		pCrab->AddContext( "from_zombie", "1", gpGlobals->curtime + 2.0f );
 #endif
 		
 		// make me the crab's owner to avoid collision issues


### PR DESCRIPTION
…

While I was debugging an issue with Wilson's responses in Entropy : Zero 2, I came upon the realization that the "duration" parameter in ``CBaseEntity::AddContext()`` is misnamed and actually represents an expiration time, not a duration.

I found this example of a context being applied with a duration instead of an expiration time in Mapbase. It looks like it is a context applied to headcrabs to say that they spawned from zombies which only lasts for two seconds.

I have not properly tested this change in game as it was the result of testing an unrelated issue. Hence I will open this in draft status for now.

---

<!-- Replace [ ] with [x] for each item your PR satisfies -->
#### PR Checklist
- [x] **My PR follows all guidelines in the CONTRIBUTING.md file**
- [x] My PR targets a `develop` branch OR targets another branch with a specific goal in mind
