### PR TITLE
Fix prop_vehicle_jeep_old not breaking item crates

### DIFF
--- a/sp/src/game/server/hl2/item_itemcrate.cpp
+++ b/sp/src/game/server/hl2/item_itemcrate.cpp
@@ -286,7 +286,11 @@ void CItem_ItemCrate::VPhysicsCollision( int index, gamevcollisionevent_t *pEven
 {
 	float flDamageScale = 1.0f;
 	if ( FClassnameIs( pEvent->pEntities[!index], "prop_vehicle_airboat" ) ||
-		 FClassnameIs( pEvent->pEntities[!index], "prop_vehicle_jeep" ) )
+		 FClassnameIs( pEvent->pEntities[!index], "prop_vehicle_jeep" )
+#ifdef MAPBASE
+		|| FClassnameIs( pEvent->pEntities[!index], "prop_vehicle_jeep_old" )
+#endif
+		)
 	{
 		flDamageScale = 100.0f;
 	}


### PR DESCRIPTION
This PR fixes `prop_vehicle_jeep_old` not being able to break `item_item_crate` on collision like `prop_vehicle_jeep` can due to their classname difference.

---

<!-- Replace [ ] with [x] for each item your PR satisfies -->
#### PR Checklist
- [x] **My PR follows all guidelines in the CONTRIBUTING.md file**
- [x] My PR targets a `develop` branch OR targets another branch with a specific goal in mind
