### PR TITLE
Fix NPC behaviors not appending ent_text

### DIFF
--- a/sp/src/game/server/ai_basenpc.cpp
+++ b/sp/src/game/server/ai_basenpc.cpp
@@ -10689,9 +10689,15 @@ int CAI_BaseNPC::DrawDebugTextOverlays(void)
 			CAI_BehaviorBase *pBehavior = GetRunningBehavior();
 			if ( pBehavior )
 			{
+#ifdef MAPBASE
+				// CAI_BehaviorBase::DrawDebugTextOverlays prints identical text, but wasn't used
+				// This change allows behaviors to print their own debug text
+				text_offset = pBehavior->DrawDebugTextOverlays( text_offset );
+#else
 				Q_snprintf(tempstr,sizeof(tempstr),"Behv: %s, ", pBehavior->GetName() );
 				EntityText(text_offset,tempstr,0);
 				text_offset++;
+#endif
 			}
 
 			const char *pName = NULL;


### PR DESCRIPTION
This PR appends `CAI_BehaviorBase::DrawDebugTextOverlays` to NPC debug text. Previously, NPCs would just print the behavior name, which is identical to the behavior seen in `CAI_BehaviorBase::DrawDebugTextOverlays`. This suggests that calling `CAI_BehaviorBase::DrawDebugTextOverlays` is the intended design, and doing so allows derived behaviors to append their own, previously unused debug text. For example, `CAI_AssaultBehavior` prints the NPC's current assault point, `CAI_FollowBehavior` prints its follow target, etc.

---

<!-- Replace [ ] with [x] for each item your PR satisfies -->
#### PR Checklist
- [x] **My PR follows all guidelines in the CONTRIBUTING.md file**
- [x] My PR targets a `develop` branch OR targets another branch with a specific goal in mind
