### PR TITLE
Add $refracttintrespectamount to SDK_Refract

### DIFF
--- a/sp/src/materialsystem/stdshaders/SDK_refract_ps2x.fxc
+++ b/sp/src/materialsystem/stdshaders/SDK_refract_ps2x.fxc
@@ -14,6 +14,7 @@
 // STATIC: "NORMAL_DECODE_MODE"				"0..0"	[XBOX]
 // STATIC: "NORMAL_DECODE_MODE"				"0..0"	[PC]
 // STATIC: "SHADER_SRGB_READ"				"0..1"	[ps20b]
+// STATIC: "REFRACTTINTRESPECTAMOUNT"		"0..1"	[ps20b]
 
 // DYNAMIC: "PIXELFOGTYPE"					"0..1"
 // DYNAMIC: "WRITE_DEPTH_TO_DESTALPHA"		"0..1"	[ps20b] [PC]
@@ -106,6 +107,10 @@ float4 main( PS_INPUT i ) : COLOR
 	float3 refractTintColor = 2.0 * g_RefractTint * tex2D( RefractTintSampler, i.vBumpTexCoord.xy );
 #else
 	float3 refractTintColor = g_RefractTint;
+#endif
+
+#if REFRACTTINTRESPECTAMOUNT
+	refractTintColor = lerp( float3(1,1,1), refractTintColor, g_RefractScale );
 #endif
 
 #if COLORMODULATE

--- a/sp/src/materialsystem/stdshaders/fxctmp9/SDK_refract_ps20b.inc
+++ b/sp/src/materialsystem/stdshaders/fxctmp9/SDK_refract_ps20b.inc
@@ -211,6 +211,27 @@ public:
 		m_bSHADER_SRGB_READ = true;
 #endif
 	}
+private:
+	int m_nREFRACTTINTRESPECTAMOUNT;
+#ifdef _DEBUG
+	bool m_bREFRACTTINTRESPECTAMOUNT;
+#endif
+public:
+	void SetREFRACTTINTRESPECTAMOUNT( int i )
+	{
+		Assert( i >= 0 && i <= 1 );
+		m_nREFRACTTINTRESPECTAMOUNT = i;
+#ifdef _DEBUG
+		m_bREFRACTTINTRESPECTAMOUNT = true;
+#endif
+	}
+	void SetREFRACTTINTRESPECTAMOUNT( bool i )
+	{
+		m_nREFRACTTINTRESPECTAMOUNT = i ? 1 : 0;
+#ifdef _DEBUG
+		m_bREFRACTTINTRESPECTAMOUNT = true;
+#endif
+	}
 public:
 	sdk_refract_ps20b_Static_Index( )
 	{
@@ -254,19 +275,23 @@ public:
 		m_bSHADER_SRGB_READ = false;
 #endif // _DEBUG
 		m_nSHADER_SRGB_READ = 0;
+#ifdef _DEBUG
+		m_bREFRACTTINTRESPECTAMOUNT = false;
+#endif // _DEBUG
+		m_nREFRACTTINTRESPECTAMOUNT = 0;
 	}
 	int GetIndex()
 	{
 		// Asserts to make sure that we aren't using any skipped combinations.
 		// Asserts to make sure that we are setting all of the combination vars.
 #ifdef _DEBUG
-		bool bAllStaticVarsDefined = m_bCONVERT_TO_SRGB && m_bBLUR && m_bFADEOUTONSILHOUETTE && m_bCUBEMAP && m_bREFRACTTINTTEXTURE && m_bMASKED && m_bCOLORMODULATE && m_bSECONDARY_NORMAL && m_bNORMAL_DECODE_MODE && m_bSHADER_SRGB_READ;
+		bool bAllStaticVarsDefined = m_bCONVERT_TO_SRGB && m_bBLUR && m_bFADEOUTONSILHOUETTE && m_bCUBEMAP && m_bREFRACTTINTTEXTURE && m_bMASKED && m_bCOLORMODULATE && m_bSECONDARY_NORMAL && m_bNORMAL_DECODE_MODE && m_bSHADER_SRGB_READ && m_bREFRACTTINTRESPECTAMOUNT;
 		Assert( bAllStaticVarsDefined );
 #endif // _DEBUG
-		return ( 4 * m_nCONVERT_TO_SRGB ) + ( 8 * m_nBLUR ) + ( 16 * m_nFADEOUTONSILHOUETTE ) + ( 32 * m_nCUBEMAP ) + ( 64 * m_nREFRACTTINTTEXTURE ) + ( 128 * m_nMASKED ) + ( 256 * m_nCOLORMODULATE ) + ( 512 * m_nSECONDARY_NORMAL ) + ( 1024 * m_nNORMAL_DECODE_MODE ) + ( 1024 * m_nSHADER_SRGB_READ ) + 0;
+		return ( 4 * m_nCONVERT_TO_SRGB ) + ( 8 * m_nBLUR ) + ( 16 * m_nFADEOUTONSILHOUETTE ) + ( 32 * m_nCUBEMAP ) + ( 64 * m_nREFRACTTINTTEXTURE ) + ( 128 * m_nMASKED ) + ( 256 * m_nCOLORMODULATE ) + ( 512 * m_nSECONDARY_NORMAL ) + ( 1024 * m_nNORMAL_DECODE_MODE ) + ( 1024 * m_nSHADER_SRGB_READ ) + ( 2048 * m_nREFRACTTINTRESPECTAMOUNT ) + 0;
 	}
 };
