### PR TITLE
Add background box capability to game_text

### DIFF
--- a/sp/src/game/client/message.cpp
+++ b/sp/src/game/client/message.cpp
@@ -911,59 +911,80 @@ void CHudMessage::MsgFunc_HudMsg(bf_read &msg)
 	if (msg.GetNumBitsLeft() > 0)
 	{
 		int len = msg.ReadByte();
-
-		// This is supposed to work around a bug where certain aspect ratios cut off lengthy texts.
-		//int lineMax = 64 * ((float)ScreenWidth() / 1440.0f);
-		int lineMax = 100 / engine->GetScreenAspectRatio();
-
-		int lineMinBreak = lineMax * 0.9;
-
-		CGMsg( 2, CON_GROUP_CHOREO, "Line max is %i from an aspect ratio of %.3f (strlen %i)\n", lineMax, engine->GetScreenAspectRatio(), len );
-
-		char *curMessage = (char*)pNetMessage->pMessage;
-		char newMessage[512];
-
-		int cur = 0; // Current time on this line
-		int i = 0; // curMessage
-		int i2 = 0; // newMessage
-		for (i = 0; i < len; i++)
+		if ( len > 0 )
 		{
-			cur++;
-			newMessage[i2] = curMessage[i];
+			// This is supposed to work around a bug where certain aspect ratios cut off lengthy texts.
+			//int lineMax = 64 * ((float)ScreenWidth() / 1440.0f);
+			int lineMax = 160 / engine->GetScreenAspectRatio();
 
-			// Check if we're past the point in which we should break the line
-			if (cur >= lineMinBreak)
+			int lineMinBreak = lineMax * 0.9;
+
+			CGMsg( 2, CON_GROUP_CHOREO, "Line max is %i from an aspect ratio of %.3f (strlen %i)\n", lineMax, engine->GetScreenAspectRatio(), len );
+
+			char *curMessage = (char*)pNetMessage->pMessage;
+			char newMessage[512];
+
+			int cur = 0; // Current time on this line
+			int i = 0; // curMessage
+			int i2 = 0; // newMessage
+			for (i = 0; i < len; i++)
 			{
-				// Line break at the next space
-				if (curMessage[i] == ' ')
+				cur++;
+				newMessage[i2] = curMessage[i];
+
+				// Check if we're past the point in which we should break the line
+				if (cur >= lineMinBreak)
 				{
-					newMessage[i2] = '\n';
-					cur = 0;
+					// Line break at the next space
+					if (curMessage[i] == ' ')
+					{
+						newMessage[i2] = '\n';
+						cur = 0;
+					}
+					else if (curMessage[i] == '\n')
+					{
+						// Already a newline here
+						cur = 0;
+					}
+					else if (cur >= lineMax)
+					{
+						// We're at the max and there's no space. Force a newline with a hyphen
+						newMessage[i2] = '-';
+						i2++;
+						newMessage[i2] = '\n';
+						i2++;
+						newMessage[i2] = curMessage[i];
+						cur = 0;
+					}
 				}
-				else if (curMessage[i] == '\n')
-				{
-					// Already a newline here
-					cur = 0;
-				}
-				else if (cur >= lineMax)
-				{
-					// We're at the max and there's no space. Force a newline with a hyphen
-					newMessage[i2] = '-';
-					i2++;
-					newMessage[i2] = '\n';
-					i2++;
-					newMessage[i2] = curMessage[i];
-					cur = 0;
-				}
+
+				i2++;
 			}
 
-			i2++;
+			// Null terminate
+			newMessage[i2] = '\0';
+
+			Q_strncpy( (char*)pNetMessage->pMessage, newMessage, 512 );
 		}
+	}
 
-		// Null terminate
-		newMessage[i2] = '\0';
-
-		Q_strncpy( (char*)pNetMessage->pMessage, newMessage, 512 );
+	// 
+	// Mapbase adds new data entries for the background box.
+	// These are not transmitted if no background box is defined, and some existing instances of this user message may not have this,
+	// so we have to make sure we have any bits left first.
+	// 
+	if (msg.GetNumBitsLeft() > 0)
+	{
+		pNetMessage->bRoundedRectBackdropBox = true;
+		pNetMessage->flBoxSize = msg.ReadFloat();
+		pNetMessage->boxcolor[0] = msg.ReadByte();
+		pNetMessage->boxcolor[1] = msg.ReadByte();
+		pNetMessage->boxcolor[2] = msg.ReadByte();
+		pNetMessage->boxcolor[3] = msg.ReadByte();
+	}
+	else
+	{
+		pNetMessage->bRoundedRectBackdropBox = false;
 	}
 #endif
 

