### PR TITLE
Fix reserve ammo disappearing when carrying multiple weapons with the same ammo type

### DIFF
--- a/sp/src/game/shared/hl2/basehlcombatweapon_shared.cpp
+++ b/sp/src/game/shared/hl2/basehlcombatweapon_shared.cpp
@@ -67,6 +67,16 @@ void CBaseHLCombatWeapon::ItemHolsterFrame( void )
 	if ( GetOwner()->GetActiveWeapon() == this )
 		return;
 
+#ifdef MAPBASE
+	if ( GetOwner()->GetActiveWeapon() )
+	{
+		// Player can't be holding another weapon that shares our ammo
+		CBaseCombatWeapon *pWeapon = GetOwner()->GetActiveWeapon();
+		if ( pWeapon->m_iPrimaryAmmoType == m_iPrimaryAmmoType || pWeapon->m_iSecondaryAmmoType == m_iSecondaryAmmoType )
+			return;
+	}
+#endif
+
 	// If it's been longer than three seconds, reload
 	if ( ( gpGlobals->curtime - m_flHolsterTime ) > sk_auto_reload_time.GetFloat() )
 	{


### PR DESCRIPTION
This PR fixes a HL2-specific issue in which inactive weapons steal from the reserve ammo of an active weapon with the same ammo type.

Normally, when a weapon is inactive in your inventory, it automatically reloads itself. However, if the weapon you are holding uses the same ammo type, then it'll noticeably steal from your reserve ammo. This PR fixes that by making sure the active weapon doesn't use the same ammo type before reloading inactive weapons.

---

<!-- Replace [ ] with [x] for each item your PR satisfies -->
#### PR Checklist
- [x] **My PR follows all guidelines in the CONTRIBUTING.md file**
- [x] My PR targets a `develop` branch OR targets another branch with a specific goal in mind
