### PR TITLE
Add raw scene file support to TF player model panel

### DIFF
--- a/src/game/client/tf/vgui/tf_playermodelpanel.cpp
+++ b/src/game/client/tf/vgui/tf_playermodelpanel.cpp
@@ -29,6 +29,10 @@
 #include "halloween/tf_weapon_spellbook.h"
 #include "matsys_controls/matsyscontrols.h"
 
+#ifdef MAPBASE
+#include "filesystem.h"
+#endif
+
 // memdbgon must be the last include file in a .cpp file!!!
 #include <tier0/memdbgon.h>
 
@@ -406,6 +410,26 @@ CChoreoScene *LoadSceneForModel( const char *filename, IChoreoEventCallback *pCa
 	V_SetExtension( loadfile, ".vcd", sizeof( loadfile ) );
 	V_FixSlashes( loadfile );
 
+#ifdef MAPBASE
+	// 
+	// Raw scene file support
+	// 
+	char *pBuffer = NULL;
+	size_t bufsize = scenefilecache->GetSceneBufferSize( loadfile );
+	if ( bufsize > 0 )
+	{
+		pBuffer = new char[ bufsize ];
+		if ( !scenefilecache->GetSceneData( filename, (byte *)pBuffer, bufsize ) )
+		{
+			delete[] pBuffer;
+			return NULL;
+		}
+	}
+	else if ( !filesystem->ReadFileEx( loadfile, NULL, (void **)&pBuffer, true ) )
+	{
+		return NULL;
+	}
+#else
 	char *pBuffer = NULL;
 	size_t bufsize = scenefilecache->GetSceneBufferSize( loadfile );
 	if ( bufsize <= 0 )
@@ -417,6 +441,7 @@ CChoreoScene *LoadSceneForModel( const char *filename, IChoreoEventCallback *pCa
 		delete[] pBuffer;
 		return NULL;
 	}
+#endif
 
 	CChoreoScene *pScene;
 	if ( IsBufferBinaryVCD( pBuffer, bufsize ) )


### PR DESCRIPTION
Mapbase adds support for loading scenes from individual VCD files (rather than only from `scenes.image`). However, this addition was not carried over to TF2's player model panel, which prevents it from loading raw VCDs.

This PR adds raw VCD support to TF2's player model panel, adding raw scene loading as a fallback case for when a `scenes.image`-provided VCD is not available (as Mapbase does [elsewhere](https://github.com/mapbase-source/source-sdk-2013/blob/b02efa76b149eae89024a55a4beae7d42a01715e/src/game/client/c_sceneentity.cpp#L765-L810)).

---

#### Does this PR close any issues?
No, though it does solve a feature parity problem.

#### PR Checklist
- [x] **My PR follows all guidelines in the CONTRIBUTING.md file**
- [x] My PR targets a `develop` branch OR targets another branch with a specific goal in mind
