### PR TITLE
Fix command line syntax in prebuild event

### DIFF
--- a/sp/src/vpc_scripts/source_dll_win32_base.vpc
+++ b/sp/src/vpc_scripts/source_dll_win32_base.vpc
@@ -57,11 +57,12 @@ $Configuration
 	
 	$PreBuildEvent
 	{
-		$CommandLine		"if EXIST $OUTBINDIR\$(TargetFileName) for /f $QUOTEdelims=$QUOTE %%A in ('attrib $QUOTE$OUTBINDIR\$(TargetFileName)$QUOTE') do set valveTmpIsReadOnly=$QUOTE%%A$QUOTE" "\n" \
+		$CommandLine		"if EXIST $QUOTE$OUTBINDIR\$(TargetFileName)$QUOTE (for /f %%A in ('attrib $QUOTE$OUTBINDIR\$(TargetFileName)$QUOTE') do set valveTmpIsReadOnly=%%A)" "\n" \
 							"set valveTmpIsReadOnlyLetter=%valveTmpIsReadOnly:~6,1%" "\n" \
-							"if $QUOTE%valveTmpIsReadOnlyLetter%$QUOTE==$QUOTER$QUOTE del /q $QUOTE$(TargetDir)$QUOTE$(TargetFileName)" "\n" \
+							"if $QUOTE%valveTmpIsReadOnlyLetter%$QUOTE==$QUOTER$QUOTE del /q $QUOTE$(TargetDir)$QUOTE$(TargetFileName)$QUOTE" "\n" \
 							"$CRCCHECK" "\n"
 	}
+
 
 	$PostBuildEvent [!$ANALYZE]
 	{
@@ -143,4 +144,3 @@ $Project
 		$Implib	"$LIBPUBLIC\vstdlib"
 	}
 }
-


### PR DESCRIPTION
#### Does this PR close any issues?
 this closes #549

#### PR Checklist
- [x] **My PR follows all guidelines in the CONTRIBUTING.md file**
- [x] My PR targets a `develop` branch OR targets another branch with a specific goal in mind

This fixes the batch command syntax used in the pre build event

Tested only with VS 2022. After applying this change the syntax error no longer appears in the build output, original issue did not prevent launching the game, but it produced an unnecessary MSB3073 error