-#define shaderStaticTest_sdk_refract_ps20b psh_forgot_to_set_static_BLUR + psh_forgot_to_set_static_FADEOUTONSILHOUETTE + psh_forgot_to_set_static_CUBEMAP + psh_forgot_to_set_static_REFRACTTINTTEXTURE + psh_forgot_to_set_static_MASKED + psh_forgot_to_set_static_COLORMODULATE + psh_forgot_to_set_static_SECONDARY_NORMAL + psh_forgot_to_set_static_NORMAL_DECODE_MODE + psh_forgot_to_set_static_SHADER_SRGB_READ + 0
+#define shaderStaticTest_sdk_refract_ps20b psh_forgot_to_set_static_BLUR + psh_forgot_to_set_static_FADEOUTONSILHOUETTE + psh_forgot_to_set_static_CUBEMAP + psh_forgot_to_set_static_REFRACTTINTTEXTURE + psh_forgot_to_set_static_MASKED + psh_forgot_to_set_static_COLORMODULATE + psh_forgot_to_set_static_SECONDARY_NORMAL + psh_forgot_to_set_static_NORMAL_DECODE_MODE + psh_forgot_to_set_static_SHADER_SRGB_READ + psh_forgot_to_set_static_REFRACTTINTRESPECTAMOUNT + 0
 class sdk_refract_ps20b_Dynamic_Index
 {
 private:

--- a/sp/src/materialsystem/stdshaders/fxctmp9_tmp/SDK_refract_ps20b.inc
+++ b/sp/src/materialsystem/stdshaders/fxctmp9_tmp/SDK_refract_ps20b.inc
@@ -211,6 +211,27 @@ public:
 		m_bSHADER_SRGB_READ = true;
 #endif
 	}
