### PR TITLE
Add vscript EmitSound_t::Get/SetPitch

### DIFF
--- a/sp/src/game/shared/mapbase/vscript_funcs_shared.cpp
+++ b/sp/src/game/shared/mapbase/vscript_funcs_shared.cpp
@@ -589,6 +589,9 @@ BEGIN_SCRIPTDESC_ROOT_NAMED( ScriptEmitSound_t, "EmitSound_t", "" )
 	DEFINE_SCRIPTFUNC( GetFlags, "Gets the sound's flags. See the 'SND_' set of constants." )
 	DEFINE_SCRIPTFUNC( SetFlags, "Sets the sound's flags. See the 'SND_' set of constants." )
 
+	DEFINE_SCRIPTFUNC( GetPitch, "" )
+	DEFINE_SCRIPTFUNC( SetPitch, "Sets the sound's pitch in range [1, 255]" )
+
 	DEFINE_SCRIPTFUNC( GetSpecialDSP, "" )
 	DEFINE_SCRIPTFUNC( SetSpecialDSP, "" )
 

--- a/sp/src/game/shared/mapbase/vscript_funcs_shared.h
+++ b/sp/src/game/shared/mapbase/vscript_funcs_shared.h
@@ -250,6 +250,9 @@ struct ScriptEmitSound_t : public EmitSound_t
 	float GetSoundTime() { return m_flSoundTime; }
 	void SetSoundTime( float flSoundTime ) { m_flSoundTime = flSoundTime; }
 
+	// NOTE: Incorrectly returns float for boolean type.
+	// Fixing this would break scripts explicitly comparing against 0 or 1
+	// Keeping this would prevent implicit falseness check in a language such as Lua where 0.0 is truthy
 	float GetEmitCloseCaption() { return m_bEmitCloseCaption; }
 	void SetEmitCloseCaption( bool bEmitCloseCaption ) { m_bEmitCloseCaption = bEmitCloseCaption; }
 

--- a/sp/src/game/shared/mapbase/vscript_funcs_shared.h
+++ b/sp/src/game/shared/mapbase/vscript_funcs_shared.h
@@ -236,6 +236,9 @@ struct ScriptEmitSound_t : public EmitSound_t
 	int GetFlags() { return m_nFlags; }
 	void SetFlags( int nFlags ) { m_nFlags = nFlags; }
 
+	int GetPitch() { return m_nPitch; }
+	void SetPitch( int nPitch ) { m_nPitch = nPitch; }
+
 	int GetSpecialDSP() { return m_nSpecialDSP; }
 	void SetSpecialDSP( int nSpecialDSP ) { m_nSpecialDSP = nSpecialDSP; }
 


### PR DESCRIPTION
Likely an oversight.

Also the return types of `GetEmitCloseCaption`, `GetWarnOnMissingCloseCaption` and `GetWarnOnDirectWaveReference` should be mentioned. As it stands, `ep.GetEmitCloseCaption() == true` doesn't work. If fixed, `ep.GetEmitCloseCaption() == 1.0` wouldn't work.

---

#### Does this PR close any issues?
* Resolves #546 

#### PR Checklist
- [x] **My PR follows all guidelines in the CONTRIBUTING.md file**
- [x] My PR targets a `develop` branch OR targets another branch with a specific goal in mind
