### PR TITLE
Ensure func_tankapcrocket always has a targeting laser

### DIFF
--- a/sp/src/game/server/hl2/func_tank.cpp
+++ b/sp/src/game/server/hl2/func_tank.cpp
@@ -3927,6 +3927,13 @@ void CFuncTankAPCRocket::Think()
 		return;
 	}
 
+	// The laser dot gets removed on a game load
+	// To prevent a game crash, recreate it here if it doesn't exist
+	if ( m_hLaserDot == NULL )
+	{
+		m_hLaserDot = CreateLaserDot( GetAbsOrigin(), this, false );
+	}
+
 	BaseClass::Think();
 	m_hLaserDot->SetAbsOrigin( m_sightOrigin );
 	SetLaserDotTarget( m_hLaserDot, m_hFuncTankTarget );


### PR DESCRIPTION
Apparently `env_laserdot` (the entity used as the targeting dot for RPGs and APC rockets, and also the Wrangler in TF2) doesn't survive a save/load. [`weapon_rpg`](https://github.com/mapbase-source/source-sdk-2013/blob/master/sp/src/game/server/hl2/weapon_rpg.cpp#L2076) and [APCs](https://github.com/mapbase-source/source-sdk-2013/blob/master/sp/src/game/server/hl2/vehicle_apc.cpp#L173) deal with this by recreating the laser if it doesn't exist. However, the obscure `func_tankapcrocket` only creates it on initial spawn. This causes the game to crash after a save is loaded and the tank is active.

This PR adds code to recreate the targeting laser to prevent game crashes.

---

#### Does this PR close any issues?
* None that are tracked

#### PR Checklist
- [x] **My PR follows all guidelines in the CONTRIBUTING.md file**
- [x] My PR targets a `develop` branch OR targets another branch with a specific goal in mind