+private:
+	int m_nREFRACTTINTRESPECTAMOUNT;
+#ifdef _DEBUG
+	bool m_bREFRACTTINTRESPECTAMOUNT;
+#endif
+public:
+	void SetREFRACTTINTRESPECTAMOUNT( int i )
+	{
+		Assert( i >= 0 && i <= 1 );
+		m_nREFRACTTINTRESPECTAMOUNT = i;
+#ifdef _DEBUG
+		m_bREFRACTTINTRESPECTAMOUNT = true;
+#endif
+	}
+	void SetREFRACTTINTRESPECTAMOUNT( bool i )
+	{
+		m_nREFRACTTINTRESPECTAMOUNT = i ? 1 : 0;
+#ifdef _DEBUG
+		m_bREFRACTTINTRESPECTAMOUNT = true;
+#endif
+	}
 public:
 	sdk_refract_ps20b_Static_Index( )
 	{
@@ -254,19 +275,23 @@ public:
 		m_bSHADER_SRGB_READ = false;
 #endif // _DEBUG
 		m_nSHADER_SRGB_READ = 0;
+#ifdef _DEBUG
+		m_bREFRACTTINTRESPECTAMOUNT = false;
+#endif // _DEBUG
+		m_nREFRACTTINTRESPECTAMOUNT = 0;
 	}
 	int GetIndex()
 	{
 		// Asserts to make sure that we aren't using any skipped combinations.
 		// Asserts to make sure that we are setting all of the combination vars.
 #ifdef _DEBUG
-		bool bAllStaticVarsDefined = m_bCONVERT_TO_SRGB && m_bBLUR && m_bFADEOUTONSILHOUETTE && m_bCUBEMAP && m_bREFRACTTINTTEXTURE && m_bMASKED && m_bCOLORMODULATE && m_bSECONDARY_NORMAL && m_bNORMAL_DECODE_MODE && m_bSHADER_SRGB_READ;
+		bool bAllStaticVarsDefined = m_bCONVERT_TO_SRGB && m_bBLUR && m_bFADEOUTONSILHOUETTE && m_bCUBEMAP && m_bREFRACTTINTTEXTURE && m_bMASKED && m_bCOLORMODULATE && m_bSECONDARY_NORMAL && m_bNORMAL_DECODE_MODE && m_bSHADER_SRGB_READ && m_bREFRACTTINTRESPECTAMOUNT;
 		Assert( bAllStaticVarsDefined );
 #endif // _DEBUG
-		return ( 4 * m_nCONVERT_TO_SRGB ) + ( 8 * m_nBLUR ) + ( 16 * m_nFADEOUTONSILHOUETTE ) + ( 32 * m_nCUBEMAP ) + ( 64 * m_nREFRACTTINTTEXTURE ) + ( 128 * m_nMASKED ) + ( 256 * m_nCOLORMODULATE ) + ( 512 * m_nSECONDARY_NORMAL ) + ( 1024 * m_nNORMAL_DECODE_MODE ) + ( 1024 * m_nSHADER_SRGB_READ ) + 0;
+		return ( 4 * m_nCONVERT_TO_SRGB ) + ( 8 * m_nBLUR ) + ( 16 * m_nFADEOUTONSILHOUETTE ) + ( 32 * m_nCUBEMAP ) + ( 64 * m_nREFRACTTINTTEXTURE ) + ( 128 * m_nMASKED ) + ( 256 * m_nCOLORMODULATE ) + ( 512 * m_nSECONDARY_NORMAL ) + ( 1024 * m_nNORMAL_DECODE_MODE ) + ( 1024 * m_nSHADER_SRGB_READ ) + ( 2048 * m_nREFRACTTINTRESPECTAMOUNT ) + 0;
 	}
 };
