### PR TITLE
Fix map-specific weapon scripts not updating HUD icons

### DIFF
--- a/sp/src/game/client/weapons_resource.cpp
+++ b/sp/src/game/client/weapons_resource.cpp
@@ -104,6 +104,16 @@ void WeaponsResource::LoadWeaponSprites( WEAPON_FILE_INFO_HANDLE hWeaponFileInfo
 	pWeaponInfo->iconSmall = NULL;
 
 	char sz[128];
+
+#ifdef MAPBASE
+	if ( pWeaponInfo->bCustom )
+	{
+		// Load the map-specific script instead
+		extern const char *g_MapName;
+		Q_snprintf( sz, sizeof( sz ), "maps/%s_%s", g_MapName, pWeaponInfo->szClassName );
+	}
+	else
+#endif
 	Q_snprintf(sz, sizeof( sz ), "scripts/%s", pWeaponInfo->szClassName);
 
 	CUtlDict< CHudTexture *, int > tempList;

--- a/sp/src/game/shared/weapon_parse.cpp
+++ b/sp/src/game/shared/weapon_parse.cpp
@@ -305,6 +305,10 @@ bool ReadWeaponDataFromFileForSlot( IFileSystem* filesystem, const char *szWeapo
 		return false;
 
 #ifdef MAPBASE
+	// Reload HUD elements if we had a custom script
+	if ( pFileInfo->bCustom )
+		pFileInfo->bLoadedHudElements = false;
+
 	pFileInfo->bCustom = false;
 #endif
 	pFileInfo->Parse( pKV, szWeaponName );
@@ -349,6 +353,7 @@ bool ReadCustomWeaponDataFromFileForSlot( IFileSystem* filesystem, const char *s
 		return false;
 
 	pFileInfo->bCustom = true;
+	pFileInfo->bLoadedHudElements = false;
 	pFileInfo->Parse( pKV, szWeaponName );
 
 	pKV->deleteThis();


### PR DESCRIPTION
This PR fixes map-specific weapon scripts (e.g. `<map name>_weapon_pistol.txt`) not being able to modify HUD icons.

---

<!-- Replace [ ] with [x] for each item your PR satisfies -->
#### PR Checklist
- [x] **My PR follows all guidelines in the CONTRIBUTING.md file**
- [x] My PR targets a `develop` branch OR targets another branch with a specific goal in mind
