### PR TITLE
Added a game_crash entity that allows mappers to crash the game and display a message

### DIFF
--- a/sp/src/game/server/game_crash.cpp
+++ b/sp/src/game/server/game_crash.cpp
@@ -1,3 +1,9 @@
+//========= Mapbase - https://github.com/mapbase-source/source-sdk-2013 ============//
+//
+// Purpose: Allows mappers to crash the game and display a message
+//
+//=============================================================================//
+
 #include "cbase.h"
 #ifdef _WIN32
 #include <windows.h>

--- a/sp/src/game/server/game_crash.cpp
+++ b/sp/src/game/server/game_crash.cpp
@@ -1,0 +1,56 @@
+#include "cbase.h"
+#ifdef _WIN32
+#include <windows.h>
+#endif
+
+class CGameCrash : public CBaseEntity
+{
+	DECLARE_CLASS( CGameCrash, CBaseEntity );
+	DECLARE_DATADESC();
+
+private:
+	void InputCrash( inputdata_t &inputdata );
+
+#ifdef _WIN32
+    char* m_szTitle;
+#endif
+	char* m_szMessage;
+	int m_nType;
+	//0 - crash without a window
+	//1 - engine error crash
+	//2 - message box crash
+};
+
+
+LINK_ENTITY_TO_CLASS( game_crash, CGameCrash );
+
+BEGIN_DATADESC( CGameCrash )
+
+	DEFINE_INPUTFUNC( FIELD_VOID, "Crash", InputCrash ),
+
+    DEFINE_KEYFIELD( m_szTitle, FIELD_STRING, "title" ),
+	DEFINE_KEYFIELD( m_szMessage, FIELD_STRING, "message" ),
+	DEFINE_KEYFIELD( m_nType, FIELD_INTEGER, "type" ),
+
+END_DATADESC()
+
+
+void CGameCrash::InputCrash( inputdata_t& inputdata )
+{
+	switch ( m_nType )
+	{
+	case 0:
+		engine->ClientCommand( UTIL_GetLocalPlayer()->edict(), "exit" );
+
+	case 1:
+		Error( "%s", m_szMessage );
+
+	case 2:
+#ifdef _WIN32
+		engine->ClientCommand( UTIL_GetLocalPlayer()->edict(), "exit" );
+		MessageBoxA( NULL, m_szMessage, m_szTitle, MB_OK );
+#else
+		Error( "%s", m_szMessage );
+#endif
+	}	
+}


### PR DESCRIPTION
<img width="128" height="128" alt="game_crash" src="https://github.com/user-attachments/assets/f482f2f4-416f-46bd-a02d-935decfb402b" /><br>
This PR adds a new game_crash entity to Mapbase, it allows mappers to crash the game and display a message.

**Inputs**
- Crash

**Keyvalues**
- title - text in the top bar of the message box
- message - text in the message box
- type - how the entity behaves when the crash input is fired, 0 - crashes without a message box, 1 - crashes with an engine error window, 2 - crashes with a message box

Now, you might be wondering, what is the difference between type 1 and type 2. There is one big problem with the Error() function used in type 1, you can't change the title of the window, as the function declaration is in tier0 (which we don't have access to).

Because of that, I created the type 2, it's using the MessageBoxA function from windows.h, but it's not perfect either, the first thing, is that I can't perfectly replicate the behavior of the Error() function. The Error() function makes the message box appear AFTER the game window is closed, but with MessageBoxA it shows the message box and only after clicking OK it closes the game window. Apart from that, it generates lots of "macro redefinition" warnings. It only works on Windows, on other OS it will fall back to Error(), but I have no idea how Error() behaves on Linux to be honest, so that might be unnecessary.

---

<!-- Replace [ ] with [x] for each item your PR satisfies -->
#### PR Checklist
- [x] **My PR follows all guidelines in the CONTRIBUTING.md file**
- [x] My PR targets a `develop` branch OR targets another branch with a specific goal in mind