-#define shaderStaticTest_sdk_refract_ps20b psh_forgot_to_set_static_BLUR + psh_forgot_to_set_static_FADEOUTONSILHOUETTE + psh_forgot_to_set_static_CUBEMAP + psh_forgot_to_set_static_REFRACTTINTTEXTURE + psh_forgot_to_set_static_MASKED + psh_forgot_to_set_static_COLORMODULATE + psh_forgot_to_set_static_SECONDARY_NORMAL + psh_forgot_to_set_static_NORMAL_DECODE_MODE + psh_forgot_to_set_static_SHADER_SRGB_READ + 0
+#define shaderStaticTest_sdk_refract_ps20b psh_forgot_to_set_static_BLUR + psh_forgot_to_set_static_FADEOUTONSILHOUETTE + psh_forgot_to_set_static_CUBEMAP + psh_forgot_to_set_static_REFRACTTINTTEXTURE + psh_forgot_to_set_static_MASKED + psh_forgot_to_set_static_COLORMODULATE + psh_forgot_to_set_static_SECONDARY_NORMAL + psh_forgot_to_set_static_NORMAL_DECODE_MODE + psh_forgot_to_set_static_SHADER_SRGB_READ + psh_forgot_to_set_static_REFRACTTINTRESPECTAMOUNT + 0
 class sdk_refract_ps20b_Dynamic_Index
 {
 private:

--- a/sp/src/materialsystem/stdshaders/refract.cpp
+++ b/sp/src/materialsystem/stdshaders/refract.cpp
@@ -18,6 +18,9 @@ BEGIN_VS_SHADER( SDK_Refract_DX90, "Help for SDK_Refract" )
 		SHADER_PARAM_OVERRIDE( ALPHA, SHADER_PARAM_TYPE_FLOAT, "1.0", "unused", SHADER_PARAM_NOT_EDITABLE )
 		SHADER_PARAM( REFRACTAMOUNT, SHADER_PARAM_TYPE_FLOAT, "2", "" )
 		SHADER_PARAM( REFRACTTINT, SHADER_PARAM_TYPE_COLOR, "[1 1 1]", "refraction tint" )
+#ifdef MAPBASE
+		SHADER_PARAM( REFRACTTINTRESPECTAMOUNT, SHADER_PARAM_TYPE_BOOL, "0", "" )
+#endif
 		SHADER_PARAM( NORMALMAP, SHADER_PARAM_TYPE_TEXTURE, "models/shadertest/shader1_normal", "normal map" )
 		SHADER_PARAM( NORMALMAP2, SHADER_PARAM_TYPE_TEXTURE, "models/shadertest/shader1_normal", "normal map" )
 		SHADER_PARAM( BUMPFRAME, SHADER_PARAM_TYPE_INTEGER, "0", "frame number for $normalmap" )
@@ -48,6 +51,9 @@ BEGIN_VS_SHADER( SDK_Refract_DX90, "Help for SDK_Refract" )
 		info.m_nFrame = FRAME;
 		info.m_nRefractAmount = REFRACTAMOUNT;
 		info.m_nRefractTint = REFRACTTINT;
+#ifdef MAPBASE
+		info.m_nRefractTintRespectAmount = REFRACTTINTRESPECTAMOUNT;
+#endif
 		info.m_nNormalMap = NORMALMAP;
 		info.m_nNormalMap2 = NORMALMAP2;
 		info.m_nBumpFrame = BUMPFRAME;

--- a/sp/src/materialsystem/stdshaders/refract_dx9_helper.cpp
+++ b/sp/src/materialsystem/stdshaders/refract_dx9_helper.cpp
@@ -228,6 +228,12 @@ void DrawRefract_DX9( CBaseVSShader *pShader, IMaterialVar** params, IShaderDyna
 		bool bShaderSRGBConvert = IsOSX() && ( g_pHardwareConfig->FakeSRGBWrite() || !g_pHardwareConfig->CanDoSRGBReadFromRTs() );
 		if ( g_pHardwareConfig->SupportsPixelShaders_2_b() || g_pHardwareConfig->ShouldAlwaysUseShaderModel2bShaders() ) // always send OpenGL down the ps2b path
 		{
+#ifdef MAPBASE
+			bool bRefractTintRespectAmount = false;
+			if ( params[info.m_nRefractTintRespectAmount]->GetIntValue() != 0 )
+				bRefractTintRespectAmount = true;
+#endif
+
 			DECLARE_STATIC_PIXEL_SHADER( sdk_refract_ps20b );
 			SET_STATIC_PIXEL_SHADER_COMBO( BLUR,  blurAmount );
 			SET_STATIC_PIXEL_SHADER_COMBO( FADEOUTONSILHOUETTE,  bFadeOutOnSilhouette );
@@ -238,6 +244,9 @@ void DrawRefract_DX9( CBaseVSShader *pShader, IMaterialVar** params, IShaderDyna
 			SET_STATIC_PIXEL_SHADER_COMBO( SECONDARY_NORMAL, bSecondaryNormal );
 			SET_STATIC_PIXEL_SHADER_COMBO( NORMAL_DECODE_MODE, (int) nNormalDecodeMode );
 			SET_STATIC_PIXEL_SHADER_COMBO( SHADER_SRGB_READ, bShaderSRGBConvert );
+#ifdef MAPBASE
+			SET_STATIC_PIXEL_SHADER_COMBO( REFRACTTINTRESPECTAMOUNT, bRefractTintRespectAmount );
+#endif
 			SET_STATIC_PIXEL_SHADER( sdk_refract_ps20b );
 		}
 		else

--- a/sp/src/materialsystem/stdshaders/refract_dx9_helper.h
+++ b/sp/src/materialsystem/stdshaders/refract_dx9_helper.h
@@ -31,6 +31,9 @@ struct Refract_DX9_Vars_t
 	int m_nFrame;
 	int m_nRefractAmount;
 	int m_nRefractTint;
+#ifdef MAPBASE
+	int m_nRefractTintRespectAmount;
+#endif
 	int m_nNormalMap;
 	int m_nNormalMap2;
 	int m_nBumpFrame;


### PR DESCRIPTION
This PR adds a new parameter called `$refracttintrespectamount` to `SDK_Refract`. This parameter causes the refract tint color to blend proportionally to refract scale.

---

<!-- Replace [ ] with [x] for each item your PR satisfies -->
#### PR Checklist
- [x] **My PR follows all guidelines in the CONTRIBUTING.md file**
- [x] My PR targets a `develop` branch OR targets another branch with a specific goal in mind