--- a/sp/src/game/server/ai_speech_new.cpp
+++ b/sp/src/game/server/ai_speech_new.cpp
@@ -948,6 +948,13 @@ bool CAI_Expresser::SpeakDispatchResponse( AIConcept_t concept, AI_Response *res
 					WRITE_STRING( response );
 					WRITE_STRING( "" ); // No custom font
 					WRITE_BYTE ( responseLen );
+
+					// Background box
+					WRITE_FLOAT( 0.4f );
+					WRITE_BYTE( 31 );
+					WRITE_BYTE( 31 );
+					WRITE_BYTE( 31 );
+					WRITE_BYTE( 127 );
 				MessageEnd();
 
 				spoke = true;

--- a/sp/src/game/server/baseflex.cpp
+++ b/sp/src/game/server/baseflex.cpp
@@ -842,6 +842,13 @@ bool CBaseFlex::StartSceneEvent( CSceneEventInfo *info, CChoreoScene *scene, CCh
 							WRITE_STRING( event->GetParameters2() );
 							WRITE_STRING( "" ); // No custom font
 							WRITE_BYTE ( Q_strlen( event->GetParameters2() ) );
+
+							// Background box
+							WRITE_FLOAT( 0.4f );
+							WRITE_BYTE( 31 );
+							WRITE_BYTE( 31 );
+							WRITE_BYTE( 31 );
+							WRITE_BYTE( 127 );
 						MessageEnd();
 					}
 					return true;

--- a/sp/src/game/server/maprules.cpp
+++ b/sp/src/game/server/maprules.cpp
@@ -336,6 +336,9 @@ BEGIN_DATADESC( CGameText )
 	DEFINE_KEYFIELD( m_textParms.fxTime, FIELD_FLOAT, "fxtime" ),
 
 #ifdef MAPBASE
+	DEFINE_KEYFIELD( m_textParms.boxSize, FIELD_FLOAT, "boxsize" ),
+	DEFINE_KEYFIELD( m_textParms.boxColor, FIELD_COLOR32, "boxcolor" ),
+
 	DEFINE_KEYFIELD( m_strFont, FIELD_STRING, "font" ),
 	DEFINE_KEYFIELD( m_bAutobreak, FIELD_BOOLEAN, "autobreak" ),
 #endif

--- a/sp/src/game/server/util.cpp
+++ b/sp/src/game/server/util.cpp
@@ -1116,9 +1116,14 @@ void UTIL_HudMessage( CBasePlayer *pToPlayer, const hudtextparms_t &textparms, c
 		WRITE_STRING( pMessage );
 #ifdef MAPBASE
 		WRITE_STRING( pszFont );
-		if (bAutobreak)
+		WRITE_BYTE ( bAutobreak ? Q_strlen( pMessage ) : 0 );
+		if ( textparms.boxSize > 0.0f )
 		{
-			WRITE_BYTE ( Q_strlen( pMessage ) );
+			WRITE_FLOAT( textparms.boxSize );
+			WRITE_BYTE( textparms.boxColor.r );
+			WRITE_BYTE( textparms.boxColor.g );
+			WRITE_BYTE( textparms.boxColor.b );
+			WRITE_BYTE( textparms.boxColor.a );
 		}
 #endif
 	MessageEnd();

--- a/sp/src/game/server/util.h
+++ b/sp/src/game/server/util.h
@@ -504,6 +504,10 @@ typedef struct hudtextparms_s
 	float		holdTime;
 	float		fxTime;
 	int			channel;
+#ifdef MAPBASE
+	float		boxSize = 0.0f;
+	color32		boxColor;
+#endif
 } hudtextparms_t;
 
 


### PR DESCRIPTION
This PR adds new `boxsize` and `boxcolor` keyvalues to `game_text` which allow the text to be displayed with a rounded box in the background, similar to other HUD elements.

<img width="518" height="263" alt="image" src="https://github.com/user-attachments/assets/a22fea34-1a65-4806-8b49-a96f55acc9b1" />
<img width="1049" height="474" alt="image" src="https://github.com/user-attachments/assets/2c0d91b1-3c96-4f04-bd24-f9f4339fa158" />

This feature already existed in the message HUD, but it previously could only be enabled through `titles.txt`.

This PR also enables the feature for text displayed by the Response System or choreo scenes.

---

<!-- Replace [ ] with [x] for each item your PR satisfies -->
#### PR Checklist
- [x] **My PR follows all guidelines in the CONTRIBUTING.md file**
- [x] My PR targets a `develop` branch OR targets another branch with a specific goal in mind
